### PR TITLE
OCPP1.6: correct field name in SetChargingProfile

### DIFF
--- a/ocpp1.6/smartcharging/set_charging_profile.go
+++ b/ocpp1.6/smartcharging/set_charging_profile.go
@@ -1,9 +1,10 @@
 package smartcharging
 
 import (
+	"reflect"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"gopkg.in/go-playground/validator.v9"
-	"reflect"
 )
 
 // -------------------- Set Charging Profile (CS -> CP) --------------------
@@ -32,7 +33,7 @@ func isValidChargingProfileStatus(fl validator.FieldLevel) bool {
 // The field definition of the SetChargingProfile request payload sent by the Central System to the Charge Point.
 type SetChargingProfileRequest struct {
 	ConnectorId     int                    `json:"connectorId" validate:"gte=0"`
-	ChargingProfile *types.ChargingProfile `json:"chargingProfile" validate:"required"`
+	ChargingProfile *types.ChargingProfile `json:"csChargingProfiles" validate:"required"`
 }
 
 // This field definition of the SetChargingProfile confirmation payload, sent by the Charge Point to the Central System in response to a SetChargingProfileRequest.

--- a/ocpp1.6_test/set_charging_profile_test.go
+++ b/ocpp1.6_test/set_charging_profile_test.go
@@ -2,6 +2,7 @@ package ocpp16_test
 
 import (
 	"fmt"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/smartcharging"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
@@ -50,7 +51,7 @@ func (suite *OcppV16TestSuite) TestSetChargingProfileE2EMocked() {
 	status := smartcharging.ChargingProfileStatusAccepted
 	chargingSchedule := types.NewChargingSchedule(chargingRateUnit, types.NewChargingSchedulePeriod(startPeriod, limit))
 	chargingProfile := types.NewChargingProfile(chargingProfileId, stackLevel, chargingProfilePurpose, chargingProfileKind, chargingSchedule)
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"connectorId":%v,"chargingProfile":{"chargingProfileId":%v,"stackLevel":%v,"chargingProfilePurpose":"%v","chargingProfileKind":"%v","chargingSchedule":{"chargingRateUnit":"%v","chargingSchedulePeriod":[{"startPeriod":%v,"limit":%v}]}}}]`,
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"connectorId":%v,"csChargingProfiles":{"chargingProfileId":%v,"stackLevel":%v,"chargingProfilePurpose":"%v","chargingProfileKind":"%v","chargingSchedule":{"chargingRateUnit":"%v","chargingSchedulePeriod":[{"startPeriod":%v,"limit":%v}]}}}]`,
 		messageId,
 		smartcharging.SetChargingProfileFeatureName,
 		connectorId,
@@ -119,7 +120,7 @@ func (suite *OcppV16TestSuite) TestSetChargingProfileInvalidEndpoint() {
 	limit := 10.0
 	chargingSchedule := types.NewChargingSchedule(chargingRateUnit, types.NewChargingSchedulePeriod(startPeriod, limit))
 	chargingProfile := types.NewChargingProfile(chargingProfileId, stackLevel, chargingProfilePurpose, chargingProfileKind, chargingSchedule)
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"connectorId":%v,"chargingProfile":{"chargingProfileId":%v,"stackLevel":%v,"chargingProfilePurpose":"%v","chargingProfileKind":"%v","chargingSchedule":{"chargingRateUnit":"%v","chargingSchedulePeriod":[{"startPeriod":%v,"limit":%v}]}}}]`,
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"connectorId":%v,"csChargingProfiles":{"chargingProfileId":%v,"stackLevel":%v,"chargingProfilePurpose":"%v","chargingProfileKind":"%v","chargingSchedule":{"chargingRateUnit":"%v","chargingSchedulePeriod":[{"startPeriod":%v,"limit":%v}]}}}]`,
 		messageId,
 		smartcharging.SetChargingProfileFeatureName,
 		connectorId,


### PR DESCRIPTION
Section 6.43 of the spec pretty clearly states that the field name is
"csChargingProfiles".

cc @frzifus @gq0