### PR TITLE
Auto-reconnection support in websockets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ stages:
 jobs:
   include:
     - stage: test
+      before_install:
+        - wget -O toxiproxy-2.1.4.deb https://github.com/Shopify/toxiproxy/releases/download/v2.1.4/toxiproxy_2.1.4_amd64.deb
+        - sudo dpkg -i toxiproxy-2.1.4.deb
+        - sudo service toxiproxy start
       script:
         - go build ./...
         - go get golang.org/x/tools/cmd/cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
       before_install:
         - wget -O toxiproxy-2.1.4.deb https://github.com/Shopify/toxiproxy/releases/download/v2.1.4/toxiproxy_2.1.4_amd64.deb
         - sudo dpkg -i toxiproxy-2.1.4.deb
-        - cp ws/toxiproxy.service /lib/systemd/system/
+        - sudo cp ws/toxiproxy.service /lib/systemd/system/
         - sudo systemctl toxiproxy start
       script:
         - go build ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         - wget -O toxiproxy-2.1.4.deb https://github.com/Shopify/toxiproxy/releases/download/v2.1.4/toxiproxy_2.1.4_amd64.deb
         - sudo dpkg -i toxiproxy-2.1.4.deb
         - sudo cp ws/toxiproxy.service /lib/systemd/system/
-        - sudo systemctl toxiproxy start
+        - sudo systemctl start toxiproxy
       script:
         - go build ./...
         - go get golang.org/x/tools/cmd/cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ jobs:
       before_install:
         - wget -O toxiproxy-2.1.4.deb https://github.com/Shopify/toxiproxy/releases/download/v2.1.4/toxiproxy_2.1.4_amd64.deb
         - sudo dpkg -i toxiproxy-2.1.4.deb
