### PR TITLE
Ocppj reconnect support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,4 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.30.0
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -43,7 +43,5 @@ gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXa
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.30.0 h1:Wk0Z37oBmKj9/n+tPyBHZmeL19LaCoK3Qq48VwYENss=
 gopkg.in/go-playground/validator.v9 v9.30.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/ocpp/ocpp.go
+++ b/ocpp/ocpp.go
@@ -4,8 +4,9 @@ package ocpp
 
 import (
 	"fmt"
-	errors2 "github.com/pkg/errors"
 	"reflect"
+
+	"github.com/pkg/errors"
 )
 
 // Feature represents a single functionality, associated to a unique name.
@@ -92,7 +93,7 @@ func (p *Profile) GetFeature(name string) Feature {
 func (p *Profile) ParseRequest(featureName string, rawRequest interface{}, requestParser func(raw interface{}, requestType reflect.Type) (Request, error)) (Request, error) {
 	feature, ok := p.Features[featureName]
 	if !ok {
-		return nil, errors2.Errorf("Feature %s not found", featureName)
+		return nil, errors.Errorf("Feature %s not found", featureName)
 	}
 	requestType := feature.GetRequestType()
 	return requestParser(rawRequest, requestType)
@@ -103,7 +104,7 @@ func (p *Profile) ParseRequest(featureName string, rawRequest interface{}, reque
 func (p *Profile) ParseResponse(featureName string, rawResponse interface{}, responseParser func(raw interface{}, responseType reflect.Type) (Response, error)) (Response, error) {
 	feature, ok := p.Features[featureName]
 	if !ok {
-		return nil, errors2.Errorf("Feature %s not found", featureName)
+		return nil, errors.Errorf("Feature %s not found", featureName)
 	}
 	responseType := feature.GetResponseType()
 	return responseParser(rawResponse, responseType)

--- a/ocpp/types.go
+++ b/ocpp/types.go
@@ -1,0 +1,24 @@
+package ocpp
+
+// Logger is the adapter interface that needs to be implemented, if the library should internally print logs.
+//
+// This allows to hook up your logger of choice.
+type Logger interface {
+	Debug(args ...interface{})
+	Debugf(format string, args ...interface{})
+	Info(args ...interface{})
+	Infof(format string, args ...interface{})
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+}
+
+// VoidLogger is an empty implementation of the Logger interface, which doesn't actually process any logs.
+// It may be used as a dummy implementation, if no logs should be visible.
+type VoidLogger struct{}
+
+func (l *VoidLogger) Debug(args ...interface{})                 {}
+func (l *VoidLogger) Debugf(format string, args ...interface{}) {}
+func (l *VoidLogger) Info(args ...interface{})                  {}
+func (l *VoidLogger) Infof(format string, args ...interface{})  {}
+func (l *VoidLogger) Error(args ...interface{})                 {}
+func (l *VoidLogger) Errorf(format string, args ...interface{}) {}

--- a/ocpp1.6_test/ocpp16_test.go
+++ b/ocpp1.6_test/ocpp16_test.go
@@ -79,7 +79,10 @@ func (websocketServer *MockWebsocketServer) NewClient(websocketId string, client
 type MockWebsocketClient struct {
 	mock.Mock
 	ws.WsClient
-	MessageHandler func(data []byte) error
+	MessageHandler      func(data []byte) error
+	ReconnectedHandler  func()
+	DisconnectedHandler func(err error)
+	errC                chan error
 }
 
 func (websocketClient *MockWebsocketClient) Start(url string) error {
@@ -95,12 +98,33 @@ func (websocketClient *MockWebsocketClient) SetMessageHandler(handler func(data 
 	websocketClient.MessageHandler = handler
 }
 
+func (websocketClient *MockWebsocketClient) SetReconnectedHandler(handler func()) {
+	websocketClient.ReconnectedHandler = handler
+}
+
+func (websocketClient *MockWebsocketClient) SetDisconnectedHandler(handler func(err error)) {
+	websocketClient.DisconnectedHandler = handler
+}
+
 func (websocketClient *MockWebsocketClient) Write(data []byte) error {
 	args := websocketClient.MethodCalled("Write", data)
 	return args.Error(0)
 }
 
 func (websocketClient *MockWebsocketClient) AddOption(option interface{}) {
+}
+
+func (websocketClient *MockWebsocketClient) SetBasicAuth(username string, password string) {
+}
+
+func (websocketClient *MockWebsocketClient) SetTimeoutConfig(config ws.ClientTimeoutConfig) {
+}
+
+func (websocketClient *MockWebsocketClient) Errors() <-chan error {
+	if websocketClient.errC == nil {
+		websocketClient.errC = make(chan error, 1)
+	}
+	return websocketClient.errC
 }
 
 // Default queue capacity

--- a/ocpp2.0_test/ocpp2_test.go
+++ b/ocpp2.0_test/ocpp2_test.go
@@ -93,7 +93,10 @@ func (websocketServer *MockWebsocketServer) NewClient(websocketId string, client
 type MockWebsocketClient struct {
 	mock.Mock
 	ws.WsClient
-	MessageHandler func(data []byte) error
+	MessageHandler      func(data []byte) error
+	ReconnectedHandler  func()
+	DisconnectedHandler func(err error)
+	errC                chan error
 }
 
 func (websocketClient *MockWebsocketClient) Start(url string) error {
@@ -109,12 +112,33 @@ func (websocketClient *MockWebsocketClient) SetMessageHandler(handler func(data 
 	websocketClient.MessageHandler = handler
 }
 
+func (websocketClient *MockWebsocketClient) SetReconnectedHandler(handler func()) {
+	websocketClient.ReconnectedHandler = handler
+}
+
+func (websocketClient *MockWebsocketClient) SetDisconnectedHandler(handler func(err error)) {
+	websocketClient.DisconnectedHandler = handler
+}
+
 func (websocketClient *MockWebsocketClient) Write(data []byte) error {
 	args := websocketClient.MethodCalled("Write", data)
 	return args.Error(0)
 }
 
 func (websocketClient *MockWebsocketClient) AddOption(option interface{}) {
+}
+
+func (websocketClient *MockWebsocketClient) SetBasicAuth(username string, password string) {
+}
+
+func (websocketClient *MockWebsocketClient) SetTimeoutConfig(config ws.ClientTimeoutConfig) {
+}
+
+func (websocketClient *MockWebsocketClient) Errors() <-chan error {
+	if websocketClient.errC == nil {
+		websocketClient.errC = make(chan error, 1)
+	}
+	return websocketClient.errC
 }
 
 // Default queue capacity

--- a/ocppj/central_system_test.go
+++ b/ocppj/central_system_test.go
@@ -4,15 +4,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp"
 	"github.com/lorenzodonini/ocpp-go/ocppj"
 	"github.com/lorenzodonini/ocpp-go/ws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"strconv"
-	"sync"
-	"time"
 )
 
 func (suite *OcppJTestSuite) TestNewServer() {

--- a/ocppj/charge_point_test.go
+++ b/ocppj/charge_point_test.go
@@ -487,10 +487,6 @@ func (suite *OcppJTestSuite) TestClientDisconnected() {
 			}
 		}
 	}()
-	// Get the pending request state struct
-	state, ok := suite.clientDispatcher.(ocppj.PendingRequestState)
-	require.True(t, ok)
-	assert.False(t, state.HasPendingRequest())
 	// Send some messages
 	for i := 0; i < messagesToQueue; i++ {
 		req := newMockRequest(fmt.Sprintf("%v", i))
@@ -505,7 +501,6 @@ func (suite *OcppJTestSuite) TestClientDisconnected() {
 	// Not all messages were sent, some are still in queue
 	assert.True(t, suite.clientDispatcher.IsPaused())
 	assert.True(t, suite.clientDispatcher.IsRunning())
-	assert.True(t, state.HasPendingRequest())
 	currentSize := suite.clientRequestQueue.Size()
 	currentSent := sentMessages
 	// Wait for some more time and double-check
@@ -516,7 +511,6 @@ func (suite *OcppJTestSuite) TestClientDisconnected() {
 	assert.Equal(t, currentSent, sentMessages)
 	assert.Less(t, currentSize, messagesToQueue)
 	assert.Less(t, sentMessages, messagesToQueue)
-	assert.True(t, state.HasPendingRequest())
 }
 
 // TestClientReconnected ensures that upon reconnection, the client retains its internal state
@@ -572,7 +566,6 @@ func (suite *OcppJTestSuite) TestClientReconnected() {
 	// One message was sent, but all others are still in queue
 	time.Sleep(200 * time.Millisecond)
 	assert.True(t, suite.clientDispatcher.IsPaused())
-	assert.True(t, state.HasPendingRequest())
 	// Wait for some more time and then reconnect
 	time.Sleep(500 * time.Millisecond)
 	suite.mockClient.ReconnectedHandler()

--- a/ocppj/client.go
+++ b/ocppj/client.go
@@ -2,9 +2,9 @@ package ocppj
 
 import (
 	"fmt"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp"
 	"github.com/lorenzodonini/ocpp-go/ws"
-	log "github.com/sirupsen/logrus"
 )
 
 // The endpoint initiating the connection to an OCPP server, in an OCPP-J topology.
@@ -185,7 +185,7 @@ func (c *Client) ocppMessageHandler(data []byte) error {
 				return err2
 			}
 		}
-		log.Print(err)
+		log.Error(err)
 		return err
 	}
 	switch message.GetMessageTypeId() {

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -73,7 +73,10 @@ func (websocketServer *MockWebsocketServer) NewClient(websocketId string, client
 type MockWebsocketClient struct {
 	mock.Mock
 	ws.WsClient
-	MessageHandler func(data []byte) error
+	MessageHandler      func(data []byte) error
+	ReconnectedHandler  func()
+	DisconnectedHandler func(err error)
+	errC                chan error
 }
 
 func (websocketClient *MockWebsocketClient) Start(url string) error {
@@ -89,12 +92,39 @@ func (websocketClient *MockWebsocketClient) SetMessageHandler(handler func(data 
 	websocketClient.MessageHandler = handler
 }
 
+func (websocketClient *MockWebsocketClient) SetReconnectedHandler(handler func()) {
+	websocketClient.ReconnectedHandler = handler
+}
+
+func (websocketClient *MockWebsocketClient) SetDisconnectedHandler(handler func(err error)) {
+	websocketClient.DisconnectedHandler = handler
+}
+
+func (websocketClient *MockWebsocketClient) ThrowError(err error) {
+	if websocketClient.errC != nil {
+		websocketClient.errC <- err
+	}
+}
+
 func (websocketClient *MockWebsocketClient) Write(data []byte) error {
 	args := websocketClient.MethodCalled("Write", data)
 	return args.Error(0)
 }
 
 func (websocketClient *MockWebsocketClient) AddOption(option interface{}) {
+}
+
+func (websocketClient *MockWebsocketClient) SetBasicAuth(username string, password string) {
+}
+
+func (websocketClient *MockWebsocketClient) SetTimeoutConfig(config ws.ClientTimeoutConfig) {
+}
+
+func (websocketClient *MockWebsocketClient) Errors() <-chan error {
+	if websocketClient.errC == nil {
+		websocketClient.errC = make(chan error, 1)
+	}
+	return websocketClient.errC
 }
 
 // ---------------------- MOCK FEATURE ----------------------

--- a/ocppj/queue.go
+++ b/ocppj/queue.go
@@ -110,6 +110,8 @@ func NewFIFOClientQueue(capacity int) *FIFOClientQueue {
 //
 // An OCPP-J server may serve multiple clients at the same time, so it will need to provide a queue for each client.
 type ServerQueueMap interface {
+	// Init puts the queue map in its initial state. May be used for initial setup or clearing.
+	Init()
 	// Get retrieves the queue associated to a specific clientID.
 	// If no such element exists, the returned flag will be false.
 	Get(clientID string) (RequestQueue, bool)
@@ -133,6 +135,12 @@ type FIFOQueueMap struct {
 	data          map[string]RequestQueue
 	queueCapacity int
 	mutex         sync.Mutex
+}
+
+func (f *FIFOQueueMap) Init() {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	f.data = map[string]RequestQueue{}
 }
 
 func (f *FIFOQueueMap) Get(clientID string) (RequestQueue, bool) {

--- a/ws/network_test.go
+++ b/ws/network_test.go
@@ -317,6 +317,8 @@ func (s *NetworkTestSuite) TestClientReadTimeout() {
 	s.server.Stop()
 }
 
+//TODO: test error channel from websocket
+
 func TestNetworkErrors(t *testing.T) {
 	suite.Run(t, new(NetworkTestSuite))
 }

--- a/ws/network_test.go
+++ b/ws/network_test.go
@@ -3,10 +3,6 @@ package ws
 import (
 	"errors"
 	"fmt"
-	"github.com/gorilla/websocket"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 	"net"
 	"net/url"
 	"os"
@@ -15,7 +11,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Shopify/toxiproxy/client"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	toxiproxy "github.com/Shopify/toxiproxy/client"
 )
 
 type NetworkTestSuite struct {
@@ -129,7 +130,7 @@ func (s *NetworkTestSuite) TestClientAutoReconnect() {
 	s.server.SetNewClientHandler(func(ws Channel) {
 		assert.NotNil(t, ws)
 		conn := s.server.connections[ws.GetID()]
-		assert.NotNil(t, conn)
+		require.NotNil(t, conn)
 	})
 	s.server.SetDisconnectedClientHandler(func(ws Channel) {
 		serverOnDisconnected <- true
@@ -156,9 +157,10 @@ func (s *NetworkTestSuite) TestClientAutoReconnect() {
 	err := s.client.Start(u.String())
 	require.Nil(t, err)
 	// Close all connection from server side
+	time.Sleep(500 * time.Millisecond)
 	for _, s := range s.server.connections {
-		err := s.connection.Close()
-		assert.Nil(t, err)
+		err = s.connection.Close()
+		require.Nil(t, err)
 	}
 	// Wait for disconnect to propagate
 	result := <-serverOnDisconnected

--- a/ws/websocket_test.go
+++ b/ws/websocket_test.go
@@ -10,7 +10,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"math/big"
 	"net"
@@ -19,6 +18,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
- Introduces support for client reconnection in OCPP-J layer. Timers are used for triggering timeout of requests. Upon disconnect, timers are reset and restarted only upon reconnection.
- Removes direct log calls from ocppj package and introduces optional logger interface instead
- Fixes bugs and network tests

