### PR TITLE
Add dateparse and DefaultTimeFormat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/lorenzodonini/ocpp-go
 go 1.12
 
 require (
+	github.com/araddon/dateparse v0.0.0-20201001162425-8aadafed4dc4
 	github.com/go-playground/locales v0.12.1 // indirect
 	github.com/go-playground/universal-translator v0.16.0 // indirect
 	github.com/gorilla/mux v1.7.3
@@ -11,7 +12,7 @@ require (
 	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/stretchr/testify v1.4.0
+	github.com/stretchr/testify v1.6.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.30.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/araddon/dateparse v0.0.0-20201001162425-8aadafed4dc4 h1:OkS1BqB3CzLtGRznRyvriSY8jeaVk2CrDn2ZiRQgMUI=
+github.com/araddon/dateparse v0.0.0-20201001162425-8aadafed4dc4/go.mod h1:hMAUZFIkk4B1FouGxqlogyMyU6BwY/UiVmmbbzz9Up8=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -19,10 +21,12 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/leodido/go-urn v1.1.0 h1:Sm1gr51B1kKyfD2BlRcLSiEkffoG96g6TPv6eRoEiB8=
 github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
@@ -30,8 +34,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -41,5 +45,5 @@ gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXa
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.30.0 h1:Wk0Z37oBmKj9/n+tPyBHZmeL19LaCoK3Qq48VwYENss=
 gopkg.in/go-playground/validator.v9 v9.30.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/ocpp1.6/types/datetime.go
+++ b/ocpp1.6/types/datetime.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"github.com/araddon/dateparse"
 	"strings"
 	"time"
 )
@@ -9,11 +10,13 @@ import (
 // ISO8601 time format, assuming Zulu timestamp.
 const ISO8601 = "2006-01-02T15:04:05Z"
 
+var DefaultTimeFormat = time.RFC3339
+
 // DateTimeFormat to be used for all OCPP messages.
 //
 // The default dateTime format is RFC3339.
 // Change this if another format is desired.
-var DateTimeFormat = time.RFC3339
+var DateTimeFormat = ""
 
 // DateTime wraps a time.Time struct, allowing for improved dateTime JSON compatibility.
 type DateTime struct {
@@ -29,8 +32,12 @@ func (dt *DateTime) UnmarshalJSON(input []byte) error {
 	strInput := string(input)
 	strInput = strings.Trim(strInput, `"`)
 	if DateTimeFormat == "" {
-		defaultTime := time.Time{}
-		err := json.Unmarshal(input, defaultTime)
+		var stringTime string
+		err := json.Unmarshal(input, &stringTime)
+		if err != nil {
+			return err
+		}
+		defaultTime, err := dateparse.ParseAny(stringTime)
 		if err != nil {
 			return err
 		}
@@ -56,11 +63,18 @@ func (dt *DateTime) MarshalJSON() ([]byte, error) {
 // Formats the UTC timestamp using the DateTimeFormat setting.
 // This function is used during JSON marshaling as well.
 func (dt *DateTime) FormatTimestamp() string {
-	return dt.UTC().Format(DateTimeFormat)
+	if DateTimeFormat != "" {
+		return dt.UTC().Format(DateTimeFormat)
+	}
+	return dt.UTC().Format(DefaultTimeFormat)
+
 }
 
 func FormatTimestamp(t time.Time) string {
-	return t.UTC().Format(DateTimeFormat)
+	if DateTimeFormat != "" {
+		return t.UTC().Format(DateTimeFormat)
+	}
+	return t.UTC().Format(DefaultTimeFormat)
 }
 
 // DateTime Validation

--- a/ocpp1.6/types/datetime_test.go
+++ b/ocpp1.6/types/datetime_test.go
@@ -1,0 +1,21 @@
+package types
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+type TestDateTime struct {
+	Timestamp DateTime `json:"timestamp"`
+}
+
+func TestDateTime_UnmarshalJSON(t *testing.T) {
+	jsonMessage := json.RawMessage(`{"timestamp": "8/8/1965 13:00:00 PM"}`)
+	var data TestDateTime
+	json.Unmarshal(jsonMessage, &data)
+	date := time.Date(1965, 8, 8, 13, 0, 0, 0, time.UTC)
+	assert.True(t, data.Timestamp.Equal(date))
+
+}


### PR DESCRIPTION
I dot this pull request because in reality when you write an OCPP central system server, you may have more than one brand of chargepoint on the same central system. 
For example in my company, we have 4 brands of chargepoint connect on the server.
And in fact chargepoint's brands do not meet the standards DateTime.
