### PR TITLE
Add improvements for OCPP 1.6

### DIFF
--- a/example/1.6/cp/charge_point_sim.go
+++ b/example/1.6/cp/charge_point_sim.go
@@ -36,8 +36,15 @@ func setupTlsChargePoint(chargePointID string) ocpp16.ChargePoint {
 	}
 	// Load CA cert
 	caPath, ok := os.LookupEnv(envVarCACertificate)
-	if !ok {
-		log.Fatalf("no required %v found", envVarCACertificate)
+	if ok {
+		caCert, err := ioutil.ReadFile(caPath)
+		if err != nil {
+			log.Warn(err)
+		} else if !certPool.AppendCertsFromPEM(caCert) {
+			log.Info("no ca.cert file found, will use system CA certificates")
+		}
+	} else {
+		log.Info("no ca.cert file found, will use system CA certificates")
 	}
 	caCert, err := ioutil.ReadFile(caPath)
 	if err != nil {

--- a/example/1.6/cp/charge_point_sim.go
+++ b/example/1.6/cp/charge_point_sim.go
@@ -46,12 +46,6 @@ func setupTlsChargePoint(chargePointID string) ocpp16.ChargePoint {
 	} else {
 		log.Info("no ca.cert file found, will use system CA certificates")
 	}
-	caCert, err := ioutil.ReadFile(caPath)
-	if err != nil {
-		log.Warn(err)
-	} else if !certPool.AppendCertsFromPEM(caCert) {
-		log.Warn("no ca.cert file found, will use system CA certificates")
-	}
 	// Load client certificate
 	clientCertPath, ok1 := os.LookupEnv(envVarClientCertificate)
 	clientKeyPath, ok2 := os.LookupEnv(envVarClientCertificateKey)
@@ -66,7 +60,7 @@ func setupTlsChargePoint(chargePointID string) ocpp16.ChargePoint {
 	}
 	// Create client with TLS config
 	client := ws.NewTLSClient(&tls.Config{
-		RootCAs: certPool,
+		RootCAs:      certPool,
 		Certificates: clientCertificates,
 	})
 	return ocpp16.NewChargePoint(chargePointID, nil, client)
@@ -152,6 +146,8 @@ func exampleRoutine(chargePoint ocpp16.ChargePoint, stateHandler *ChargePointHan
 	logDefault(stopConf.GetFeatureName()).Infof("transaction %v stopped", startConf.TransactionId)
 	// Update connector status
 	updateStatus(stateHandler, chargingConnector, core.ChargePointStatusAvailable)
+	// Wait for some time ...
+	wait(5 * time.Minute)
 }
 
 // Start function

--- a/example/1.6/cp/handler.go
+++ b/example/1.6/cp/handler.go
@@ -197,16 +197,16 @@ func (handler *ChargePointHandler) OnTriggerMessage(request *remotetrigger.Trigg
 		//TODO: schedule meter values message
 		break
 	case core.StatusNotificationFeatureName:
-		connectorID := request.ConnectorId
+		connectorID := *request.ConnectorId
 		// Check if requested connector is valid and status can be retrieved
 		if !handler.isValidConnectorID(connectorID) {
-			logDefault(request.GetFeatureName()).Errorf("cannot trigger %v: requested invalid connector %v", request.RequestedMessage, request.ConnectorId)
+			logDefault(request.GetFeatureName()).Errorf("cannot trigger %v: requested invalid connector %v", request.RequestedMessage, connectorID)
 			return remotetrigger.NewTriggerMessageConfirmation(remotetrigger.TriggerMessageStatusRejected), nil
 		}
 		// Schedule status notification request
 		fn := func() {
 			status := handler.status
-			if c, ok := handler.connectors[request.ConnectorId]; ok {
+			if c, ok := handler.connectors[connectorID]; ok {
 				status = c.status
 			}
 			statusConfirmation, err := chargePoint.StatusNotification(connectorID, handler.errorCode, status)

--- a/example/1.6/cp/handler.go
+++ b/example/1.6/cp/handler.go
@@ -11,6 +11,10 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/smartcharging"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	log "github.com/sirupsen/logrus"
+	"io"
+	"net/http"
+	"os"
+	"time"
 )
 
 // ConnectorInfo contains some simple state about a single connector.
@@ -45,17 +49,29 @@ func (handler *ChargePointHandler) isValidConnectorID(ID int) bool {
 // ------------- Core profile callbacks -------------
 
 func (handler *ChargePointHandler) OnChangeAvailability(request *core.ChangeAvailabilityRequest) (confirmation *core.ChangeAvailabilityConfirmation, err error) {
+	if _, ok := handler.connectors[request.ConnectorId]; !ok {
+		logDefault(request.GetFeatureName()).Errorf("cannot change availability for invalid connector %v", request.ConnectorId)
+		return core.NewChangeAvailabilityConfirmation(core.AvailabilityStatusRejected), nil
+	}
 	handler.connectors[request.ConnectorId].availability = request.Type
+	if request.Type == core.AvailabilityTypeInoperative {
+		// TODO: stop ongoing transactions
+		handler.connectors[request.ConnectorId].status = core.ChargePointStatusUnavailable
+	} else {
+		handler.connectors[request.ConnectorId].status = core.ChargePointStatusAvailable
+	}
+	logDefault(request.GetFeatureName()).Infof("change availability for connector %v", request.ConnectorId)
+	go updateStatus(handler, request.ConnectorId, handler.connectors[request.ConnectorId].status)
 	return core.NewChangeAvailabilityConfirmation(core.AvailabilityStatusAccepted), nil
 }
 
 func (handler *ChargePointHandler) OnChangeConfiguration(request *core.ChangeConfigurationRequest) (confirmation *core.ChangeConfigurationConfirmation, err error) {
 	configKey, ok := handler.configuration[request.Key]
 	if !ok {
-		logDefault(request.GetFeatureName()).Infof("couldn't change configuration for unsupported parameter %v", configKey.Key)
+		logDefault(request.GetFeatureName()).Errorf("couldn't change configuration for unsupported parameter %v", configKey.Key)
 		return core.NewChangeConfigurationConfirmation(core.ConfigurationStatusNotSupported), nil
 	} else if configKey.Readonly {
-		logDefault(request.GetFeatureName()).Infof("couldn't change configuration for readonly parameter %v", configKey.Key)
+		logDefault(request.GetFeatureName()).Errorf("couldn't change configuration for readonly parameter %v", configKey.Key)
 		return core.NewChangeConfigurationConfirmation(core.ConfigurationStatusRejected), nil
 	}
 	configKey.Value = request.Value
@@ -65,6 +81,7 @@ func (handler *ChargePointHandler) OnChangeConfiguration(request *core.ChangeCon
 }
 
 func (handler *ChargePointHandler) OnClearCache(request *core.ClearCacheRequest) (confirmation *core.ClearCacheConfirmation, err error) {
+	logDefault(request.GetFeatureName()).Infof("cleared mocked cache")
 	return core.NewClearCacheConfirmation(core.ClearCacheStatusAccepted), nil
 }
 
@@ -84,6 +101,13 @@ func (handler *ChargePointHandler) OnGetConfiguration(request *core.GetConfigura
 			resultKeys = append(resultKeys, configKey)
 		}
 	}
+	if len(request.Key) == 0 {
+		// Return config for all keys
+		for _, v := range handler.configuration {
+			resultKeys = append(resultKeys, v)
+		}
+	}
+	logDefault(request.GetFeatureName()).Infof("returning configuration for requested keys: %v", request.Key)
 	conf := core.NewGetConfigurationConfirmation(resultKeys)
 	conf.UnknownKey = unknownKeys
 	return conf, nil
@@ -101,6 +125,7 @@ func (handler *ChargePointHandler) OnRemoteStartTransaction(request *core.Remote
 		connector.currentTransaction = *request.ConnectorId
 		return core.NewRemoteStartTransactionConfirmation(types.RemoteStartStopStatusAccepted), nil
 	}
+	logDefault(request.GetFeatureName()).Errorf("couldn't start a transaction for %v without a connectorID", request.IdTag)
 	return core.NewRemoteStartTransactionConfirmation(types.RemoteStartStopStatusRejected), nil
 }
 
@@ -114,19 +139,23 @@ func (handler *ChargePointHandler) OnRemoteStopTransaction(request *core.RemoteS
 			return core.NewRemoteStopTransactionConfirmation(types.RemoteStartStopStatusAccepted), nil
 		}
 	}
+	logDefault(request.GetFeatureName()).Errorf("couldn't stop transaction %v, no such transaction is ongoing", request.TransactionId)
 	return core.NewRemoteStopTransactionConfirmation(types.RemoteStartStopStatusRejected), nil
 }
 
 func (handler *ChargePointHandler) OnReset(request *core.ResetRequest) (confirmation *core.ResetConfirmation, err error) {
 	//TODO: stop all ongoing transactions
+	logDefault(request.GetFeatureName()).Warn("no reset logic implemented yet")
 	return core.NewResetConfirmation(core.ResetStatusAccepted), nil
 }
 
 func (handler *ChargePointHandler) OnUnlockConnector(request *core.UnlockConnectorRequest) (confirmation *core.UnlockConnectorConfirmation, err error) {
 	_, ok := handler.connectors[request.ConnectorId]
 	if !ok {
+		logDefault(request.GetFeatureName()).Errorf("couldn't unlock invalid connector %v", request.ConnectorId)
 		return core.NewUnlockConnectorConfirmation(core.UnlockStatusNotSupported), nil
 	}
+	logDefault(request.GetFeatureName()).Infof("unlocked connector %v", request.ConnectorId)
 	return core.NewUnlockConnectorConfirmation(core.UnlockStatusUnlocked), nil
 }
 
@@ -139,6 +168,7 @@ func (handler *ChargePointHandler) OnGetLocalListVersion(request *localauth.GetL
 
 func (handler *ChargePointHandler) OnSendLocalList(request *localauth.SendLocalListRequest) (confirmation *localauth.SendLocalListConfirmation, err error) {
 	if request.ListVersion <= handler.localAuthListVersion {
+		logDefault(request.GetFeatureName()).Errorf("requested listVersion %v is lower/equal than the current list version %v", request.ListVersion, handler.localAuthListVersion)
 		return localauth.NewSendLocalListConfirmation(localauth.UpdateStatusVersionMismatch), nil
 	}
 	if request.UpdateType == localauth.UpdateTypeFull {
@@ -148,14 +178,16 @@ func (handler *ChargePointHandler) OnSendLocalList(request *localauth.SendLocalL
 		handler.localAuthList = append(handler.localAuthList, request.LocalAuthorizationList...)
 		handler.localAuthListVersion = request.ListVersion
 	}
+	logDefault(request.GetFeatureName()).Errorf("accepted new local authorization list %v, %v", request.ListVersion, request.UpdateType)
 	return localauth.NewSendLocalListConfirmation(localauth.UpdateStatusAccepted), nil
 }
 
 // ------------- Firmware management profile callbacks -------------
 
 func (handler *ChargePointHandler) OnGetDiagnostics(request *firmware.GetDiagnosticsRequest) (confirmation *firmware.GetDiagnosticsConfirmation, err error) {
-	return firmware.NewGetDiagnosticsConfirmation(), nil
 	//TODO: perform diagnostics upload out-of-band
+	logDefault(request.GetFeatureName()).Warn("no diagnostics upload logic implemented yet")
+	return firmware.NewGetDiagnosticsConfirmation(), nil
 }
 
 func (handler *ChargePointHandler) OnUpdateFirmware(request *firmware.UpdateFirmwareRequest) (confirmation *firmware.UpdateFirmwareConfirmation, err error) {
@@ -170,7 +202,6 @@ func (handler *ChargePointHandler) OnUpdateFirmware(request *firmware.UpdateFirm
 	logDefault(request.GetFeatureName()).Infof("starting update firmware procedure")
 	go updateFirmware(request.Location, request.RetrieveDate, retries, retryInterval)
 	return firmware.NewUpdateFirmwareConfirmation(), nil
-	//TODO: download new firmware out-of-band
 }
 
 // ------------- Remote trigger profile callbacks -------------
@@ -266,16 +297,19 @@ func (handler *ChargePointHandler) OnCancelReservation(request *reservation.Canc
 
 func (handler *ChargePointHandler) OnSetChargingProfile(request *smartcharging.SetChargingProfileRequest) (confirmation *smartcharging.SetChargingProfileConfirmation, err error) {
 	//TODO: handle logic
+	logDefault(request.GetFeatureName()).Warn("no set charging profile logic implemented yet")
 	return smartcharging.NewSetChargingProfileConfirmation(smartcharging.ChargingProfileStatusNotImplemented), nil
 }
 
 func (handler *ChargePointHandler) OnClearChargingProfile(request *smartcharging.ClearChargingProfileRequest) (confirmation *smartcharging.ClearChargingProfileConfirmation, err error) {
 	//TODO: handle logic
+	logDefault(request.GetFeatureName()).Warn("no clear charging profile logic implemented yet")
 	return smartcharging.NewClearChargingProfileConfirmation(smartcharging.ClearChargingProfileStatusUnknown), nil
 }
 
 func (handler *ChargePointHandler) OnGetCompositeSchedule(request *smartcharging.GetCompositeScheduleRequest) (confirmation *smartcharging.GetCompositeScheduleConfirmation, err error) {
 	//TODO: handle logic
+	logDefault(request.GetFeatureName()).Warn("no get composite schedule logic implemented yet")
 	return smartcharging.NewGetCompositeScheduleConfirmation(smartcharging.GetCompositeScheduleStatusRejected), nil
 }
 

--- a/ocpp1.6/core/get_configuration.go
+++ b/ocpp1.6/core/get_configuration.go
@@ -17,7 +17,7 @@ type ConfigurationKey struct {
 
 // The field definition of the GetConfiguration request payload sent by the Central System to the Charge Point.
 type GetConfigurationRequest struct {
-	Key []string `json:"key" validate:"required,min=1,unique,dive,max=50"`
+	Key []string `json:"key,omitempty" validate:"omitempty,unique,dive,max=50"`
 }
 
 // TODO: validation of cardinalities for the two fields should be handled somewhere (#configurationKey + #unknownKey > 0)
@@ -25,8 +25,8 @@ type GetConfigurationRequest struct {
 // This field definition of the GetConfiguration confirmation payload, sent by the Charge Point to the Central System in response to a GetConfigurationRequest.
 // In case the request was invalid, or couldn't be processed, an error will be sent instead.
 type GetConfigurationConfirmation struct {
-	ConfigurationKey []ConfigurationKey `json:"configurationKey,omitempty" validate:"dive"`
-	UnknownKey       []string           `json:"unknownKey,omitempty" validate:"dive,max=50"`
+	ConfigurationKey []ConfigurationKey `json:"configurationKey,omitempty" validate:"omitempty,dive"`
+	UnknownKey       []string           `json:"unknownKey,omitempty" validate:"omitempty,dive,max=50"`
 }
 
 // To retrieve the value of configuration settings, the Central System SHALL send a GetConfigurationRequest to the Charge Point.

--- a/ocpp1.6/core/meter_values.go
+++ b/ocpp1.6/core/meter_values.go
@@ -12,7 +12,7 @@ const MeterValuesFeatureName = "MeterValues"
 // The field definition of the MeterValues request payload sent by the Charge Point to the Central System.
 type MeterValuesRequest struct {
 	ConnectorId   int                `json:"connectorId" validate:"gte=0"`
-	TransactionId int                `json:"reservationId,omitempty"`
+	TransactionId *int               `json:"reservationId,omitempty"`
 	MeterValue    []types.MeterValue `json:"meterValue" validate:"required,min=1,dive"`
 }
 

--- a/ocpp1.6/core/remote_start_transaction.go
+++ b/ocpp1.6/core/remote_start_transaction.go
@@ -11,7 +11,7 @@ const RemoteStartTransactionFeatureName = "RemoteStartTransaction"
 
 // The field definition of the RemoteStartTransaction request payload sent by the Central System to the Charge Point.
 type RemoteStartTransactionRequest struct {
-	ConnectorId     int                    `json:"connectorId,omitempty" validate:"omitempty,gt=0"`
+	ConnectorId     *int                   `json:"connectorId,omitempty" validate:"omitempty,gt=0"`
 	IdTag           string                 `json:"idTag" validate:"required,max=20"`
 	ChargingProfile *types.ChargingProfile `json:"chargingProfile,omitempty"`
 }

--- a/ocpp1.6/core/start_transaction.go
+++ b/ocpp1.6/core/start_transaction.go
@@ -14,7 +14,7 @@ type StartTransactionRequest struct {
 	ConnectorId   int             `json:"connectorId" validate:"gt=0"`
 	IdTag         string          `json:"idTag" validate:"required,max=20"`
 	MeterStart    int             `json:"meterStart" validate:"gte=0"`
-	ReservationId int             `json:"reservationId,omitempty"`
+	ReservationId *int            `json:"reservationId,omitempty" validate:"omitempty,gte=0"`
 	Timestamp     *types.DateTime `json:"timestamp" validate:"required"`
 }
 

--- a/ocpp1.6/firmware/get_diagnostics.go
+++ b/ocpp1.6/firmware/get_diagnostics.go
@@ -12,8 +12,8 @@ const GetDiagnosticsFeatureName = "GetDiagnostics"
 // The field definition of the GetDiagnostics request payload sent by the Central System to the Charge Point.
 type GetDiagnosticsRequest struct {
 	Location      string          `json:"location" validate:"required,uri"`
-	Retries       int             `json:"retries" validate:"gte=0"`       //TODO: pointer?
-	RetryInterval int             `json:"retryInterval" validate:"gte=0"` //TODO: pointer?
+	Retries       *int            `json:"retries,omitempty" validate:"omitempty,gte=0"`
+	RetryInterval *int            `json:"retryInterval,omitempty" validate:"omitempty,gte=0"`
 	StartTime     *types.DateTime `json:"startTime,omitempty"`
 	EndTime       *types.DateTime `json:"endTime,omitempty"`
 }

--- a/ocpp1.6/firmware/update_firmware.go
+++ b/ocpp1.6/firmware/update_firmware.go
@@ -12,9 +12,9 @@ const UpdateFirmwareFeatureName = "UpdateFirmware"
 // The field definition of the UpdateFirmware request payload sent by the Central System to the Charge Point.
 type UpdateFirmwareRequest struct {
 	Location      string          `json:"location" validate:"required,uri"`
-	Retries       int             `json:"retries" validate:"gte=0"` //TODO: pointer?
+	Retries       *int            `json:"retries,omitempty" validate:"omitempty,gte=0"`
 	RetrieveDate  *types.DateTime `json:"retrieveDate" validate:"required"`
-	RetryInterval int             `json:"retryInterval" validate:"gte=0"` //TODO: pointer?
+	RetryInterval *int            `json:"retryInterval,omitempty" validate:"omitempty,gte=0"`
 }
 
 // This field definition of the UpdateFirmware confirmation payload, sent by the Charge Point to the Central System in response to a UpdateFirmwareRequest.

--- a/ocpp1.6/localauth/send_local_list.go
+++ b/ocpp1.6/localauth/send_local_list.go
@@ -49,11 +49,12 @@ type AuthorizationData struct {
 
 // The field definition of the SendLocalList request payload sent by the Central System to the Charge Point.
 // If no (empty) localAuthorizationList is given and the updateType is Full, all identifications are removed from the list.
+//
 // Requesting a Differential update without (empty) localAuthorizationList will have no effect on the list.
 // All idTags in the localAuthorizationList MUST be unique, no duplicate values are allowed.
 type SendLocalListRequest struct {
-	ListVersion            int                 `json:"listVersion" validate:"gt=-1"`
-	LocalAuthorizationList []AuthorizationData `json:"localAuthorizationList" validate:"dive"`
+	ListVersion            int                 `json:"listVersion" validate:"gte=0"`
+	LocalAuthorizationList []AuthorizationData `json:"localAuthorizationList,omitempty" validate:"omitempty,dive"`
 	UpdateType             UpdateType          `json:"updateType" validate:"required,updateType"`
 }
 

--- a/ocpp1.6/remotetrigger/trigger_message.go
+++ b/ocpp1.6/remotetrigger/trigger_message.go
@@ -47,7 +47,7 @@ func isValidMessageTrigger(fl validator.FieldLevel) bool {
 // The field definition of the TriggerMessage request payload sent by the Central System to the Charge Point.
 type TriggerMessageRequest struct {
 	RequestedMessage MessageTrigger `json:"requestedMessage" validate:"required,messageTrigger"`
-	ConnectorId      int            `json:"connectorId,omitempty" validate:"omitempty,gt=0"`
+	ConnectorId      *int           `json:"connectorId,omitempty" validate:"omitempty,gt=0"`
 }
 
 // This field definition of the TriggerMessage confirmation payload, sent by the Charge Point to the Central System in response to a TriggerMessageRequest.

--- a/ocpp1.6/smartcharging/clear_charging_profile.go
+++ b/ocpp1.6/smartcharging/clear_charging_profile.go
@@ -30,10 +30,10 @@ func isValidClearChargingProfileStatus(fl validator.FieldLevel) bool {
 
 // The field definition of the ClearChargingProfile request payload sent by the Central System to the Charge Point.
 type ClearChargingProfileRequest struct {
-	Id                     int                              `json:"id,omitempty" validate:"gte=0"`
-	ConnectorId            int                              `json:"connectorId,omitempty" validate:"gte=0"` //TODO: handle 0 case with pointer?
+	Id                     *int                             `json:"id,omitempty" validate:"omitempty,gte=0"`
+	ConnectorId            *int                             `json:"connectorId,omitempty" validate:"omitempty,gte=0"`
 	ChargingProfilePurpose types.ChargingProfilePurposeType `json:"chargingProfilePurpose,omitempty" validate:"omitempty,chargingProfilePurpose"`
-	StackLevel             int                              `json:"stackLevel,omitempty" validate:"omitempty,gt=0"`
+	StackLevel             *int                             `json:"stackLevel,omitempty" validate:"omitempty,gt=0"`
 }
 
 // This field definition of the ClearChargingProfile confirmation payload, sent by the Charge Point to the Central System in response to a ClearChargingProfileRequest.

--- a/ocpp1.6/smartcharging/get_composite_schedule.go
+++ b/ocpp1.6/smartcharging/get_composite_schedule.go
@@ -39,7 +39,7 @@ type GetCompositeScheduleRequest struct {
 // In case the request was invalid, or couldn't be processed, an error will be sent instead.
 type GetCompositeScheduleConfirmation struct {
 	Status           GetCompositeScheduleStatus `json:"status" validate:"required,compositeScheduleStatus"`
-	ConnectorId      int                        `json:"connectorId,omitempty" validate:"omitempty,gt=0"`
+	ConnectorId      *int                       `json:"connectorId,omitempty" validate:"omitempty,gt=0"`
 	ScheduleStart    *types.DateTime            `json:"scheduleStart,omitempty"`
 	ChargingSchedule *types.ChargingSchedule    `json:"chargingSchedule,omitempty" validate:"omitempty"`
 }

--- a/ocpp1.6/types/types.go
+++ b/ocpp1.6/types/types.go
@@ -111,7 +111,7 @@ func isValidChargingRateUnit(fl validator.FieldLevel) bool {
 type ChargingSchedulePeriod struct {
 	StartPeriod  int     `json:"startPeriod" validate:"gte=0"`
 	Limit        float64 `json:"limit" validate:"gte=0"`
-	NumberPhases int     `json:"numberPhases,omitempty" validate:"gte=0"`
+	NumberPhases *int    `json:"numberPhases,omitempty" validate:"omitempty,gte=0"`
 }
 
 func NewChargingSchedulePeriod(startPeriod int, limit float64) ChargingSchedulePeriod {
@@ -119,11 +119,11 @@ func NewChargingSchedulePeriod(startPeriod int, limit float64) ChargingScheduleP
 }
 
 type ChargingSchedule struct {
-	Duration               int                      `json:"duration,omitempty" validate:"gte=0"`
+	Duration               *int                     `json:"duration,omitempty" validate:"omitempty,gte=0"`
 	StartSchedule          *DateTime                `json:"startSchedule,omitempty"`
 	ChargingRateUnit       ChargingRateUnitType     `json:"chargingRateUnit" validate:"required,chargingRateUnit"`
 	ChargingSchedulePeriod []ChargingSchedulePeriod `json:"chargingSchedulePeriod" validate:"required,min=1"`
-	MinChargingRate        float64                  `json:"minChargingRate,omitempty" validate:"gte=0"`
+	MinChargingRate        *float64                 `json:"minChargingRate,omitempty" validate:"omitempty,gte=0"`
 }
 
 func NewChargingSchedule(chargingRateUnit ChargingRateUnitType, schedulePeriod ...ChargingSchedulePeriod) *ChargingSchedule {

--- a/ocpp1.6_test/authorize_test.go
+++ b/ocpp1.6_test/authorize_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"time"
 )
 
@@ -39,24 +40,30 @@ func (suite *OcppV16TestSuite) TestAuthorizeE2EMocked() {
 	parentIdTag := "parentTag1"
 	status := types.AuthorizationStatusAccepted
 	expiryDate := types.NewDateTime(time.Now().Add(time.Hour * 8))
+	idTagInfo := types.IdTagInfo{ExpiryDate: expiryDate, ParentIdTag: parentIdTag, Status: status}
 	requestJson := fmt.Sprintf(`[2,"%v","%v",{"idTag":"%v"}]`, messageId, core.AuthorizeFeatureName, idTag)
 	responseJson := fmt.Sprintf(`[3,"%v",{"idTagInfo":{"expiryDate":"%v","parentIdTag":"%v","status":"%v"}}]`, messageId, expiryDate.FormatTimestamp(), parentIdTag, status)
-	authorizeConfirmation := core.NewAuthorizationConfirmation(&types.IdTagInfo{ExpiryDate: expiryDate, ParentIdTag: parentIdTag, Status: status})
+	authorizeConfirmation := core.NewAuthorizationConfirmation(&idTagInfo)
 	requestRaw := []byte(requestJson)
 	responseRaw := []byte(responseJson)
 	channel := NewMockWebSocket(wsId)
 
 	coreListener := MockCentralSystemCoreListener{}
-	coreListener.On("OnAuthorize", mock.AnythingOfType("string"), mock.Anything).Return(authorizeConfirmation, nil)
+	coreListener.On("OnAuthorize", mock.AnythingOfType("string"), mock.Anything).Return(authorizeConfirmation, nil).Run(func(args mock.Arguments) {
+		request, ok := args.Get(1).(*core.AuthorizeRequest)
+		require.True(t, ok)
+		require.NotNil(t, request)
+		assert.Equal(t, idTag, request.IdTag)
+	})
 	setupDefaultCentralSystemHandlers(suite, coreListener, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: responseRaw, forwardWrittenMessage: true})
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: requestRaw, forwardWrittenMessage: true})
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	confirmation, err := suite.chargePoint.Authorize(idTag)
-	assert.Nil(t, err)
-	assert.NotNil(t, confirmation)
+	require.Nil(t, err)
+	require.NotNil(t, confirmation)
 	assert.Equal(t, status, confirmation.IdTagInfo.Status)
 	assert.Equal(t, parentIdTag, confirmation.IdTagInfo.ParentIdTag)
 	assertDateTimeEquality(t, *expiryDate, *confirmation.IdTagInfo.ExpiryDate)

--- a/ocpp1.6_test/cancel_reservation_test.go
+++ b/ocpp1.6_test/cancel_reservation_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/reservation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // Test
@@ -43,7 +44,8 @@ func (suite *OcppV16TestSuite) TestCancelReservationE2EMocked() {
 	reservationListener := MockChargePointReservationListener{}
 	reservationListener.On("OnCancelReservation", mock.Anything).Return(cancelReservationConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*reservation.CancelReservationRequest)
-		assert.True(t, ok)
+		require.NotNil(t, request)
+		require.True(t, ok)
 		assert.Equal(t, reservationId, request.ReservationId)
 	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
@@ -55,12 +57,12 @@ func (suite *OcppV16TestSuite) TestCancelReservationE2EMocked() {
 	assert.Nil(t, err)
 	resultChannel := make(chan bool, 1)
 	err = suite.centralSystem.CancelReservation(wsId, func(confirmation *reservation.CancelReservationConfirmation, err error) {
-		assert.Nil(t, err)
-		assert.NotNil(t, confirmation)
+		require.Nil(t, err)
+		require.NotNil(t, confirmation)
 		assert.Equal(t, status, confirmation.Status)
 		resultChannel <- true
 	}, reservationId)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	result := <-resultChannel
 	assert.True(t, result)
 }

--- a/ocpp1.6_test/cancel_reservation_test.go
+++ b/ocpp1.6_test/cancel_reservation_test.go
@@ -54,7 +54,7 @@ func (suite *OcppV16TestSuite) TestCancelReservationE2EMocked() {
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	resultChannel := make(chan bool, 1)
 	err = suite.centralSystem.CancelReservation(wsId, func(confirmation *reservation.CancelReservationConfirmation, err error) {
 		require.Nil(t, err)

--- a/ocpp1.6_test/change_availability_test.go
+++ b/ocpp1.6_test/change_availability_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func (suite *OcppV16TestSuite) TestChangeAvailabilityRequestValidation() {
@@ -47,7 +48,13 @@ func (suite *OcppV16TestSuite) TestChangeAvailabilityE2EMocked() {
 	channel := NewMockWebSocket(wsId)
 	// Setting handlers
 	coreListener := MockChargePointCoreListener{}
-	coreListener.On("OnChangeAvailability", mock.Anything).Return(changeAvailabilityConfirmation, nil)
+	coreListener.On("OnChangeAvailability", mock.Anything).Return(changeAvailabilityConfirmation, nil).Run(func(args mock.Arguments) {
+		request, ok := args.Get(0).(*core.ChangeAvailabilityRequest)
+		require.NotNil(t, request)
+		require.True(t, ok)
+		assert.Equal(t, connectorId, request.ConnectorId)
+		assert.Equal(t, availabilityType, request.Type)
+	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargePointHandlers(suite, coreListener, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
 	// Run Test
@@ -56,12 +63,12 @@ func (suite *OcppV16TestSuite) TestChangeAvailabilityE2EMocked() {
 	assert.Nil(t, err)
 	resultChannel := make(chan bool, 1)
 	err = suite.centralSystem.ChangeAvailability(wsId, func(confirmation *core.ChangeAvailabilityConfirmation, err error) {
-		assert.NotNil(t, confirmation)
-		assert.Nil(t, err)
+		require.NotNil(t, confirmation)
+		require.Nil(t, err)
 		assert.Equal(t, status, confirmation.Status)
 		resultChannel <- true
 	}, connectorId, availabilityType)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	result := <-resultChannel
 	assert.True(t, result)
 }

--- a/ocpp1.6_test/change_availability_test.go
+++ b/ocpp1.6_test/change_availability_test.go
@@ -60,7 +60,7 @@ func (suite *OcppV16TestSuite) TestChangeAvailabilityE2EMocked() {
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	resultChannel := make(chan bool, 1)
 	err = suite.centralSystem.ChangeAvailability(wsId, func(confirmation *core.ChangeAvailabilityConfirmation, err error) {
 		require.NotNil(t, confirmation)

--- a/ocpp1.6_test/change_configuration_test.go
+++ b/ocpp1.6_test/change_configuration_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // Test
@@ -47,21 +48,27 @@ func (suite *OcppV16TestSuite) TestChangeConfigurationE2EMocked() {
 	channel := NewMockWebSocket(wsId)
 
 	coreListener := MockChargePointCoreListener{}
-	coreListener.On("OnChangeConfiguration", mock.Anything).Return(changeConfigurationConfirmation, nil)
+	coreListener.On("OnChangeConfiguration", mock.Anything).Return(changeConfigurationConfirmation, nil).Run(func(args mock.Arguments) {
+		request, ok := args.Get(0).(*core.ChangeConfigurationRequest)
+		require.NotNil(t, request)
+		require.True(t, ok)
+		assert.Equal(t, key, request.Key)
+		assert.Equal(t, value, request.Value)
+	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargePointHandlers(suite, coreListener, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	resultChannel := make(chan bool, 1)
 	err = suite.centralSystem.ChangeConfiguration(wsId, func(confirmation *core.ChangeConfigurationConfirmation, err error) {
-		assert.Nil(t, err)
-		assert.NotNil(t, confirmation)
+		require.Nil(t, err)
+		require.NotNil(t, confirmation)
 		assert.Equal(t, status, confirmation.Status)
 		resultChannel <- true
 	}, key, value)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	result := <-resultChannel
 	assert.True(t, result)
 }

--- a/ocpp1.6_test/clear_cache_test.go
+++ b/ocpp1.6_test/clear_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // Test
@@ -45,15 +46,15 @@ func (suite *OcppV16TestSuite) TestClearCacheE2EMocked() {
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	resultChannel := make(chan bool, 1)
 	err = suite.centralSystem.ClearCache(wsId, func(confirmation *core.ClearCacheConfirmation, err error) {
-		assert.Nil(t, err)
-		assert.NotNil(t, confirmation)
+		require.Nil(t, err)
+		require.NotNil(t, confirmation)
 		assert.Equal(t, status, confirmation.Status)
 		resultChannel <- true
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	result := <-resultChannel
 	assert.True(t, result)
 }

--- a/ocpp1.6_test/common_test.go
+++ b/ocpp1.6_test/common_test.go
@@ -5,6 +5,11 @@ import (
 	"time"
 )
 
+// Utility functions
+func newInt(i int) *int {
+	return &i
+}
+
 // Test
 func (suite *OcppV16TestSuite) TestIdTagInfoValidation() {
 	var testTable = []GenericTestEntry{

--- a/ocpp1.6_test/common_test.go
+++ b/ocpp1.6_test/common_test.go
@@ -10,6 +10,10 @@ func newInt(i int) *int {
 	return &i
 }
 
+func newFloat(f float64) *float64 {
+	return &f
+}
+
 // Test
 func (suite *OcppV16TestSuite) TestIdTagInfoValidation() {
 	var testTable = []GenericTestEntry{
@@ -30,13 +34,13 @@ func (suite *OcppV16TestSuite) TestIdTagInfoValidation() {
 func (suite *OcppV16TestSuite) TestChargingSchedulePeriodValidation() {
 	t := suite.T()
 	var testTable = []GenericTestEntry{
-		{types.ChargingSchedulePeriod{StartPeriod: 0, Limit: 10.0, NumberPhases: 3}, true},
+		{types.ChargingSchedulePeriod{StartPeriod: 0, Limit: 10.0, NumberPhases: newInt(3)}, true},
 		{types.ChargingSchedulePeriod{StartPeriod: 0, Limit: 10.0}, true},
 		{types.ChargingSchedulePeriod{StartPeriod: 0}, true},
 		{types.ChargingSchedulePeriod{}, true},
 		{types.ChargingSchedulePeriod{StartPeriod: 0, Limit: -1.0}, false},
 		{types.ChargingSchedulePeriod{StartPeriod: -1, Limit: 10.0}, false},
-		{types.ChargingSchedulePeriod{StartPeriod: 0, Limit: 10.0, NumberPhases: -1}, false},
+		{types.ChargingSchedulePeriod{StartPeriod: 0, Limit: 10.0, NumberPhases: newInt(-1)}, false},
 	}
 	ExecuteGenericTestTable(t, testTable)
 }
@@ -47,15 +51,15 @@ func (suite *OcppV16TestSuite) TestChargingScheduleValidation() {
 	chargingSchedulePeriods[0] = types.NewChargingSchedulePeriod(0, 10.0)
 	chargingSchedulePeriods[1] = types.NewChargingSchedulePeriod(100, 8.0)
 	var testTable = []GenericTestEntry{
-		{types.ChargingSchedule{Duration: 0, StartSchedule: types.NewDateTime(time.Now()), ChargingRateUnit: types.ChargingRateUnitWatts, ChargingSchedulePeriod: chargingSchedulePeriods, MinChargingRate: 1.0}, true},
-		{types.ChargingSchedule{Duration: 0, ChargingRateUnit: types.ChargingRateUnitWatts, ChargingSchedulePeriod: chargingSchedulePeriods, MinChargingRate: 1.0}, true},
-		{types.ChargingSchedule{Duration: 0, ChargingRateUnit: types.ChargingRateUnitWatts, ChargingSchedulePeriod: chargingSchedulePeriods}, true},
-		{types.ChargingSchedule{Duration: 0, ChargingRateUnit: types.ChargingRateUnitWatts}, false},
-		{types.ChargingSchedule{Duration: 0, ChargingSchedulePeriod: chargingSchedulePeriods}, false},
-		{types.ChargingSchedule{Duration: -1, StartSchedule: types.NewDateTime(time.Now()), ChargingRateUnit: types.ChargingRateUnitWatts, ChargingSchedulePeriod: chargingSchedulePeriods, MinChargingRate: 1.0}, false},
-		{types.ChargingSchedule{Duration: 0, StartSchedule: types.NewDateTime(time.Now()), ChargingRateUnit: types.ChargingRateUnitWatts, ChargingSchedulePeriod: chargingSchedulePeriods, MinChargingRate: -1.0}, false},
-		{types.ChargingSchedule{Duration: 0, StartSchedule: types.NewDateTime(time.Now()), ChargingRateUnit: types.ChargingRateUnitWatts, ChargingSchedulePeriod: make([]types.ChargingSchedulePeriod, 0), MinChargingRate: 1.0}, false},
-		{types.ChargingSchedule{Duration: -1, StartSchedule: types.NewDateTime(time.Now()), ChargingRateUnit: "invalidChargeRateUnit", ChargingSchedulePeriod: chargingSchedulePeriods, MinChargingRate: 1.0}, false},
+		{types.ChargingSchedule{Duration: newInt(0), StartSchedule: types.NewDateTime(time.Now()), ChargingRateUnit: types.ChargingRateUnitWatts, ChargingSchedulePeriod: chargingSchedulePeriods, MinChargingRate: newFloat(1.0)}, true},
+		{types.ChargingSchedule{Duration: newInt(0), ChargingRateUnit: types.ChargingRateUnitWatts, ChargingSchedulePeriod: chargingSchedulePeriods, MinChargingRate: newFloat(1.0)}, true},
+		{types.ChargingSchedule{Duration: newInt(0), ChargingRateUnit: types.ChargingRateUnitWatts, ChargingSchedulePeriod: chargingSchedulePeriods}, true},
+		{types.ChargingSchedule{Duration: newInt(0), ChargingRateUnit: types.ChargingRateUnitWatts}, false},
+		{types.ChargingSchedule{Duration: newInt(0), ChargingSchedulePeriod: chargingSchedulePeriods}, false},
+		{types.ChargingSchedule{Duration: newInt(-1), StartSchedule: types.NewDateTime(time.Now()), ChargingRateUnit: types.ChargingRateUnitWatts, ChargingSchedulePeriod: chargingSchedulePeriods, MinChargingRate: newFloat(1.0)}, false},
+		{types.ChargingSchedule{Duration: newInt(0), StartSchedule: types.NewDateTime(time.Now()), ChargingRateUnit: types.ChargingRateUnitWatts, ChargingSchedulePeriod: chargingSchedulePeriods, MinChargingRate: newFloat(-1.0)}, false},
+		{types.ChargingSchedule{Duration: newInt(0), StartSchedule: types.NewDateTime(time.Now()), ChargingRateUnit: types.ChargingRateUnitWatts, ChargingSchedulePeriod: make([]types.ChargingSchedulePeriod, 0), MinChargingRate: newFloat(1.0)}, false},
+		{types.ChargingSchedule{Duration: newInt(0), StartSchedule: types.NewDateTime(time.Now()), ChargingRateUnit: "invalidChargeRateUnit", ChargingSchedulePeriod: chargingSchedulePeriods, MinChargingRate: newFloat(1.0)}, false},
 	}
 	ExecuteGenericTestTable(t, testTable)
 }

--- a/ocpp1.6_test/data_transfer_test.go
+++ b/ocpp1.6_test/data_transfer_test.go
@@ -79,12 +79,12 @@ func (suite *OcppV16TestSuite) TestDataTransferFromChargePointE2EMocked() {
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	confirmation, err := suite.chargePoint.DataTransfer(vendorId, func(request *core.DataTransferRequest) {
 		request.Data = data
 	})
-	assert.Nil(t, err)
-	assert.NotNil(t, confirmation)
+	require.Nil(t, err)
+	require.NotNil(t, confirmation)
 	assert.Equal(t, status, confirmation.Status)
 }
 
@@ -119,17 +119,17 @@ func (suite *OcppV16TestSuite) TestDataTransferFromCentralSystemE2EMocked() {
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	resultChannel := make(chan bool, 1)
 	err = suite.centralSystem.DataTransfer(wsId, func(confirmation *core.DataTransferConfirmation, err error) {
-		assert.Nil(t, err)
-		assert.NotNil(t, confirmation)
+		require.Nil(t, err)
+		require.NotNil(t, confirmation)
 		assert.Equal(t, status, confirmation.Status)
 		resultChannel <- true
 	}, vendorId, func(request *core.DataTransferRequest) {
 		request.Data = data
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	result := <-resultChannel
 	assert.True(t, result)
 }

--- a/ocpp1.6_test/data_transfer_test.go
+++ b/ocpp1.6_test/data_transfer_test.go
@@ -1,11 +1,25 @@
 package ocpp16_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
+
+type CustomData struct {
+	Field1 string `json:"field1" validate:"required"`
+	Field2 int    `json:"field2" validate:"gt=0"`
+}
+
+func parseCustomData(req *core.DataTransferRequest) (CustomData, error) {
+	jsonString, _ := json.Marshal(req.Data)
+	var result CustomData
+	err := json.Unmarshal(jsonString, &result)
+	return result, err
+}
 
 // Test
 func (suite *OcppV16TestSuite) TestDataTransferRequestValidation() {
@@ -40,21 +54,35 @@ func (suite *OcppV16TestSuite) TestDataTransferFromChargePointE2EMocked() {
 	messageId := defaultMessageId
 	wsUrl := "someUrl"
 	vendorId := "vendor1"
+	data := CustomData{Field1: "dummyData", Field2: 42}
 	status := core.DataTransferStatusAccepted
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"vendorId":"%v"}]`, messageId, core.DataTransferFeatureName, vendorId)
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"vendorId":"%v","data":{"field1":"%v","field2":%v}}]`, messageId, core.DataTransferFeatureName, vendorId, data.Field1, data.Field2)
 	responseJson := fmt.Sprintf(`[3,"%v",{"status":"%v"}]`, messageId, status)
 	dataTransferConfirmation := core.NewDataTransferConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 
 	coreListener := MockCentralSystemCoreListener{}
-	coreListener.On("OnDataTransfer", mock.AnythingOfType("string"), mock.Anything).Return(dataTransferConfirmation, nil)
+	coreListener.On("OnDataTransfer", mock.AnythingOfType("string"), mock.Anything).Return(dataTransferConfirmation, nil).Run(func(args mock.Arguments) {
+		request, ok := args.Get(1).(*core.DataTransferRequest)
+		require.NotNil(t, request)
+		require.True(t, ok)
+		assert.Equal(t, vendorId, request.VendorId)
+		require.NotNil(t, request.Data)
+		customData, err := parseCustomData(request)
+		require.Nil(t, err)
+		require.NotNil(t, customData)
+		assert.Equal(t, data.Field1, customData.Field1)
+		assert.Equal(t, data.Field2, customData.Field2)
+	})
 	setupDefaultCentralSystemHandlers(suite, coreListener, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
 	assert.Nil(t, err)
-	confirmation, err := suite.chargePoint.DataTransfer(vendorId)
+	confirmation, err := suite.chargePoint.DataTransfer(vendorId, func(request *core.DataTransferRequest) {
+		request.Data = data
+	})
 	assert.Nil(t, err)
 	assert.NotNil(t, confirmation)
 	assert.Equal(t, status, confirmation.Status)
@@ -66,14 +94,26 @@ func (suite *OcppV16TestSuite) TestDataTransferFromCentralSystemE2EMocked() {
 	messageId := defaultMessageId
 	wsUrl := "someUrl"
 	vendorId := "vendor1"
+	data := CustomData{Field1: "dummyData", Field2: 42}
 	status := core.DataTransferStatusAccepted
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"vendorId":"%v"}]`, messageId, core.DataTransferFeatureName, vendorId)
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"vendorId":"%v","data":{"field1":"%v","field2":%v}}]`, messageId, core.DataTransferFeatureName, vendorId, data.Field1, data.Field2)
 	responseJson := fmt.Sprintf(`[3,"%v",{"status":"%v"}]`, messageId, status)
 	dataTransferConfirmation := core.NewDataTransferConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 
 	coreListener := MockChargePointCoreListener{}
-	coreListener.On("OnDataTransfer", mock.Anything).Return(dataTransferConfirmation, nil)
+	coreListener.On("OnDataTransfer", mock.Anything).Return(dataTransferConfirmation, nil).Run(func(args mock.Arguments) {
+		request, ok := args.Get(0).(*core.DataTransferRequest)
+		require.NotNil(t, request)
+		require.True(t, ok)
+		assert.Equal(t, vendorId, request.VendorId)
+		require.NotNil(t, request.Data)
+		customData, err := parseCustomData(request)
+		require.Nil(t, err)
+		require.NotNil(t, customData)
+		assert.Equal(t, data.Field1, customData.Field1)
+		assert.Equal(t, data.Field2, customData.Field2)
+	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargePointHandlers(suite, coreListener, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
 	// Run Test
@@ -86,7 +126,9 @@ func (suite *OcppV16TestSuite) TestDataTransferFromCentralSystemE2EMocked() {
 		assert.NotNil(t, confirmation)
 		assert.Equal(t, status, confirmation.Status)
 		resultChannel <- true
-	}, vendorId)
+	}, vendorId, func(request *core.DataTransferRequest) {
+		request.Data = data
+	})
 	assert.Nil(t, err)
 	result := <-resultChannel
 	assert.True(t, result)

--- a/ocpp1.6_test/diagnostics_status_notification_test.go
+++ b/ocpp1.6_test/diagnostics_status_notification_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // Test
@@ -40,7 +41,8 @@ func (suite *OcppV16TestSuite) TestDiagnosticsStatusNotificationE2EMocked() {
 	firmwareListener := MockCentralSystemFirmwareManagementListener{}
 	firmwareListener.On("OnDiagnosticsStatusNotification", mock.AnythingOfType("string"), mock.Anything).Return(diagnosticsStatusNotificationConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(1).(*firmware.DiagnosticsStatusNotificationRequest)
-		assert.True(t, ok)
+		require.True(t, ok)
+		require.NotNil(t, request)
 		assert.Equal(t, status, request.Status)
 	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
@@ -49,10 +51,10 @@ func (suite *OcppV16TestSuite) TestDiagnosticsStatusNotificationE2EMocked() {
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	confirmation, err := suite.chargePoint.DiagnosticsStatusNotification(status)
-	assert.Nil(t, err)
-	assert.NotNil(t, confirmation)
+	require.Nil(t, err)
+	require.NotNil(t, confirmation)
 }
 
 func (suite *OcppV16TestSuite) TestDiagnosticsStatusNotificationInvalidEndpoint() {

--- a/ocpp1.6_test/firmware_status_notification_test.go
+++ b/ocpp1.6_test/firmware_status_notification_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // Test
@@ -40,7 +41,8 @@ func (suite *OcppV16TestSuite) TestFirmwareStatusNotificationE2EMocked() {
 	firmwareListener := MockCentralSystemFirmwareManagementListener{}
 	firmwareListener.On("OnFirmwareStatusNotification", mock.AnythingOfType("string"), mock.Anything).Return(firmwareStatusNotificationConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(1).(*firmware.FirmwareStatusNotificationRequest)
-		assert.True(t, ok)
+		require.True(t, ok)
+		require.NotNil(t, request)
 		assert.Equal(t, status, request.Status)
 	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
@@ -49,10 +51,10 @@ func (suite *OcppV16TestSuite) TestFirmwareStatusNotificationE2EMocked() {
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	confirmation, err := suite.chargePoint.FirmwareStatusNotification(status)
-	assert.Nil(t, err)
-	assert.NotNil(t, confirmation)
+	require.Nil(t, err)
+	require.NotNil(t, confirmation)
 }
 
 func (suite *OcppV16TestSuite) TestFirmwareStatusNotificationInvalidEndpoint() {

--- a/ocpp1.6_test/get_diagnostics_test.go
+++ b/ocpp1.6_test/get_diagnostics_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"time"
 )
 
@@ -13,15 +14,15 @@ import (
 func (suite *OcppV16TestSuite) TestGetDiagnosticsRequestValidation() {
 	t := suite.T()
 	var requestTable = []GenericTestEntry{
-		{firmware.GetDiagnosticsRequest{Location: "ftp:some/path", Retries: 10, RetryInterval: 10, StartTime: types.NewDateTime(time.Now()), EndTime: types.NewDateTime(time.Now())}, true},
-		{firmware.GetDiagnosticsRequest{Location: "ftp:some/path", Retries: 10, RetryInterval: 10, StartTime: types.NewDateTime(time.Now())}, true},
-		{firmware.GetDiagnosticsRequest{Location: "ftp:some/path", Retries: 10, RetryInterval: 10}, true},
-		{firmware.GetDiagnosticsRequest{Location: "ftp:some/path", Retries: 10}, true},
+		{firmware.GetDiagnosticsRequest{Location: "ftp:some/path", Retries: newInt(10), RetryInterval: newInt(10), StartTime: types.NewDateTime(time.Now()), EndTime: types.NewDateTime(time.Now())}, true},
+		{firmware.GetDiagnosticsRequest{Location: "ftp:some/path", Retries: newInt(10), RetryInterval: newInt(10), StartTime: types.NewDateTime(time.Now())}, true},
+		{firmware.GetDiagnosticsRequest{Location: "ftp:some/path", Retries: newInt(10), RetryInterval: newInt(10)}, true},
+		{firmware.GetDiagnosticsRequest{Location: "ftp:some/path", Retries: newInt(10)}, true},
 		{firmware.GetDiagnosticsRequest{Location: "ftp:some/path"}, true},
 		{firmware.GetDiagnosticsRequest{}, false},
 		{firmware.GetDiagnosticsRequest{Location: "invalidUri"}, false},
-		{firmware.GetDiagnosticsRequest{Location: "ftp:some/path", Retries: -1}, false},
-		{firmware.GetDiagnosticsRequest{Location: "ftp:some/path", RetryInterval: -1}, false},
+		{firmware.GetDiagnosticsRequest{Location: "ftp:some/path", Retries: newInt(-1)}, false},
+		{firmware.GetDiagnosticsRequest{Location: "ftp:some/path", RetryInterval: newInt(-1)}, false},
 	}
 	ExecuteGenericTestTable(t, requestTable)
 }
@@ -44,47 +45,52 @@ func (suite *OcppV16TestSuite) TestGetDiagnosticsE2EMocked() {
 	wsUrl := "someUrl"
 	location := "ftp:some/path"
 	fileName := "diagnostics.json"
-	retries := 10
-	retryInterval := 600
+	retries := newInt(10)
+	retryInterval := newInt(600)
 	startTime := types.NewDateTime(time.Now().Add(-10 * time.Hour * 24))
 	endTime := types.NewDateTime(time.Now())
 	requestJson := fmt.Sprintf(`[2,"%v","%v",{"location":"%v","retries":%v,"retryInterval":%v,"startTime":"%v","endTime":"%v"}]`,
-		messageId, firmware.GetDiagnosticsFeatureName, location, retries, retryInterval, startTime.FormatTimestamp(), endTime.FormatTimestamp())
+		messageId, firmware.GetDiagnosticsFeatureName, location, *retries, *retryInterval, startTime.FormatTimestamp(), endTime.FormatTimestamp())
 	responseJson := fmt.Sprintf(`[3,"%v",{"fileName":"%v"}]`, messageId, fileName)
 	getDiagnosticsConfirmation := firmware.NewGetDiagnosticsConfirmation()
 	getDiagnosticsConfirmation.FileName = fileName
 	channel := NewMockWebSocket(wsId)
 
 	firmwareListener := MockChargePointFirmwareManagementListener{}
-	firmwareListener.On("OnGetDiagnostics", mock.Anything).Return(getDiagnosticsConfirmation, nil)
+	firmwareListener.On("OnGetDiagnostics", mock.Anything).Return(getDiagnosticsConfirmation, nil).Run(func(args mock.Arguments) {
+		request, ok := args.Get(0).(*firmware.GetDiagnosticsRequest)
+		require.NotNil(t, request)
+		require.True(t, ok)
+		assert.Equal(t, location, request.Location)
+		require.NotNil(t, request.Retries)
+		assert.Equal(t, *retries, *request.Retries)
+		require.NotNil(t, request.RetryInterval)
+		assert.Equal(t, *retryInterval, *request.RetryInterval)
+		assertDateTimeEquality(t, *startTime, *request.StartTime)
+		assertDateTimeEquality(t, *endTime, *request.EndTime)
+	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	suite.chargePoint.SetFirmwareManagementHandler(firmwareListener)
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	resultChannel := make(chan bool, 1)
 	err = suite.centralSystem.GetDiagnostics(wsId, func(confirmation *firmware.GetDiagnosticsConfirmation, err error) {
-		assert.Nil(t, err)
-		assert.NotNil(t, confirmation)
-		if confirmation != nil {
-			assert.Equal(t, fileName, confirmation.FileName)
-			resultChannel <- true
-		} else {
-			resultChannel <- false
-		}
+		require.Nil(t, err)
+		require.NotNil(t, confirmation)
+		assert.Equal(t, fileName, confirmation.FileName)
+		resultChannel <- true
 	}, location, func(request *firmware.GetDiagnosticsRequest) {
 		request.RetryInterval = retryInterval
 		request.Retries = retries
 		request.StartTime = startTime
 		request.EndTime = endTime
 	})
-	assert.Nil(t, err)
-	if err == nil {
-		result := <-resultChannel
-		assert.True(t, result)
-	}
+	require.Nil(t, err)
+	result := <-resultChannel
+	assert.True(t, result)
 }
 
 func (suite *OcppV16TestSuite) TestGetDiagnosticsInvalidEndpoint() {

--- a/ocpp1.6_test/remote_stop_transaction_test.go
+++ b/ocpp1.6_test/remote_stop_transaction_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // Test
@@ -43,21 +44,26 @@ func (suite *OcppV16TestSuite) TestRemoteStopTransactionE2EMocked() {
 	channel := NewMockWebSocket(wsId)
 
 	coreListener := MockChargePointCoreListener{}
-	coreListener.On("OnRemoteStopTransaction", mock.Anything).Return(RemoteStopTransactionConfirmation, nil)
+	coreListener.On("OnRemoteStopTransaction", mock.Anything).Return(RemoteStopTransactionConfirmation, nil).Run(func(args mock.Arguments) {
+		request, ok := args.Get(0).(*core.RemoteStopTransactionRequest)
+		require.NotNil(t, request)
+		require.True(t, ok)
+		assert.Equal(t, transactionId, request.TransactionId)
+	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargePointHandlers(suite, coreListener, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	resultChannel := make(chan bool, 1)
 	err = suite.centralSystem.RemoteStopTransaction(wsId, func(confirmation *core.RemoteStopTransactionConfirmation, err error) {
-		assert.Nil(t, err)
-		assert.NotNil(t, confirmation)
+		require.Nil(t, err)
+		require.NotNil(t, confirmation)
 		assert.Equal(t, status, confirmation.Status)
 		resultChannel <- true
 	}, transactionId)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	result := <-resultChannel
 	assert.True(t, result)
 }

--- a/ocpp1.6_test/set_charging_profile_test.go
+++ b/ocpp1.6_test/set_charging_profile_test.go
@@ -94,15 +94,15 @@ func (suite *OcppV16TestSuite) TestSetChargingProfileE2EMocked() {
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	resultChannel := make(chan bool, 1)
 	err = suite.centralSystem.SetChargingProfile(wsId, func(confirmation *smartcharging.SetChargingProfileConfirmation, err error) {
-		assert.Nil(t, err)
-		assert.NotNil(t, confirmation)
+		require.Nil(t, err)
+		require.NotNil(t, confirmation)
 		assert.Equal(t, status, confirmation.Status)
 		resultChannel <- true
 	}, connectorId, chargingProfile)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	result := <-resultChannel
 	assert.True(t, result)
 }

--- a/ocpp1.6_test/set_charging_profile_test.go
+++ b/ocpp1.6_test/set_charging_profile_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // Test
@@ -67,8 +68,8 @@ func (suite *OcppV16TestSuite) TestSetChargingProfileE2EMocked() {
 	smartChargingListener := MockChargePointSmartChargingListener{}
 	smartChargingListener.On("OnSetChargingProfile", mock.Anything).Return(SetChargingProfileConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*smartcharging.SetChargingProfileRequest)
-		assert.True(t, ok)
-		assert.NotNil(t, request)
+		require.True(t, ok)
+		require.NotNil(t, request)
 		assert.Equal(t, connectorId, request.ConnectorId)
 		assert.Equal(t, chargingProfileId, request.ChargingProfile.ChargingProfileId)
 		assert.Equal(t, chargingProfileKind, request.ChargingProfile.ChargingProfileKind)
@@ -79,13 +80,13 @@ func (suite *OcppV16TestSuite) TestSetChargingProfileE2EMocked() {
 		assert.Nil(t, request.ChargingProfile.ValidFrom)
 		assert.Nil(t, request.ChargingProfile.ValidTo)
 		assert.Equal(t, chargingRateUnit, request.ChargingProfile.ChargingSchedule.ChargingRateUnit)
-		assert.Equal(t, 0.0, request.ChargingProfile.ChargingSchedule.MinChargingRate)
-		assert.Equal(t, 0, request.ChargingProfile.ChargingSchedule.Duration)
+		assert.Nil(t, request.ChargingProfile.ChargingSchedule.MinChargingRate)
+		assert.Nil(t, request.ChargingProfile.ChargingSchedule.Duration)
 		assert.Nil(t, request.ChargingProfile.ChargingSchedule.StartSchedule)
-		assert.Equal(t, 1, len(request.ChargingProfile.ChargingSchedule.ChargingSchedulePeriod))
+		require.Len(t, request.ChargingProfile.ChargingSchedule.ChargingSchedulePeriod, 1)
 		assert.Equal(t, limit, request.ChargingProfile.ChargingSchedule.ChargingSchedulePeriod[0].Limit)
 		assert.Equal(t, startPeriod, request.ChargingProfile.ChargingSchedule.ChargingSchedulePeriod[0].StartPeriod)
-		assert.Equal(t, 0, request.ChargingProfile.ChargingSchedule.ChargingSchedulePeriod[0].NumberPhases)
+		assert.Nil(t, request.ChargingProfile.ChargingSchedule.ChargingSchedulePeriod[0].NumberPhases)
 	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})

--- a/ocpp1.6_test/start_transaction_test.go
+++ b/ocpp1.6_test/start_transaction_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"time"
 )
 
@@ -13,7 +14,7 @@ import (
 func (suite *OcppV16TestSuite) TestStartTransactionRequestValidation() {
 	t := suite.T()
 	var requestTable = []GenericTestEntry{
-		{core.StartTransactionRequest{ConnectorId: 1, IdTag: "12345", MeterStart: 100, ReservationId: 42, Timestamp: types.NewDateTime(time.Now())}, true},
+		{core.StartTransactionRequest{ConnectorId: 1, IdTag: "12345", MeterStart: 100, ReservationId: newInt(42), Timestamp: types.NewDateTime(time.Now())}, true},
 		{core.StartTransactionRequest{ConnectorId: 1, IdTag: "12345", MeterStart: 100, Timestamp: types.NewDateTime(time.Now())}, true},
 		{core.StartTransactionRequest{ConnectorId: 1, IdTag: "12345", Timestamp: types.NewDateTime(time.Now())}, true},
 		{core.StartTransactionRequest{ConnectorId: 0, IdTag: "12345", MeterStart: 100, Timestamp: types.NewDateTime(time.Now())}, false},
@@ -44,14 +45,15 @@ func (suite *OcppV16TestSuite) TestStartTransactionE2EMocked() {
 	wsUrl := "someUrl"
 	idTag := "tag1"
 	meterStart := 100
-	reservationId := 42
+	reservationId := newInt(42)
 	connectorId := 1
 	timestamp := types.NewDateTime(time.Now())
 	parentIdTag := "parentTag1"
 	status := types.AuthorizationStatusAccepted
 	expiryDate := types.NewDateTime(time.Now().Add(time.Hour * 8))
 	transactionId := 16
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"connectorId":%v,"idTag":"%v","meterStart":%v,"reservationId":%v,"timestamp":"%v"}]`, messageId, core.StartTransactionFeatureName, connectorId, idTag, meterStart, reservationId, timestamp.FormatTimestamp())
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"connectorId":%v,"idTag":"%v","meterStart":%v,"reservationId":%v,"timestamp":"%v"}]`,
+		messageId, core.StartTransactionFeatureName, connectorId, idTag, meterStart, *reservationId, timestamp.FormatTimestamp())
 	responseJson := fmt.Sprintf(`[3,"%v",{"idTagInfo":{"expiryDate":"%v","parentIdTag":"%v","status":"%v"},"transactionId":%v}]`, messageId, expiryDate.FormatTimestamp(), parentIdTag, status, transactionId)
 	startTransactionConfirmation := core.NewStartTransactionConfirmation(&types.IdTagInfo{ExpiryDate: expiryDate, ParentIdTag: parentIdTag, Status: status}, transactionId)
 	requestRaw := []byte(requestJson)
@@ -60,11 +62,13 @@ func (suite *OcppV16TestSuite) TestStartTransactionE2EMocked() {
 
 	coreListener := MockCentralSystemCoreListener{}
 	coreListener.On("OnStartTransaction", mock.AnythingOfType("string"), mock.Anything).Return(startTransactionConfirmation, nil).Run(func(args mock.Arguments) {
-		request := args.Get(1).(*core.StartTransactionRequest)
+		request, ok := args.Get(1).(*core.StartTransactionRequest)
+		require.True(t, ok)
+		require.NotNil(t, request)
 		assert.Equal(t, connectorId, request.ConnectorId)
 		assert.Equal(t, idTag, request.IdTag)
 		assert.Equal(t, meterStart, request.MeterStart)
-		assert.Equal(t, reservationId, request.ReservationId)
+		assert.Equal(t, *reservationId, *request.ReservationId)
 		assertDateTimeEquality(t, *timestamp, *request.Timestamp)
 	})
 	setupDefaultCentralSystemHandlers(suite, coreListener, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: responseRaw, forwardWrittenMessage: true})
@@ -72,12 +76,12 @@ func (suite *OcppV16TestSuite) TestStartTransactionE2EMocked() {
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	confirmation, err := suite.chargePoint.StartTransaction(connectorId, idTag, meterStart, timestamp, func(request *core.StartTransactionRequest) {
 		request.ReservationId = reservationId
 	})
-	assert.Nil(t, err)
-	assert.NotNil(t, confirmation)
+	require.Nil(t, err)
+	require.NotNil(t, confirmation)
 	assert.Equal(t, status, confirmation.IdTagInfo.Status)
 	assert.Equal(t, parentIdTag, confirmation.IdTagInfo.ParentIdTag)
 	assertDateTimeEquality(t, *expiryDate, *confirmation.IdTagInfo.ExpiryDate)

--- a/ocpp1.6_test/status_notification_test.go
+++ b/ocpp1.6_test/status_notification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"time"
 )
 
@@ -57,7 +58,8 @@ func (suite *OcppV16TestSuite) TestStatusNotificationE2EMocked() {
 	coreListener := MockCentralSystemCoreListener{}
 	coreListener.On("OnStatusNotification", mock.AnythingOfType("string"), mock.Anything).Return(statusNotificationConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(1).(*core.StatusNotificationRequest)
-		assert.True(t, ok)
+		require.True(t, ok)
+		require.NotNil(t, request)
 		assert.Equal(t, connectorId, request.ConnectorId)
 		assert.Equal(t, cpErrorCode, request.ErrorCode)
 		assert.Equal(t, status, request.Status)
@@ -71,15 +73,15 @@ func (suite *OcppV16TestSuite) TestStatusNotificationE2EMocked() {
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	confirmation, err := suite.chargePoint.StatusNotification(connectorId, cpErrorCode, status, func(request *core.StatusNotificationRequest) {
 		request.Timestamp = timestamp
 		request.Info = info
 		request.VendorId = vendorId
 		request.VendorErrorCode = vendorErrorCode
 	})
-	assert.Nil(t, err)
-	assert.NotNil(t, confirmation)
+	require.Nil(t, err)
+	require.NotNil(t, confirmation)
 }
 
 func (suite *OcppV16TestSuite) TestStatusNotificationInvalidEndpoint() {

--- a/ocpp1.6_test/unlock_connector_test.go
+++ b/ocpp1.6_test/unlock_connector_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func (suite *OcppV16TestSuite) TestUnlockConnectorRequestValidation() {
@@ -41,21 +42,26 @@ func (suite *OcppV16TestSuite) TestUnlockConnectorE2EMocked() {
 	channel := NewMockWebSocket(wsId)
 	// Setting handlers
 	coreListener := MockChargePointCoreListener{}
-	coreListener.On("OnUnlockConnector", mock.Anything).Return(unlockConnectorConfirmation, nil)
+	coreListener.On("OnUnlockConnector", mock.Anything).Return(unlockConnectorConfirmation, nil).Run(func(args mock.Arguments) {
+		request, ok := args.Get(0).(*core.UnlockConnectorRequest)
+		require.NotNil(t, request)
+		require.True(t, ok)
+		assert.Equal(t, connectorId, request.ConnectorId)
+	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargePointHandlers(suite, coreListener, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	resultChannel := make(chan bool, 1)
 	err = suite.centralSystem.UnlockConnector(wsId, func(confirmation *core.UnlockConnectorConfirmation, err error) {
-		assert.NotNil(t, confirmation)
-		assert.Nil(t, err)
+		require.NotNil(t, confirmation)
+		require.Nil(t, err)
 		assert.Equal(t, status, confirmation.Status)
 		resultChannel <- true
 	}, connectorId)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	result := <-resultChannel
 	assert.True(t, result)
 }

--- a/ocpp1.6_test/update_firmware_test.go
+++ b/ocpp1.6_test/update_firmware_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"time"
 )
 
@@ -13,14 +14,14 @@ import (
 func (suite *OcppV16TestSuite) TestUpdateFirmwareRequestValidation() {
 	t := suite.T()
 	var requestTable = []GenericTestEntry{
-		{firmware.UpdateFirmwareRequest{Location: "ftp:some/path", Retries: 10, RetryInterval: 10, RetrieveDate: types.NewDateTime(time.Now())}, true},
-		{firmware.UpdateFirmwareRequest{Location: "ftp:some/path", Retries: 10, RetrieveDate: types.NewDateTime(time.Now())}, true},
+		{firmware.UpdateFirmwareRequest{Location: "ftp:some/path", Retries: newInt(10), RetryInterval: newInt(10), RetrieveDate: types.NewDateTime(time.Now())}, true},
+		{firmware.UpdateFirmwareRequest{Location: "ftp:some/path", Retries: newInt(10), RetrieveDate: types.NewDateTime(time.Now())}, true},
 		{firmware.UpdateFirmwareRequest{Location: "ftp:some/path", RetrieveDate: types.NewDateTime(time.Now())}, true},
 		{firmware.UpdateFirmwareRequest{}, false},
 		{firmware.UpdateFirmwareRequest{Location: "ftp:some/path"}, false},
 		{firmware.UpdateFirmwareRequest{Location: "invalidUri", RetrieveDate: types.NewDateTime(time.Now())}, false},
-		{firmware.UpdateFirmwareRequest{Location: "ftp:some/path", Retries: -1, RetrieveDate: types.NewDateTime(time.Now())}, false},
-		{firmware.UpdateFirmwareRequest{Location: "ftp:some/path", RetryInterval: -1, RetrieveDate: types.NewDateTime(time.Now())}, false},
+		{firmware.UpdateFirmwareRequest{Location: "ftp:some/path", Retries: newInt(-1), RetrieveDate: types.NewDateTime(time.Now())}, false},
+		{firmware.UpdateFirmwareRequest{Location: "ftp:some/path", RetryInterval: newInt(-1), RetrieveDate: types.NewDateTime(time.Now())}, false},
 	}
 	ExecuteGenericTestTable(t, requestTable)
 }
@@ -39,17 +40,27 @@ func (suite *OcppV16TestSuite) TestUpdateFirmwareE2EMocked() {
 	messageId := defaultMessageId
 	wsUrl := "someUrl"
 	location := "ftp:some/path"
-	retries := 10
-	retryInterval := 600
+	retries := newInt(10)
+	retryInterval := newInt(600)
 	retrieveDate := types.NewDateTime(time.Now())
 	requestJson := fmt.Sprintf(`[2,"%v","%v",{"location":"%v","retries":%v,"retrieveDate":"%v","retryInterval":%v}]`,
-		messageId, firmware.UpdateFirmwareFeatureName, location, retries, retrieveDate.FormatTimestamp(), retryInterval)
+		messageId, firmware.UpdateFirmwareFeatureName, location, *retries, retrieveDate.FormatTimestamp(), *retryInterval)
 	responseJson := fmt.Sprintf(`[3,"%v",{}]`, messageId)
 	updateFirmwareConfirmation := firmware.NewUpdateFirmwareConfirmation()
 	channel := NewMockWebSocket(wsId)
 
 	firmwareListener := MockChargePointFirmwareManagementListener{}
-	firmwareListener.On("OnUpdateFirmware", mock.Anything).Return(updateFirmwareConfirmation, nil)
+	firmwareListener.On("OnUpdateFirmware", mock.Anything).Return(updateFirmwareConfirmation, nil).Run(func(args mock.Arguments) {
+		request, ok := args.Get(0).(*firmware.UpdateFirmwareRequest)
+		require.NotNil(t, request)
+		require.True(t, ok)
+		assert.Equal(t, location, request.Location)
+		assert.NotNil(t, request.Retries)
+		assert.Equal(t, *retries, *request.Retries)
+		assert.NotNil(t, request.RetryInterval)
+		assert.Equal(t, *retryInterval, *request.RetryInterval)
+		assertDateTimeEquality(t, *retrieveDate, *request.RetrieveDate)
+	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	suite.chargePoint.SetFirmwareManagementHandler(firmwareListener)
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
@@ -59,22 +70,16 @@ func (suite *OcppV16TestSuite) TestUpdateFirmwareE2EMocked() {
 	assert.Nil(t, err)
 	resultChannel := make(chan bool, 1)
 	err = suite.centralSystem.UpdateFirmware(wsId, func(confirmation *firmware.UpdateFirmwareConfirmation, err error) {
-		assert.Nil(t, err)
-		assert.NotNil(t, confirmation)
-		if confirmation == nil || err != nil {
-			resultChannel <- false
-		} else {
-			resultChannel <- true
-		}
+		require.Nil(t, err)
+		require.NotNil(t, confirmation)
+		resultChannel <- true
 	}, location, retrieveDate, func(request *firmware.UpdateFirmwareRequest) {
 		request.RetryInterval = retryInterval
 		request.Retries = retries
 	})
-	assert.Nil(t, err)
-	if err == nil {
-		result := <-resultChannel
-		assert.True(t, result)
-	}
+	require.Nil(t, err)
+	result := <-resultChannel
+	assert.True(t, result)
 }
 
 func (suite *OcppV16TestSuite) TestUpdateFirmwareInvalidEndpoint() {


### PR DESCRIPTION
Adds following improvements:
- Some optional fields in messages were properly converted to pointers
- Tests are more extensive on parsed messages
- Dummy firmware update logic in charge point example
- Bugfixes following OCPP 1.6 Plugfest 07-2020