### PR TITLE
Concurrent charge point requests

### DIFF
--- a/example/1.6/cp/charge_point_sim.go
+++ b/example/1.6/cp/charge_point_sim.go
@@ -4,16 +4,19 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	ocpp16 "github.com/lorenzodonini/ocpp-go/ocpp1.6"
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/localauth"
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"github.com/lorenzodonini/ocpp-go/ws"
-	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/sirupsen/logrus"
+
+	ocpp16 "github.com/lorenzodonini/ocpp-go/ocpp1.6"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/localauth"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/lorenzodonini/ocpp-go/ocppj"
+	"github.com/lorenzodonini/ocpp-go/ws"
 )
 
 const (
@@ -24,6 +27,8 @@ const (
 	envVarClientCertificate    = "CLIENT_CERTIFICATE_PATH"
 	envVarClientCertificateKey = "CLIENT_CERTIFICATE_KEY_PATH"
 )
+
+var log *logrus.Logger
 
 func setupChargePoint(chargePointID string) ocpp16.ChargePoint {
 	return ocpp16.NewChargePoint(chargePointID, nil, nil)
@@ -162,6 +167,7 @@ func main() {
 	chargePoint.SetReservationHandler(handler)
 	chargePoint.SetRemoteTriggerHandler(handler)
 	chargePoint.SetSmartChargingHandler(handler)
+	ocppj.SetLogger(log)
 	// Connects to central system
 	err := chargePoint.Start(csUrl)
 	if err != nil {
@@ -176,10 +182,12 @@ func main() {
 }
 
 func init() {
-	log.SetLevel(log.InfoLevel)
+	log = logrus.New()
+	log.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+	log.SetLevel(logrus.InfoLevel)
 }
 
 // Utility functions
-func logDefault(feature string) *log.Entry {
+func logDefault(feature string) *logrus.Entry {
 	return log.WithField("message", feature)
 }

--- a/example/1.6/cp/handler.go
+++ b/example/1.6/cp/handler.go
@@ -2,6 +2,11 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
 	ocpp16 "github.com/lorenzodonini/ocpp-go/ocpp1.6"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
@@ -10,11 +15,6 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/reservation"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/smartcharging"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	log "github.com/sirupsen/logrus"
-	"io"
-	"net/http"
-	"os"
-	"time"
 )
 
 // ConnectorInfo contains some simple state about a single connector.

--- a/example/1.6/cs/central_system_sim.go
+++ b/example/1.6/cs/central_system_sim.go
@@ -3,6 +3,13 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
 	ocpp16 "github.com/lorenzodonini/ocpp-go/ocpp1.6"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
@@ -10,12 +17,8 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/remotetrigger"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/reservation"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/lorenzodonini/ocpp-go/ocppj"
 	"github.com/lorenzodonini/ocpp-go/ws"
-	log "github.com/sirupsen/logrus"
-	"io/ioutil"
-	"os"
-	"strconv"
-	"time"
 )
 
 const (
@@ -28,6 +31,7 @@ const (
 	envVarServerCertificateKey = "SERVER_CERTIFICATE_KEY_PATH"
 )
 
+var log *logrus.Logger
 var centralSystem ocpp16.CentralSystem
 
 func setupCentralSystem() ocpp16.CentralSystem {
@@ -222,6 +226,7 @@ func main() {
 		log.WithField("client", chargePointId).Info("charge point disconnected")
 		delete(handler.chargePoints, chargePointId)
 	})
+	ocppj.SetLogger(log)
 	// Run central system
 	log.Infof("starting central system on port %v", listenPort)
 	centralSystem.Start(listenPort, "/{ws}")
@@ -229,5 +234,7 @@ func main() {
 }
 
 func init() {
-	log.SetLevel(log.InfoLevel)
+	log = logrus.New()
+	log.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+	log.SetLevel(logrus.InfoLevel)
 }

--- a/example/1.6/cs/handler.go
+++ b/example/1.6/cs/handler.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 var (
@@ -179,6 +181,6 @@ func (handler *CentralSystemHandler) OnFirmwareStatusNotification(chargePointId 
 
 // Utility functions
 
-func logDefault(chargePointId string, feature string) *log.Entry {
-	return log.WithFields(log.Fields{"client": chargePointId, "message": feature})
+func logDefault(chargePointId string, feature string) *logrus.Entry {
+	return log.WithFields(logrus.Fields{"client": chargePointId, "message": feature})
 }

--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -406,7 +406,7 @@ func (cs *centralSystem) sendResponse(chargePointId string, confirmation ocpp.Re
 	}
 
 	if confirmation == nil {
-		err = fmt.Errorf("empty confirmation to request %s", requestId)
+		err = fmt.Errorf("empty confirmation to %s for request %s", chargePointId, requestId)
 		cs.error(err)
 		return
 	}

--- a/ocpp1.6/charge_point.go
+++ b/ocpp1.6/charge_point.go
@@ -274,7 +274,19 @@ func (cp *chargePoint) asyncCallbackHandler() {
 				cp.error(err)
 			}
 		case _, _ = <-cp.stopC:
+			// Handler stopped, cleanup callbacks.
+			// No callback invocation, since the user manually stopped the client.
+			cp.clearCallbacks(false)
 			return
+		}
+	}
+}
+
+func (cp *chargePoint) clearCallbacks(invokeCallback bool) {
+	for cb, ok := cp.callbacks.Dequeue("main"); ok; cb, ok = cp.callbacks.Dequeue("main") {
+		if invokeCallback {
+			err := ocpp.NewError(ocppj.GenericError, "client stopped, no response received from server", "")
+			cb(nil, err)
 		}
 	}
 }

--- a/ocpp2.0/v2.go
+++ b/ocpp2.0/v2.go
@@ -3,7 +3,6 @@ package ocpp2
 
 import (
 	"github.com/gorilla/websocket"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/lorenzodonini/ocpp-go/internal/callbackqueue"
 	"github.com/lorenzodonini/ocpp-go/ocpp"
@@ -119,6 +118,9 @@ type ChargingStation interface {
 	// Stops the charging station routine, disconnecting it from the CSMS.
 	// Any pending requests are discarded.
 	Stop()
+	// Errors returns a channel for error messages. If it doesn't exist it es created.
+	// The channel is closed by the charging station when stopped.
+	Errors() <-chan error
 }
 
 // Creates a new OCPP 2.0 charging station client.
@@ -302,6 +304,8 @@ type CSMS interface {
 
 	// The function blocks forever, so it is suggested to wrap it in a goroutine, in case other functionality needs to be executed on the main program thread.
 	Start(listenPort int, listenPath string)
+	// Errors returns a channel for error messages. If it doesn't exist it es created.
+	Errors() <-chan error
 }
 
 // Creates a new OCPP 2.0 CSMS.
@@ -328,10 +332,4 @@ func NewCSMS(endpoint *ocppj.Server, server ws.WsServer) CSMS {
 	cs.server.SetResponseHandler(cs.handleIncomingResponse)
 	cs.server.SetErrorHandler(cs.handleIncomingError)
 	return &cs
-}
-
-func init() {
-	log.New()
-	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
-	log.SetLevel(log.InfoLevel)
 }

--- a/ocppj/central_system_test.go
+++ b/ocppj/central_system_test.go
@@ -60,6 +60,7 @@ func (suite *OcppJTestSuite) TestCentralSystemSendRequest() {
 	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	suite.mockServer.On("Write", mockChargePointId, mock.Anything).Return(nil)
 	suite.centralSystem.Start(8887, "/{ws}")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	mockRequest := newMockRequest("mockValue")
 	err := suite.centralSystem.SendRequest(mockChargePointId, mockRequest)
 	assert.Nil(suite.T(), err)
@@ -70,6 +71,7 @@ func (suite *OcppJTestSuite) TestCentralSystemSendInvalidRequest() {
 	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	suite.mockServer.On("Write", mockChargePointId, mock.Anything).Return(nil)
 	suite.centralSystem.Start(8887, "/{ws}")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	mockRequest := newMockRequest("")
 	err := suite.centralSystem.SendRequest(mockChargePointId, mockRequest)
 	assert.NotNil(suite.T(), err)
@@ -80,6 +82,7 @@ func (suite *OcppJTestSuite) TestServerSendInvalidJsonRequest() {
 	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	suite.mockServer.On("Write", mockChargePointId, mock.Anything).Return(nil)
 	suite.centralSystem.Start(8887, "/{ws}")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	mockRequest := newMockRequest("somevalue")
 	mockRequest.MockAny = make(chan int)
 	err := suite.centralSystem.SendRequest(mockChargePointId, mockRequest)
@@ -92,6 +95,7 @@ func (suite *OcppJTestSuite) TestServerSendInvalidCall() {
 	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	suite.mockServer.On("Write", mockChargePointId, mock.Anything).Return(nil)
 	suite.centralSystem.Start(8887, "/{ws}")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	mockRequest := newMockRequest("somevalue")
 	// Delete existing profiles and test error
 	suite.centralSystem.Profiles = []*ocpp.Profile{}
@@ -111,11 +115,12 @@ func (suite *OcppJTestSuite) TestCentralSystemSendRequestFailed() {
 		require.False(t, q.IsEmpty())
 		req := q.Peek().(ocppj.RequestBundle)
 		callID = req.Call.GetUniqueId()
-		// Before anything is returned, the request must still be pending
+		// Before error is returned, the request must still be pending
 		_, ok = suite.centralSystem.RequestState.GetClientState(mockChargePointId).GetPendingRequest(callID)
 		assert.True(t, ok)
 	})
 	suite.centralSystem.Start(8887, "/{ws}")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	mockRequest := newMockRequest("mockValue")
 	err := suite.centralSystem.SendRequest(mockChargePointId, mockRequest)
 	//TODO: currently the network error is not returned by SendRequest, but is only generated internally
@@ -135,6 +140,7 @@ func (suite *OcppJTestSuite) TestCentralSystemSendConfirmation() {
 	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	suite.mockServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	suite.centralSystem.Start(8887, "/{ws}")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	mockConfirmation := newMockConfirmation("mockValue")
 	err := suite.centralSystem.SendResponse(mockChargePointId, mockUniqueId, mockConfirmation)
 	assert.Nil(t, err)
@@ -147,6 +153,7 @@ func (suite *OcppJTestSuite) TestCentralSystemSendInvalidConfirmation() {
 	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	suite.mockServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	suite.centralSystem.Start(8887, "/{ws}")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	mockConfirmation := newMockConfirmation("")
 	// This is allowed. Endpoint doesn't keep track of incoming requests, but only outgoing ones
 	err := suite.centralSystem.SendResponse(mockChargePointId, mockUniqueId, mockConfirmation)
@@ -160,6 +167,7 @@ func (suite *OcppJTestSuite) TestCentralSystemSendConfirmationFailed() {
 	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	suite.mockServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Return(fmt.Errorf("networkError"))
 	suite.centralSystem.Start(8887, "/{ws}")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	mockConfirmation := newMockConfirmation("mockValue")
 	err := suite.centralSystem.SendResponse(mockChargePointId, mockUniqueId, mockConfirmation)
 	assert.NotNil(t, err)
@@ -175,6 +183,7 @@ func (suite *OcppJTestSuite) TestCentralSystemSendError() {
 	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	suite.mockServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	suite.centralSystem.Start(8887, "/{ws}")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	err := suite.centralSystem.SendError(mockChargePointId, mockUniqueId, ocppj.GenericError, mockDescription, nil)
 	assert.Nil(t, err)
 }
@@ -187,6 +196,7 @@ func (suite *OcppJTestSuite) TestCentralSystemSendInvalidError() {
 	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	suite.mockServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	suite.centralSystem.Start(8887, "/{ws}")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	err := suite.centralSystem.SendError(mockChargePointId, mockUniqueId, "InvalidErrorCode", mockDescription, nil)
 	assert.NotNil(t, err)
 }
@@ -198,6 +208,7 @@ func (suite *OcppJTestSuite) TestCentralSystemSendErrorFailed() {
 	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	suite.mockServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Return(fmt.Errorf("networkError"))
 	suite.centralSystem.Start(8887, "/{ws}")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	mockConfirmation := newMockConfirmation("mockValue")
 	err := suite.centralSystem.SendResponse(mockChargePointId, mockUniqueId, mockConfirmation)
 	assert.NotNil(t, err)
@@ -220,6 +231,9 @@ func (suite *OcppJTestSuite) TestCentralSystemNewClientHandler() {
 	channel := NewMockWebSocket(mockClientID)
 	suite.mockServer.NewClientHandler(channel)
 	ok, _ := <-connectedC
+	assert.True(t, ok)
+	// Client state was created
+	_, ok = suite.serverRequestMap.Get(mockClientID)
 	assert.True(t, ok)
 }
 
@@ -262,13 +276,13 @@ func (suite *OcppJTestSuite) TestCentralSystemRequestHandler() {
 		assert.Equal(t, MockFeatureName, action)
 		assert.NotNil(t, request)
 	})
-	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return().Run(func(args mock.Arguments) {
-		// Simulate charge point message
-		channel := NewMockWebSocket(mockChargePointId)
-		err := suite.mockServer.MessageHandler(channel, []byte(mockRequest))
-		assert.Nil(t, err)
-	})
+	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return()
 	suite.centralSystem.Start(8887, "somePath")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
+	// Simulate charge point message
+	channel := NewMockWebSocket(mockChargePointId)
+	err := suite.mockServer.MessageHandler(channel, []byte(mockRequest))
+	assert.Nil(t, err)
 }
 
 func (suite *OcppJTestSuite) TestCentralSystemConfirmationHandler() {
@@ -286,6 +300,7 @@ func (suite *OcppJTestSuite) TestCentralSystemConfirmationHandler() {
 	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	// Start central system
 	suite.centralSystem.Start(8887, "somePath")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	// Set mocked request in queue and mark as pending
 	addMockPendingRequest(suite, mockRequest, mockUniqueId, mockChargePointId)
 	// Simulate charge point message
@@ -316,6 +331,7 @@ func (suite *OcppJTestSuite) TestCentralSystemErrorHandler() {
 	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	// Start central system
 	suite.centralSystem.Start(8887, "somePath")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	// Set mocked request in queue and mark as pending
 	addMockPendingRequest(suite, mockRequest, mockUniqueId, mockChargePointId)
 	// Simulate charge point message
@@ -345,8 +361,10 @@ func (suite *OcppJTestSuite) TestServerEnqueueRequest() {
 	suite.mockServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	// Start normally
 	suite.centralSystem.Start(8887, "/{ws}")
-	req := newMockRequest("somevalue")
 	mockChargePointId := "1234"
+	suite.serverDispatcher.CreateClient(mockChargePointId)
+	// Simulate request
+	req := newMockRequest("somevalue")
 	err := suite.centralSystem.SendRequest(mockChargePointId, req)
 	require.Nil(t, err)
 	time.Sleep(500 * time.Millisecond)
@@ -378,6 +396,7 @@ func (suite *OcppJTestSuite) TestEnqueueMultipleRequests() {
 	}).Return(nil)
 	// Start normally
 	suite.centralSystem.Start(8887, "/{ws}")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	for i := 0; i < messagesToQueue; i++ {
 		req := newMockRequest(fmt.Sprintf("request-%v", i))
 		err := suite.centralSystem.SendRequest(mockChargePointId, req)
@@ -412,6 +431,7 @@ func (suite *OcppJTestSuite) TestRequestQueueFull() {
 	suite.mockServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	// Start normally
 	suite.centralSystem.Start(8887, "/{ws}")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	for i := 0; i < messagesToQueue; i++ {
 		req := newMockRequest(fmt.Sprintf("request-%v", i))
 		err := suite.centralSystem.SendRequest(mockChargePointId, req)
@@ -435,6 +455,7 @@ func (suite *OcppJTestSuite) TestParallelRequests() {
 	}).Return(nil)
 	// Start normally
 	suite.centralSystem.Start(8887, "/{ws}")
+	suite.serverDispatcher.CreateClient(mockChargePointId)
 	for i := 0; i < messagesToQueue; i++ {
 		go func() {
 			req := newMockRequest(fmt.Sprintf("someReq"))
@@ -535,6 +556,8 @@ func (suite *OcppJTestSuite) TestServerRequestFlow() {
 	}()
 	// Start server normally
 	suite.centralSystem.Start(8887, "/{ws}")
+	suite.serverDispatcher.CreateClient(mockChargePoint1)
+	suite.serverDispatcher.CreateClient(mockChargePoint2)
 	for i := 0; i < messagesToQueue*2; i++ {
 		// Select a source client
 		var chargePointTarget string

--- a/ocppj/client.go
+++ b/ocppj/client.go
@@ -74,7 +74,6 @@ func (c *Client) Start(serverURL string) error {
 	c.client.SetMessageHandler(c.ocppMessageHandler)
 	c.client.SetDisconnectedHandler(c.onDisconnected)
 	c.client.SetReconnectedHandler(c.onReconnected)
-	c.dispatcher.SetOnRequestCanceled(c.onDispatcherError)
 	// Connect & run
 	fullUrl := fmt.Sprintf("%v/%v", serverURL, c.Id)
 	err := c.client.Start(fullUrl)
@@ -221,11 +220,4 @@ func (c *Client) onDisconnected(err error) {
 
 func (c *Client) onReconnected() {
 	c.dispatcher.Resume()
-}
-
-// Callback invoked by dispatcher, whenever a queued request is canceled, due to timeout.
-func (c *Client) onDispatcherError(requestID string) {
-	if c.errorHandler != nil {
-		c.errorHandler(ocpp.NewError(GenericError, "request timed out, no response received from server", requestID), nil)
-	}
 }

--- a/ocppj/client.go
+++ b/ocppj/client.go
@@ -61,14 +61,14 @@ func (c *Client) SetErrorHandler(handler func(err *ocpp.Error, details interface
 }
 
 // Connects to the given serverURL and starts running the I/O loop for the underlying connection.
-// The write routine runs on a separate goroutine, while the read routine runs on the caller's routine.
-// This means, the function is blocking for as long as the Client is connected to the Server.
 //
-// Whenever the connection is ended, the function returns.
+// If the connection is established successfully, the function returns control to the caller immediately.
+// The read/write routines are run on dedicated goroutines, so the main thread can perform other operations.
 //
-// Call this function in a separate goroutine, to perform other operations on the main thread.
+// In case of disconnection, the client handles re-connection automatically.
+// The client will attempt to re-connect to the server forever, until it is stopped by invoking the Stop method.
 //
-// An error may be returned, if the connection failed or if it broke unexpectedly.
+// An error may be returned, if establishing the connection failed.
 func (c *Client) Start(serverURL string) error {
 	// Set internal message handler
 	c.client.SetMessageHandler(c.ocppMessageHandler)

--- a/ocppj/dispatcher_test.go
+++ b/ocppj/dispatcher_test.go
@@ -48,6 +48,8 @@ func (s *ServerDispatcherTestSuite) TestSendRequest() {
 	}).Return(nil)
 	s.dispatcher.Start()
 	require.True(t, s.dispatcher.IsRunning())
+	// Simulate client connection
+	s.dispatcher.CreateClient(clientID)
 	// Create and send mock request
 	req := newMockRequest("somevalue")
 	call, err := s.endpoint.CreateCall(req)
@@ -102,6 +104,8 @@ func (s *ServerDispatcherTestSuite) TestRequestCanceled() {
 	})
 	s.dispatcher.Start()
 	require.True(t, s.dispatcher.IsRunning())
+	// Simulate client connection
+	s.dispatcher.CreateClient(clientID)
 	// Send mock request
 	err = s.dispatcher.SendRequest(clientID, bundle)
 	require.NoError(t, err)
@@ -120,6 +124,22 @@ func (s *ServerDispatcherTestSuite) TestRequestCanceled() {
 	assert.True(t, q.IsEmpty())
 }
 
+func (s *ServerDispatcherTestSuite) TestCreateClient() {
+	t := s.T()
+	// Setup
+	clientID := "client1"
+	s.dispatcher.Start()
+	require.True(t, s.dispatcher.IsRunning())
+	// No client state created yet
+	_, ok := s.queueMap.Get(clientID)
+	assert.False(t, ok)
+	// Create client state
+	s.dispatcher.CreateClient(clientID)
+	_, ok = s.queueMap.Get(clientID)
+	assert.True(t, ok)
+	assert.False(t, s.state.HasPendingRequest(clientID))
+}
+
 func (s *ServerDispatcherTestSuite) TestDeleteClient() {
 	t := s.T()
 	// Setup
@@ -132,6 +152,8 @@ func (s *ServerDispatcherTestSuite) TestDeleteClient() {
 	}).Return(nil)
 	s.dispatcher.Start()
 	require.True(t, s.dispatcher.IsRunning())
+	// Simulate client connection
+	s.dispatcher.CreateClient(clientID)
 	// Create and send mock request
 	req := newMockRequest("somevalue")
 	call, err := s.endpoint.CreateCall(req)

--- a/ocppj/dispatcher_test.go
+++ b/ocppj/dispatcher_test.go
@@ -93,9 +93,11 @@ func (s *ServerDispatcherTestSuite) TestRequestCanceled() {
 	require.NoError(t, err)
 	bundle := ocppj.RequestBundle{Call: call, Data: data}
 	// Set canceled callback
-	s.dispatcher.SetOnRequestCanceled(func(client string, request string) {
-		assert.Equal(t, clientID, client)
-		assert.Equal(t, requestID, request)
+	s.dispatcher.SetOnRequestCanceled(func(cID string, rID string, action string, request ocpp.Request) {
+		assert.Equal(t, clientID, cID)
+		assert.Equal(t, requestID, rID)
+		assert.Equal(t, MockFeatureName, action)
+		assert.Equal(t, req, request)
 		canceled <- true
 	})
 	s.dispatcher.Start()
@@ -220,8 +222,10 @@ func (c *ClientDispatcherTestSuite) TestRequestCanceled() {
 	require.NoError(t, err)
 	bundle := ocppj.RequestBundle{Call: call, Data: data}
 	// Set canceled callback
-	c.dispatcher.SetOnRequestCanceled(func(request string) {
-		assert.Equal(t, requestID, request)
+	c.dispatcher.SetOnRequestCanceled(func(rID string, action string, request ocpp.Request) {
+		assert.Equal(t, requestID, rID)
+		assert.Equal(t, MockFeatureName, action)
+		assert.Equal(t, req, request)
 		canceled <- true
 	})
 	c.dispatcher.Start()
@@ -260,8 +264,10 @@ func (c *ClientDispatcherTestSuite) TestDispatcherTimeout() {
 	bundle := ocppj.RequestBundle{Call: call, Data: data}
 	// Set low timeout to trigger OnRequestCanceled callback
 	c.dispatcher.SetTimeout(1 * time.Second)
-	c.dispatcher.SetOnRequestCanceled(func(reqID string) {
-		assert.Equal(t, requestID, reqID)
+	c.dispatcher.SetOnRequestCanceled(func(rID string, action string, request ocpp.Request) {
+		assert.Equal(t, requestID, rID)
+		assert.Equal(t, MockFeatureName, action)
+		assert.Equal(t, req, request)
 		timeout <- true
 	})
 	c.dispatcher.Start()
@@ -294,8 +300,10 @@ func (c *ClientDispatcherTestSuite) TestPauseDispatcher() {
 	// Set timeout to test pause functionality
 	c.dispatcher.SetTimeout(500 * time.Millisecond)
 	// The callback will only be triggered at the end of the test case
-	c.dispatcher.SetOnRequestCanceled(func(reqID string) {
-		assert.Equal(t, requestID, reqID)
+	c.dispatcher.SetOnRequestCanceled(func(rID string, action string, request ocpp.Request) {
+		assert.Equal(t, requestID, rID)
+		assert.Equal(t, MockFeatureName, action)
+		assert.Equal(t, req, request)
 		timeout <- true
 	})
 	c.dispatcher.Start()
@@ -332,7 +340,7 @@ func (c *ClientDispatcherTestSuite) TestSendWhilePausedDispatcher() {
 	// Set timeout (unused for this test)
 	c.dispatcher.SetTimeout(1 * time.Second)
 	// The callback will only be triggered at the end of the test case
-	c.dispatcher.SetOnRequestCanceled(func(reqID string) {
+	c.dispatcher.SetOnRequestCanceled(func(rID string, action string, request ocpp.Request) {
 		require.Fail(t, "unexpected OnRequestCanceled")
 	})
 	c.dispatcher.Start()

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -36,6 +36,7 @@ type MockWebsocketServer struct {
 	MessageHandler            func(ws ws.Channel, data []byte) error
 	NewClientHandler          func(ws ws.Channel)
 	DisconnectedClientHandler func(ws ws.Channel)
+	errC                      chan error
 }
 
 func (websocketServer *MockWebsocketServer) Start(port int, listenPath string) {
@@ -64,6 +65,19 @@ func (websocketServer *MockWebsocketServer) SetDisconnectedClientHandler(handler
 }
 
 func (websocketServer *MockWebsocketServer) AddSupportedSubprotocol(subProto string) {
+}
+
+func (websocketServer *MockWebsocketServer) Errors() <-chan error {
+	if websocketServer.errC == nil {
+		websocketServer.errC = make(chan error, 1)
+	}
+	return websocketServer.errC
+}
+
+func (websocketServer *MockWebsocketServer) ThrowError(err error) {
+	if websocketServer.errC != nil {
+		websocketServer.errC <- err
+	}
 }
 
 func (websocketServer *MockWebsocketServer) NewClient(websocketId string, client interface{}) {


### PR DESCRIPTION
Allows charge point applications to issue multiple requests concurrently, from different goroutines

Also includes a bunch of other improvements.