### PR TITLE
Add option to server to get TLS ConnectionState for connections

### DIFF
--- a/ocpp1.6_test/ocpp16_test.go
+++ b/ocpp1.6_test/ocpp16_test.go
@@ -1,6 +1,7 @@
 package ocpp16_test
 
 import (
+	"crypto/tls"
 	"fmt"
 	"reflect"
 	"testing"
@@ -28,6 +29,10 @@ type MockWebSocket struct {
 
 func (websocket MockWebSocket) GetID() string {
 	return websocket.id
+}
+
+func (websocket MockWebSocket) GetTLSConnectionState() *tls.ConnectionState {
+	return nil
 }
 
 func NewMockWebSocket(id string) MockWebSocket {

--- a/ocpp2.0_test/ocpp2_test.go
+++ b/ocpp2.0_test/ocpp2_test.go
@@ -1,6 +1,7 @@
 package ocpp2_test
 
 import (
+	"crypto/tls"
 	"fmt"
 	"reflect"
 	"testing"
@@ -41,6 +42,10 @@ type MockWebSocket struct {
 
 func (websocket MockWebSocket) GetID() string {
 	return websocket.id
+}
+
+func (websocket MockWebSocket) GetTLSConnectionState() *tls.ConnectionState {
+	return nil
 }
 
 func NewMockWebSocket(id string) MockWebSocket {

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -1,6 +1,7 @@
 package ocppj_test
 
 import (
+	"crypto/tls"
 	"fmt"
 	"reflect"
 	"testing"
@@ -22,6 +23,10 @@ type MockWebSocket struct {
 
 func (websocket MockWebSocket) GetID() string {
 	return websocket.id
+}
+
+func (websocket MockWebSocket) GetTLSConnectionState() *tls.ConnectionState {
+	return nil
 }
 
 func NewMockWebSocket(id string) MockWebSocket {


### PR DESCRIPTION
This is one way of doing it, another would be to stash the `tls.ConnectionState` in the `WebSocket` and add an accessor.