### PR TITLE
Fix certificate SANs for websocket tests

### DIFF
--- a/example/1.6/create-test-certificates.sh
+++ b/example/1.6/create-test-certificates.sh
@@ -7,9 +7,9 @@ cd certs
 openssl req -new -x509 -nodes -days 120 -extensions v3_ca -keyout ca.key -out ca.crt -subj "/CN=ocpp-go-example"
 # Generate self-signed central-system certificate
 openssl genrsa -out cs/central-system.key 4096
-openssl req -out cs/central-system.csr -key cs/central-system.key -new -subj "/CN=central-system"
-openssl x509 -req -in cs/central-system.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out cs/central-system.crt -days 120
+openssl req -new -out cs/central-system.csr -key cs/central-system.key -config ../openssl-cs.conf
+openssl x509 -req -in cs/central-system.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out cs/central-system.crt -days 120 -extensions req_ext -extfile ../openssl-cs.conf
 # Generate self-signed charge-point certificate
 openssl genrsa -out cp/charge-point.key 4096
-openssl req -new -out cp/charge-point.csr -key cp/charge-point.key -subj "/CN=charge-point"
-openssl x509 -req -in cp/charge-point.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out cp/charge-point.crt -days 120
+openssl req -new -out cp/charge-point.csr -key cp/charge-point.key -config ../openssl-cp.conf
+openssl x509 -req -in cp/charge-point.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out cp/charge-point.crt -days 120 -extensions req_ext -extfile ../openssl-cp.conf

--- a/example/1.6/openssl-cp.conf
+++ b/example/1.6/openssl-cp.conf
@@ -1,0 +1,14 @@
+[req]
+distinguished_name = req_dn
+req_extensions = req_ext
+prompt = no
+[req_dn]
+CN = charge-point
+[req_ext]
+basicConstraints        = CA:FALSE
+subjectKeyIdentifier    = hash
+keyUsage                = digitalSignature, keyEncipherment
+extendedKeyUsage        = clientAuth
+subjectAltName          = @alt_names
+[alt_names]
+DNS.1 = charge-point

--- a/example/1.6/openssl-cs.conf
+++ b/example/1.6/openssl-cs.conf
@@ -1,0 +1,14 @@
+[req]
+distinguished_name = req_dn
+req_extensions = req_ext
+prompt = no
+[req_dn]
+CN = central-system
+[req_ext]
+basicConstraints        = CA:FALSE
+subjectKeyIdentifier    = hash
+keyUsage                = digitalSignature, keyEncipherment, dataEncipherment
+extendedKeyUsage        = serverAuth
+subjectAltName          = @alt_naes
+[alt_names]
+DNS.1 = central-system

--- a/ws/websocket_test.go
+++ b/ws/websocket_test.go
@@ -446,9 +446,9 @@ func TestInvalidClientTLSCertificate(t *testing.T) {
 	u := url.URL{Scheme: "wss", Host: host, Path: testPath}
 	err = wsClient.Start(u.String())
 	assert.NotNil(t, err)
-	netError, ok := err.(*net.OpError)
+	netError, ok := err.(net.Error)
 	require.True(t, ok)
-	assert.Equal(t, "tls: bad certificate", netError.Err.Error()) // tls.alertBadCertificate = 42
+	assert.Equal(t, "remote error: tls: bad certificate", netError.Error()) // tls.alertBadCertificate = 42
 	// Cleanup
 	wsServer.Stop()
 }
@@ -510,6 +510,7 @@ func createCACertificate(certificateFilename string, keyFilename string) (*x509.
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
 	}
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
 	if err != nil {
@@ -569,6 +570,7 @@ func createTLSCertificate(certificateFilename string, keyFilename string, cn str
 		KeyUsage:              keyUsage,
 		ExtKeyUsage:           extKeyUsage,
 		BasicConstraintsValid: true,
+		DNSNames:              []string{cn},
 	}
 	var derBytes []byte
 	if ca != nil && caKey != nil {


### PR DESCRIPTION
Fixes certificate validation issue in tests, introduced by Go 1.15 (CN not valid anymore for domain verification, SAN should be used instead).