-        - sudo service toxiproxy start
+        - cp ws/toxiproxy.service /lib/systemd/system/
+        - sudo systemctl toxiproxy start
       script:
         - go build ./...
         - go get golang.org/x/tools/cmd/cover

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/lorenzodonini/ocpp-go
 go 1.12
 
 require (
+	github.com/Shopify/toxiproxy v2.1.4+incompatible
 	github.com/go-playground/locales v0.12.1 // indirect
 	github.com/go-playground/universal-translator v0.16.0 // indirect
 	github.com/gorilla/mux v1.7.3
@@ -15,4 +16,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.30.0
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
+github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -41,5 +43,7 @@ gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXa
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.30.0 h1:Wk0Z37oBmKj9/n+tPyBHZmeL19LaCoK3Qq48VwYENss=
 gopkg.in/go-playground/validator.v9 v9.30.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/ws/network_test.go
+++ b/ws/network_test.go
@@ -1,0 +1,325 @@
+package ws
+
+import (
+	"errors"
+	"fmt"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/Shopify/toxiproxy/client"
+)
+
+type NetworkTestSuite struct {
+	suite.Suite
+	proxy     *toxiproxy.Proxy
+	proxyPort int
+}
+
+func (s *NetworkTestSuite) SetupSuite() {
+	client := toxiproxy.NewClient("localhost:8474")
+	s.proxyPort = 8886
+	// Proxy listens on 8886 and upstreams to 8887 (where ocpp server is actually listening)
+	oldProxy, err := client.Proxy("ocpp")
+	if oldProxy != nil {
+		oldProxy.Delete()
+	}
+	p, err := client.CreateProxy("ocpp", "localhost:8886", fmt.Sprintf("localhost:%v", serverPort))
+	require.NoError(s.T(), err)
+	s.proxy = p
+}
+
+func (s *NetworkTestSuite) TearDownSuite() {
+	s.proxy.Delete()
+}
+
+func (s *NetworkTestSuite) TearDownTest() {
+	// Reset websocket timeouts
+	pongWait = defaultPongWait
+	pingWait = defaultPingWait
+	pingPeriod = defaultPingPeriod
+	autoReconnectDelay = defaultAutoReconnectDelay
+	maxReconnectionDelay = defaultMaxReconnectionDelay
+}
+
+func (s *NetworkTestSuite) TestClientConnectionFailed() {
+	t := s.T()
+	var wsServer *Server
+	wsServer = NewWebsocketServer(t, nil)
+	wsServer.SetNewClientHandler(func(ws Channel) {
+		assert.Fail(t, "should not accept new clients")
+	})
+	go wsServer.Start(serverPort, serverPath)
+	time.Sleep(1 * time.Second)
+
+	// Test client
+	wsClient := NewWebsocketClient(t, nil)
+	host := s.proxy.Listen
+	u := url.URL{Scheme: "ws", Host: host, Path: testPath}
+
+	// Disable network
+	_ = s.proxy.Disable()
+	defer s.proxy.Enable()
+	// Attempt connection
+	err := wsClient.Start(u.String())
+	require.Error(t, err)
+	netError, ok := err.(*net.OpError)
+	require.True(t, ok)
+	require.NotNil(t, netError.Err)
+	sysError, ok := netError.Err.(*os.SyscallError)
+	require.True(t, ok)
+	assert.Equal(t, "connect", sysError.Syscall)
+	assert.Equal(t, syscall.ECONNREFUSED, sysError.Err)
+	// Cleanup
+	wsServer.Stop()
+}
+
+func (s *NetworkTestSuite) TestClientConnectionFailedTimeout() {
+	t := s.T()
+	// Set timeouts for test
+	handshakeTimeout = 2 * time.Second
+	// Setup
+	var wsServer *Server
+	wsServer = NewWebsocketServer(t, nil)
+	wsServer.SetNewClientHandler(func(ws Channel) {
+		assert.Fail(t, "should not accept new clients")
+	})
+	go wsServer.Start(serverPort, serverPath)
+	time.Sleep(1 * time.Second)
+
+	// Test client
+	wsClient := NewWebsocketClient(t, nil)
+	host := s.proxy.Listen
+	u := url.URL{Scheme: "ws", Host: host, Path: testPath}
+
+	// Add connection timeout
+	_, err := s.proxy.AddToxic("connectTimeout", "timeout", "upstream", 1, toxiproxy.Attributes{
+		"timeout": 3000, // 3 seconds
+	})
+	defer s.proxy.RemoveToxic("connectTimeout")
+	require.NoError(t, err)
+	// Attempt connection
+	err = wsClient.Start(u.String())
+	require.Error(t, err)
+	netError, ok := err.(*net.OpError)
+	require.True(t, ok)
+	require.NotNil(t, netError.Err)
+	assert.True(t, strings.Contains(netError.Error(), "timeout"))
+	assert.True(t, netError.Timeout())
+	// Cleanup
+	wsServer.Stop()
+}
+
+func (s *NetworkTestSuite) TestClientAutoReconnect() {
+	t := s.T()
+	// Set timeouts for test
+	autoReconnectDelay = 1 * time.Second
+	// Setup
+	var wsServer *Server
+	serverOnDisconnected := make(chan bool, 1)
+	clientOnDisconnected := make(chan bool, 1)
+	reconnected := make(chan bool, 1)
+	wsServer = NewWebsocketServer(t, nil)
+	wsServer.SetNewClientHandler(func(ws Channel) {
+		assert.NotNil(t, ws)
+		conn := wsServer.connections[ws.GetID()]
+		assert.NotNil(t, conn)
+		// Simulate connection closed as soon client is connected
+		err := conn.connection.Close()
+		assert.Nil(t, err)
+	})
+	wsServer.SetDisconnectedClientHandler(func(ws Channel) {
+		serverOnDisconnected <- true
+	})
+	go wsServer.Start(serverPort, serverPath)
+	time.Sleep(1 * time.Second)
+
+	// Test bench
+	wsClient := NewWebsocketClient(t, nil)
+	wsClient.SetDisconnectedHandler(func(err error) {
+		assert.NotNil(t, err)
+		closeError, ok := err.(*websocket.CloseError)
+		require.True(t, ok)
+		assert.Equal(t, websocket.CloseAbnormalClosure, closeError.Code)
+		assert.False(t, wsClient.IsConnected())
+		clientOnDisconnected <- true
+	})
+	wsClient.SetReconnectedHandler(func() {
+		reconnected <- true
+	})
+	// Connect client
+	host := s.proxy.Listen
+	u := url.URL{Scheme: "ws", Host: host, Path: testPath}
+	err := wsClient.Start(u.String())
+	require.Nil(t, err)
+	result := <-serverOnDisconnected
+	require.True(t, result)
+	result = <-clientOnDisconnected
+	require.True(t, result)
+	start := time.Now()
+	// Wait for reconnection
+	result = <-reconnected
+	elapsed := time.Since(start)
+	assert.True(t, result)
+	assert.True(t, wsClient.IsConnected())
+	assert.True(t, elapsed >= autoReconnectDelay)
+	// Cleanup
+	wsClient.Stop()
+	wsServer.Stop()
+}
+
+func (s *NetworkTestSuite) TestClientPongTimeout() {
+	t := s.T()
+	// Set timeouts for test
+	// Will attempt to send ping after 1 second, and server expects ping within 1.4 seconds
+	// Server will close connection
+	pongWait = 2 * time.Second
+	pingWait = (pongWait * 7) / 10
+	pingPeriod = (pongWait * 5) / 10
+	autoReconnectDelay = 1 * time.Second
+	// Setup
+	var wsServer *Server
+	serverOnDisconnected := make(chan bool, 1)
+	clientOnDisconnected := make(chan bool, 1)
+	reconnected := make(chan bool, 1)
+	wsServer = NewWebsocketServer(t, nil)
+	wsServer.SetNewClientHandler(func(ws Channel) {
+		assert.NotNil(t, ws)
+	})
+	wsServer.SetDisconnectedClientHandler(func(ws Channel) {
+		serverOnDisconnected <- true
+	})
+	wsServer.SetMessageHandler(func(ws Channel, data []byte) error {
+		assert.Fail(t, "unexpected message received")
+		return errors.New("unexpected message received")
+	})
+	go wsServer.Start(serverPort, serverPath)
+	time.Sleep(1 * time.Second)
+
+	// Test client
+	wsClient := NewWebsocketClient(t, nil)
+	wsClient.SetDisconnectedHandler(func(err error) {
+		defer func() {
+			clientOnDisconnected <- true
+		}()
+		require.Error(t, err)
+		closeError, ok := err.(*websocket.CloseError)
+		require.True(t, ok)
+		assert.Equal(t, websocket.CloseAbnormalClosure, closeError.Code)
+	})
+	wsClient.SetReconnectedHandler(func() {
+		reconnected <- true
+	})
+	host := s.proxy.Listen
+	u := url.URL{Scheme: "ws", Host: host, Path: testPath}
+
+	// Attempt connection
+	err := wsClient.Start(u.String())
+	require.NoError(t, err)
+	// Slow upstream network -> ping won't get through and server-side close will be triggered
+	_, err = s.proxy.AddToxic("readTimeout", "timeout", "upstream", 1, toxiproxy.Attributes{
+		"timeout": 5000, // 5 seconds
+	})
+	require.NoError(t, err)
+	// Attempt to send message
+	require.NoError(t, err)
+	result := <-clientOnDisconnected
+	require.True(t, result)
+	result = <-serverOnDisconnected
+	require.True(t, result)
+	// Reconnect time starts
+	s.proxy.RemoveToxic("readTimeout")
+	startTimeout := time.Now()
+	result = <-reconnected
+	require.True(t, result)
+	elapsed := time.Since(startTimeout)
+	assert.GreaterOrEqual(t, elapsed.Milliseconds(), autoReconnectDelay.Milliseconds())
+	// Cleanup
+	wsClient.Stop()
+	wsServer.Stop()
+}
+
+func (s *NetworkTestSuite) TestClientReadTimeout() {
+	t := s.T()
+	// Set timeouts for test
+	pongWait = 2 * time.Second
+	pingWait = pongWait
+	pingPeriod = (pongWait * 8) / 10
+	autoReconnectDelay = 1 * time.Second
+	// Setup
+	var wsServer *Server
+	serverOnDisconnected := make(chan bool, 1)
+	clientOnDisconnected := make(chan bool, 1)
+	reconnected := make(chan bool, 1)
+	wsServer = NewWebsocketServer(t, nil)
+	wsServer.SetNewClientHandler(func(ws Channel) {
+		assert.NotNil(t, ws)
+	})
+	wsServer.SetDisconnectedClientHandler(func(ws Channel) {
+		serverOnDisconnected <- true
+	})
+	wsServer.SetMessageHandler(func(ws Channel, data []byte) error {
+		assert.Fail(t, "unexpected message received")
+		return errors.New("unexpected message received")
+	})
+	go wsServer.Start(serverPort, serverPath)
+	time.Sleep(1 * time.Second)
+
+	// Test client
+	wsClient := NewWebsocketClient(t, nil)
+	wsClient.SetDisconnectedHandler(func(err error) {
+		defer func() {
+			clientOnDisconnected <- true
+		}()
+		require.Error(t, err)
+		errMsg := err.Error()
+		c := strings.Contains(errMsg, "timeout")
+		if !c {
+			fmt.Println(errMsg)
+		}
+		//TODO: not deterministic. Sometimes abnormal closure, sometimes timeout
+		assert.True(t, c)
+	})
+	wsClient.SetReconnectedHandler(func() {
+		reconnected <- true
+	})
+	host := s.proxy.Listen
+	u := url.URL{Scheme: "ws", Host: host, Path: testPath}
+
+	// Attempt connection
+	err := wsClient.Start(u.String())
+	require.NoError(t, err)
+	// Slow down network. Ping will be received but pong won't go through
+	_, err = s.proxy.AddToxic("writeTimeout", "timeout", "downstream", 1, toxiproxy.Attributes{
+		"timeout": 5000, // 5 seconds
+	})
+	require.NoError(t, err)
+	// Attempt to send message
+	require.NoError(t, err)
+	result := <-serverOnDisconnected
+	require.True(t, result)
+	result = <-clientOnDisconnected
+	require.True(t, result)
+	// Reconnect time starts
+	s.proxy.RemoveToxic("writeTimeout")
+	startTimeout := time.Now()
+	result = <-reconnected
+	require.True(t, result)
+	elapsed := time.Since(startTimeout)
+	assert.GreaterOrEqual(t, elapsed.Milliseconds(), autoReconnectDelay.Milliseconds())
+	// Cleanup
+	wsClient.Stop()
+	wsServer.Stop()
+}
+
+func TestNetworkErrors(t *testing.T) {
+	suite.Run(t, new(NetworkTestSuite))
+}

--- a/ws/network_test.go
+++ b/ws/network_test.go
@@ -120,7 +120,7 @@ func (s *NetworkTestSuite) TestClientConnectionFailedTimeout() {
 func (s *NetworkTestSuite) TestClientAutoReconnect() {
 	t := s.T()
 	// Set timeouts for test
-	s.client.timeoutConfig.AutoReconnectDelay = 1 * time.Second
+	s.client.timeoutConfig.ReconnectBackoff = 1 * time.Second
 	// Setup
 	serverOnDisconnected := make(chan bool, 1)
 	clientOnDisconnected := make(chan bool, 1)
@@ -167,7 +167,7 @@ func (s *NetworkTestSuite) TestClientAutoReconnect() {
 	elapsed := time.Since(start)
 	assert.True(t, result)
 	assert.True(t, s.client.IsConnected())
-	assert.True(t, elapsed >= s.client.timeoutConfig.AutoReconnectDelay)
+	assert.True(t, elapsed >= s.client.timeoutConfig.ReconnectBackoff)
 	// Cleanup
 	s.client.Stop()
 	s.server.Stop()
@@ -180,7 +180,7 @@ func (s *NetworkTestSuite) TestClientPongTimeout() {
 	// Server will close connection
 	s.client.timeoutConfig.PongWait = 2 * time.Second
 	s.client.timeoutConfig.PingPeriod = (s.client.timeoutConfig.PongWait * 5) / 10
-	s.client.timeoutConfig.AutoReconnectDelay = 1 * time.Second
+	s.client.timeoutConfig.ReconnectBackoff = 1 * time.Second
 	s.server.timeoutConfig.PingWait = (s.client.timeoutConfig.PongWait * 7) / 10
 	// Setup
 	serverOnDisconnected := make(chan bool, 1)
@@ -235,7 +235,7 @@ func (s *NetworkTestSuite) TestClientPongTimeout() {
 	result = <-reconnected
 	require.True(t, result)
 	elapsed := time.Since(startTimeout)
-	assert.GreaterOrEqual(t, elapsed.Milliseconds(), s.client.timeoutConfig.AutoReconnectDelay.Milliseconds())
+	assert.GreaterOrEqual(t, elapsed.Milliseconds(), s.client.timeoutConfig.ReconnectBackoff.Milliseconds())
 	// Cleanup
 	s.client.Stop()
 	s.server.Stop()
@@ -246,7 +246,7 @@ func (s *NetworkTestSuite) TestClientReadTimeout() {
 	// Set timeouts for test
 	s.client.timeoutConfig.PongWait = 2 * time.Second
 	s.client.timeoutConfig.PingPeriod = (s.client.timeoutConfig.PongWait * 7) / 10
-	s.client.timeoutConfig.AutoReconnectDelay = 1 * time.Second
+	s.client.timeoutConfig.ReconnectBackoff = 1 * time.Second
 	s.server.timeoutConfig.PingWait = s.client.timeoutConfig.PongWait
 	// Setup
 	serverOnDisconnected := make(chan bool, 1)
@@ -305,7 +305,7 @@ func (s *NetworkTestSuite) TestClientReadTimeout() {
 	result = <-reconnected
 	require.True(t, result)
 	elapsed := time.Since(startTimeout)
-	assert.GreaterOrEqual(t, elapsed.Milliseconds(), s.client.timeoutConfig.AutoReconnectDelay.Milliseconds())
+	assert.GreaterOrEqual(t, elapsed.Milliseconds(), s.client.timeoutConfig.ReconnectBackoff.Milliseconds())
 	// Cleanup
 	s.client.Stop()
 	s.server.Stop()

--- a/ws/network_test.go
+++ b/ws/network_test.go
@@ -49,7 +49,6 @@ func (s *NetworkTestSuite) SetupTest() {
 }
 
 func (s *NetworkTestSuite) TearDownTest() {
-	// Reset websocket timeouts
 	s.server = nil
 	s.client = nil
 }
@@ -61,7 +60,7 @@ func (s *NetworkTestSuite) TestClientConnectionFailed() {
 		assert.Fail(t, "should not accept new clients")
 	})
 	go s.server.Start(serverPort, serverPath)
-	time.Sleep(1 * time.Second)
+	time.Sleep(500 * time.Millisecond)
 
 	// Test client
 	host := s.proxy.Listen
@@ -94,7 +93,7 @@ func (s *NetworkTestSuite) TestClientConnectionFailedTimeout() {
 		assert.Fail(t, "should not accept new clients")
 	})
 	go s.server.Start(serverPort, serverPath)
-	time.Sleep(1 * time.Second)
+	time.Sleep(500 * time.Millisecond)
 
 	// Test client
 	host := s.proxy.Listen
@@ -139,7 +138,7 @@ func (s *NetworkTestSuite) TestClientAutoReconnect() {
 		serverOnDisconnected <- true
 	})
 	go s.server.Start(serverPort, serverPath)
-	time.Sleep(1 * time.Second)
+	time.Sleep(500 * time.Millisecond)
 
 	// Test bench
 	s.client.SetDisconnectedHandler(func(err error) {
@@ -198,7 +197,7 @@ func (s *NetworkTestSuite) TestClientPongTimeout() {
 		return errors.New("unexpected message received")
 	})
 	go s.server.Start(serverPort, serverPath)
-	time.Sleep(1 * time.Second)
+	time.Sleep(500 * time.Millisecond)
 
 	// Test client
 	s.client.SetDisconnectedHandler(func(err error) {
@@ -264,7 +263,7 @@ func (s *NetworkTestSuite) TestClientReadTimeout() {
 		return errors.New("unexpected message received")
 	})
 	go s.server.Start(serverPort, serverPath)
-	time.Sleep(1 * time.Second)
+	time.Sleep(500 * time.Millisecond)
 
 	// Test client
 	s.client.SetDisconnectedHandler(func(err error) {

--- a/ws/toxiproxy.service
+++ b/ws/toxiproxy.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=TCP proxy to simulate network and system conditions
+After=network-online.target firewalld.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+Environment=HOST=localhost
+Environment=PORT=8474
+ExecStart=/usr/bin/toxiproxy-server -port $PORT -host $HOST
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -63,10 +63,12 @@ func NewServerTimeoutConfig() ServerTimeoutConfig {
 // To set a custom configuration, refer to the client's SetTimeoutConfig method.
 // If no configuration is passed, a default configuration is generated via the NewClientTimeoutConfig function.
 type ClientTimeoutConfig struct {
-	WriteWait        time.Duration
-	HandshakeTimeout time.Duration
-	PongWait         time.Duration
-	PingPeriod       time.Duration
+	WriteWait             time.Duration
+	HandshakeTimeout      time.Duration
+	PongWait              time.Duration
+	PingPeriod            time.Duration
+	AutoReconnectDelay    time.Duration
+	MaxAutoReconnectDelay time.Duration
 }
 
 // NewClientTimeoutConfig creates a default timeout configuration for a websocket endpoint.
@@ -74,10 +76,12 @@ type ClientTimeoutConfig struct {
 // You may change fields arbitrarily and pass the struct to a SetTimeoutConfig method.
 func NewClientTimeoutConfig() ClientTimeoutConfig {
 	return ClientTimeoutConfig{
-		WriteWait:        defaultWriteWait,
-		HandshakeTimeout: defaultHandshakeTimeout,
-		PongWait:         defaultPongWait,
-		PingPeriod:       defaultPingPeriod,
+		WriteWait:             defaultWriteWait,
+		HandshakeTimeout:      defaultHandshakeTimeout,
+		PongWait:              defaultPongWait,
+		PingPeriod:            defaultPingPeriod,
+		AutoReconnectDelay:    defaultAutoReconnectDelay,
+		MaxAutoReconnectDelay: defaultMaxReconnectionDelay,
 	}
 }
 

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -34,10 +34,10 @@ const (
 	defaultHandshakeTimeout = 30 * time.Second
 	// Default sub-protocol to send to peer upon connection.
 	defaultSubProtocol = "ocpp1.6"
-	// The base delay to be used for automatic reconnection. Will increase exponentially up to maxReconnectionDelay.
-	defaultAutoReconnectDelay = 5 * time.Second
+	// The base delay to be used for automatic reconnection. Will double for every attempt up to maxReconnectionDelay.
+	defaultReconnectBackoff = 5 * time.Second
 	// Default maximum reconnection delay for websockets
-	defaultMaxReconnectionDelay = 2 * time.Minute
+	defaultReconnectMaxBackoff = 2 * time.Minute
 )
 
 // Config contains optional configuration parameters for a websocket server.
@@ -63,12 +63,12 @@ func NewServerTimeoutConfig() ServerTimeoutConfig {
 // To set a custom configuration, refer to the client's SetTimeoutConfig method.
 // If no configuration is passed, a default configuration is generated via the NewClientTimeoutConfig function.
 type ClientTimeoutConfig struct {
-	WriteWait             time.Duration
-	HandshakeTimeout      time.Duration
-	PongWait              time.Duration
-	PingPeriod            time.Duration
-	AutoReconnectDelay    time.Duration
-	MaxAutoReconnectDelay time.Duration
+	WriteWait           time.Duration
+	HandshakeTimeout    time.Duration
+	PongWait            time.Duration
+	PingPeriod          time.Duration
+	ReconnectBackoff    time.Duration
+	ReconnectMaxBackoff time.Duration
 }
 
 // NewClientTimeoutConfig creates a default timeout configuration for a websocket endpoint.
@@ -76,12 +76,12 @@ type ClientTimeoutConfig struct {
 // You may change fields arbitrarily and pass the struct to a SetTimeoutConfig method.
 func NewClientTimeoutConfig() ClientTimeoutConfig {
 	return ClientTimeoutConfig{
-		WriteWait:             defaultWriteWait,
-		HandshakeTimeout:      defaultHandshakeTimeout,
-		PongWait:              defaultPongWait,
-		PingPeriod:            defaultPingPeriod,
-		AutoReconnectDelay:    defaultAutoReconnectDelay,
-		MaxAutoReconnectDelay: defaultMaxReconnectionDelay,
+		WriteWait:           defaultWriteWait,
+		HandshakeTimeout:    defaultHandshakeTimeout,
+		PongWait:            defaultPongWait,
+		PingPeriod:          defaultPingPeriod,
+		ReconnectBackoff:    defaultReconnectBackoff,
+		ReconnectMaxBackoff: defaultReconnectMaxBackoff,
 	}
 }
 
@@ -98,7 +98,7 @@ type WebSocket struct {
 	connection  *websocket.Conn
 	id          string
 	outQueue    chan []byte
-	closeSignal chan error
+	closeSignal chan error // used by the readPump to notify the closed connection to the writePump
 	pingMessage chan []byte
 }
 
@@ -390,8 +390,7 @@ func (server *Server) readPump(ws *WebSocket) {
 	conn := ws.connection
 	defer func() {
 		_ = conn.Close()
-		//TODO: close signal
-		//ws.closeSignal <- true
+		//TODO: close signal?
 	}()
 
 	conn.SetPingHandler(func(appData string) error {
@@ -705,7 +704,7 @@ func (client *Client) readPump() {
 }
 
 func (client *Client) handleReconnection() {
-	delay := defaultAutoReconnectDelay
+	delay := client.timeoutConfig.ReconnectBackoff
 	for {
 		// Wait before reconnecting
 		time.Sleep(delay)
@@ -719,8 +718,8 @@ func (client *Client) handleReconnection() {
 		}
 		// Re-connection failed, increase delay exponentially
 		delay *= 2
-		if delay >= defaultMaxReconnectionDelay {
-			delay = defaultMaxReconnectionDelay
+		if delay >= client.timeoutConfig.ReconnectMaxBackoff {
+			delay = client.timeoutConfig.ReconnectMaxBackoff
 		}
 	}
 }

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -33,6 +34,10 @@ const (
 	defaultHandshakeTimeout = 30 * time.Second
 	// Default sub-protocol to send to peer upon connection.
 	defaultSubProtocol = "ocpp1.6"
+	// The base delay to be used for automatic reconnection. Will increase exponentially up to maxReconnectionDelay.
+	defaultAutoReconnectDelay = 5 * time.Second
+	// Default maximum reconnection delay for websockets
+	defaultMaxReconnectionDelay = 2 * time.Minute
 )
 
 // Config contains optional configuration parameters for a websocket server.
@@ -89,7 +94,7 @@ type WebSocket struct {
 	connection  *websocket.Conn
 	id          string
 	outQueue    chan []byte
-	closeSignal chan bool
+	closeSignal chan error
 	pingMessage chan []byte
 }
 
@@ -366,8 +371,7 @@ func (server *Server) wsHandler(w http.ResponseWriter, r *http.Request) {
 		server.error(fmt.Errorf("upgrade failed: %w", err))
 		return
 	}
-
-	ws := WebSocket{connection: conn, id: url.Path, outQueue: make(chan []byte), closeSignal: make(chan bool, 1), pingMessage: make(chan []byte, 1)}
+	ws := WebSocket{connection: conn, id: url.Path, outQueue: make(chan []byte), closeSignal: make(chan error, 1), pingMessage: make(chan []byte, 1)}
 	server.connections[url.Path] = &ws
 	// Read and write routines are started in separate goroutines and function will return immediately
 	go server.writePump(&ws)
@@ -382,7 +386,8 @@ func (server *Server) readPump(ws *WebSocket) {
 	conn := ws.connection
 	defer func() {
 		_ = conn.Close()
-		ws.closeSignal <- true
+		//TODO: close signal
+		//ws.closeSignal <- true
 	}()
 
 	conn.SetPingHandler(func(appData string) error {
@@ -447,7 +452,8 @@ func (server *Server) writePump(ws *WebSocket) {
 				return
 			}
 		case closed, ok := <-ws.closeSignal:
-			if !ok || closed {
+			if !ok || closed != nil {
+				//TODO: handle signal
 				return
 			}
 		}
@@ -509,6 +515,19 @@ type WsClient interface {
 	//
 	// This function must be called before connecting to the server, otherwise it may lead to unexpected behavior.
 	SetTimeoutConfig(config ClientTimeoutConfig)
+	// Sets a callback function for receiving notifications about an unexpected disconnection from the server.
+	// The callback is invoked even if the automatic reconnection mechanism is active.
+	//
+	// If the client was stopped using the Stop function, the callback will NOT be invoked.
+	SetDisconnectedHandler(handler func(err error))
+	// Sets a callback function for receiving notifications whenever the connection to the server is re-established.
+	// Connections are re-established automatically thanks to the auto-reconnection mechanism.
+	//
+	// If set, the DisconnectedHandler will always be invoked before the Reconnected callback is invoked.
+	SetReconnectedHandler(handler func())
+	// IsConnected Returns information about the current connection status.
+	// If the client is currently attempting to auto-reconnect to the server, the function returns false.
+	IsConnected() bool
 	// Sends a message to the server over the websocket.
 	//
 	// The data is queued and will be sent asynchronously in the background.
@@ -529,6 +548,10 @@ type Client struct {
 	dialOptions    []func(*websocket.Dialer)
 	authHeader     http.Header
 	timeoutConfig  ClientTimeoutConfig
+	connected      bool
+	onDisconnected func(err error)
+	onReconnected  func()
+	mutex          sync.Mutex
 	errC           chan error
 }
 
@@ -573,6 +596,14 @@ func (client *Client) SetTimeoutConfig(config ClientTimeoutConfig) {
 	client.timeoutConfig = config
 }
 
+func (client *Client) SetDisconnectedHandler(handler func(err error)) {
+	client.onDisconnected = handler
+}
+
+func (client *Client) SetReconnectedHandler(handler func()) {
+	client.onReconnected = handler
+}
+
 func (client *Client) AddOption(option interface{}) {
 	dialOption, ok := option.(func(*websocket.Dialer))
 	if ok {
@@ -589,10 +620,15 @@ func (client *Client) SetBasicAuth(username string, password string) {
 func (client *Client) writePump() {
 	ticker := time.NewTicker(client.timeoutConfig.PingPeriod)
 	conn := client.webSocket.connection
-	defer func() {
+	// Closure function shuts down the current connection
+	closure := func(err error) {
 		ticker.Stop()
 		_ = conn.Close()
-	}()
+		client.setConnected(false)
+		if client.onDisconnected != nil && err != nil {
+			client.onDisconnected(err)
+		}
+	}
 
 	for {
 		select {
@@ -604,21 +640,32 @@ func (client *Client) writePump() {
 				if err != nil {
 					client.error(fmt.Errorf("close failed: %w", err))
 				}
+				// Disconnected by user command. Not calling auto-reconnect.
+				// Passing nil will also not call onDisconnected
+				closure(nil)
 				return
 			}
 			err := conn.WriteMessage(websocket.TextMessage, data)
 			if err != nil {
 				client.error(fmt.Errorf("write failed: %w", err))
+				closure(err)
+				client.handleReconnection()
 				return
 			}
 		case <-ticker.C:
+			// Send periodic ping
 			_ = conn.SetWriteDeadline(time.Now().Add(client.timeoutConfig.WriteWait))
 			if err := conn.WriteMessage(websocket.PingMessage, []byte{}); err != nil {
 				client.error(fmt.Errorf("write failed: %w", err))
+				closure(err)
+				client.handleReconnection()
 				return
 			}
 		case closed, ok := <-client.webSocket.closeSignal:
-			if !ok || closed {
+			// Read pump sent a closeSignal (i.e. a message couldn't be read in that moment)
+			if !ok || closed != nil {
+				closure(closed)
+				client.handleReconnection()
 				return
 			}
 		}
@@ -627,10 +674,6 @@ func (client *Client) writePump() {
 
 func (client *Client) readPump() {
 	conn := client.webSocket.connection
-	defer func() {
-		_ = conn.Close()
-		client.webSocket.closeSignal <- true
-	}()
 	_ = conn.SetReadDeadline(time.Now().Add(client.timeoutConfig.PongWait))
 	conn.SetPongHandler(func(string) error {
 		return conn.SetReadDeadline(time.Now().Add(client.timeoutConfig.PongWait))
@@ -641,12 +684,15 @@ func (client *Client) readPump() {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure, websocket.CloseNormalClosure) {
 				client.error(fmt.Errorf("read failed: %w", err))
 			}
+			// Notify writePump of error. Disconnection will be handled there
+			client.webSocket.closeSignal <- err
 			return
 		}
 
 		if client.messageHandler != nil {
 			err = client.messageHandler(message)
 			if err != nil {
+				// TODO: Handle?
 				client.error(fmt.Errorf("handle failed: %w", err))
 				continue
 			}
@@ -654,7 +700,43 @@ func (client *Client) readPump() {
 	}
 }
 
+func (client *Client) handleReconnection() {
+	delay := defaultAutoReconnectDelay
+	for {
+		// Wait before reconnecting
+		time.Sleep(delay)
+		err := client.Start(client.webSocket.id)
+		if err == nil {
+			// Re-connection was successful
+			if client.onReconnected != nil {
+				client.onReconnected()
+			}
+			return
+		}
+		// Re-connection failed, increase delay exponentially
+		delay *= 2
+		if delay >= defaultMaxReconnectionDelay {
+			delay = defaultMaxReconnectionDelay
+		}
+	}
+}
+
+func (client *Client) setConnected(connected bool) {
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
+	client.connected = connected
+}
+
+func (client *Client) IsConnected() bool {
+	client.mutex.Lock()
+	defer client.mutex.Unlock()
+	return client.connected
+}
+
 func (client *Client) Write(data []byte) error {
+	if !client.IsConnected() {
+		return errors.New("client is currently not connected, cannot send data")
+	}
 	client.webSocket.outQueue <- data
 	return nil
 }
@@ -685,7 +767,8 @@ func (client *Client) Start(url string) error {
 		return err
 	}
 
-	client.webSocket = WebSocket{connection: ws, id: url, outQueue: make(chan []byte), closeSignal: make(chan bool, 1)}
+	client.webSocket = WebSocket{connection: ws, id: url, outQueue: make(chan []byte), closeSignal: make(chan error, 1)}
+	client.setConnected(true)
 	//Start reader and write routine
 	go client.writePump()
 	go client.readPump()

--- a/ws/websocket_test.go
+++ b/ws/websocket_test.go
@@ -65,6 +65,17 @@ func NewWebsocketClient(t *testing.T, onMessage func(data []byte) ([]byte, error
 	return wsClient
 }
 
+func TestWebsocketSetConnected(t *testing.T) {
+	wsClient := NewWebsocketClient(t, func(data []byte) ([]byte, error) {
+		return nil, nil
+	})
+	assert.False(t, wsClient.IsConnected())
+	wsClient.setConnected(true)
+	assert.True(t, wsClient.IsConnected())
+	wsClient.setConnected(false)
+	assert.False(t, wsClient.IsConnected())
+}
+
 func TestWebsocketEcho(t *testing.T) {
 	message := []byte("Hello WebSocket!")
 	var wsServer *Server
@@ -99,6 +110,7 @@ func TestWebsocketEcho(t *testing.T) {
 	}()
 	err := wsClient.Start(u.String())
 	assert.Nil(t, err)
+	assert.True(t, wsClient.IsConnected())
 	result := <-done
 	assert.True(t, result)
 	// Cleanup


### PR DESCRIPTION
Implements auto-reconnect behavior for client websockets, as requested in https://github.com/lorenzodonini/ocpp-go/issues/38.

### Implementation details

- Client auto-reconnect behavior is triggered by default upon:
  - timeouts
  - connection errors
- User-initiated disconnects will NOT trigger auto-reconnection
- Auto-reconnect delays may be set via `ClientTimeoutConfig`
- `SetDisconnectedHandler` and `SetReconnectedHandler` allow to register handlers for being notified of the respective events

### Known Issues

This new feature only affects the `websocket` package and is not yet fully integrated by the ocpp-j package.

The OCPP library will work as before, but upon reconnection, no retransmissions are triggered and no pending requests are cancelled. This will be tackled in a future PR.

### Connection tests

Tests for network errors were added, to simulate connection drops. 

[Toxiproxy](https://github.com/Shopify/toxiproxy) is being used as a service for this purpose.
