### PR TITLE
Fix nil panic in dispatcher

### DIFF
--- a/ocppj/dispatcher.go
+++ b/ocppj/dispatcher.go
@@ -517,9 +517,8 @@ func (d *DefaultServerDispatcher) messagePump() {
 			}
 		case clientID = <-d.readyForDispatch:
 			// Client can now transmit again
-			rdy = true
+			clientQueue, rdy = d.queueMap.Get(clientID)
 			clientReadyMap[clientID] = rdy
-			clientQueue, _ = d.queueMap.Get(clientID)
 		}
 		// Only dispatch request if able to send and request queue isn't empty
 		if rdy && !clientQueue.IsEmpty() {

--- a/ocppj/dispatcher.go
+++ b/ocppj/dispatcher.go
@@ -518,7 +518,9 @@ func (d *DefaultServerDispatcher) messagePump() {
 		case clientID = <-d.readyForDispatch:
 			// Client can now transmit again
 			clientQueue, rdy = d.queueMap.Get(clientID)
-			clientReadyMap[clientID] = rdy
+			if rdy {
+				clientReadyMap[clientID] = rdy
+			}
 		}
 		// Only dispatch request if able to send and request queue isn't empty
 		if rdy && !clientQueue.IsEmpty() {


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x8efd41]

goroutine 54 [running]:
github.com/lorenzodonini/ocpp-go/ocppj.(*DefaultServerDispatcher).messagePump(0xc0003845f0)
        /home/mike/projects/project/client/vendor/github.com/lorenzodonini/ocpp-go/ocppj/dispatcher.go:526 +0x201
created by github.com/lorenzodonini/ocpp-go/ocppj.(*DefaultServerDispatcher).Start
        /home/mike/projects/project/client/vendor/github.com/lorenzodonini/ocpp-go/ocppj/dispatcher.go:407 +0x6c
```
I believe here `ServerQueueMap.Get` returns `nil` because `ServerQueueMap.Remove` is called on disconnect.