### PR TITLE
Fix nil stateHandler in ocppj.NewServer()

### DIFF
--- a/ocppj/server.go
+++ b/ocppj/server.go
@@ -27,15 +27,15 @@ type Server struct {
 // You may create a simple new server by using these default values:
 //	s := ocppj.NewServer(ws.NewServer(), nil, nil)
 func NewServer(wsServer ws.WsServer, dispatcher ServerDispatcher, stateHandler PendingRequestState, profiles ...*ocpp.Profile) *Server {
-	endpoint := Endpoint{PendingRequestState: stateHandler}
-	for _, profile := range profiles {
-		endpoint.AddProfile(profile)
-	}
 	if dispatcher == nil {
 		dispatcher = NewDefaultServerDispatcher(NewFIFOQueueMap(0))
 		if stateHandler == nil {
 			stateHandler = dispatcher.(*DefaultServerDispatcher)
 		}
+	}
+	endpoint := Endpoint{PendingRequestState: stateHandler}
+	for _, profile := range profiles {
+		endpoint.AddProfile(profile)
 	}
 	if wsServer == nil {
 		wsServer = ws.NewServer()


### PR DESCRIPTION
At the moment calling `ocppj.NewServer(ws.NewServer(), nil, nil)` throws:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x8f3777]

goroutine 57 [running]:
github.com/lorenzodonini/ocpp-go/ocppj.(*Endpoint).ParseMessage(0xc0002b8a10, 0xc000136a00, 0x3, 0x4, 0x3, 0x4, 0x26)
        /home/mike/projects/grid-x/client/vendor/github.com/lorenzodonini/ocpp-go/ocppj/ocppj.go:333 +0xc77
```

on use, because `stateHandler` isn't initialized before being passed to `Endpoint{}`