### PR TITLE
Pass ws.Channel to ocppj callbacks

### DIFF
--- a/ocpp1.6_test/ocpp16_test.go
+++ b/ocpp1.6_test/ocpp16_test.go
@@ -27,11 +27,11 @@ type MockWebSocket struct {
 	id string
 }
 
-func (websocket MockWebSocket) GetID() string {
+func (websocket MockWebSocket) ID() string {
 	return websocket.id
 }
 
-func (websocket MockWebSocket) GetTLSConnectionState() *tls.ConnectionState {
+func (websocket MockWebSocket) TLSConnectionState() *tls.ConnectionState {
 	return nil
 }
 
@@ -426,7 +426,7 @@ func NewWebsocketServer(t *testing.T, onMessage func(data []byte) ([]byte, error
 			response, err := onMessage(data)
 			assert.Nil(t, err)
 			if response != nil {
-				err = wsServer.Write(ws.GetID(), data)
+				err = wsServer.Write(ws.ID(), data)
 				assert.Nil(t, err)
 			}
 		}
@@ -473,8 +473,8 @@ type expectedChargePointOptions struct {
 
 func setupDefaultCentralSystemHandlers(suite *OcppV16TestSuite, coreListener core.CentralSystemHandler, options expectedCentralSystemOptions) {
 	t := suite.T()
-	suite.centralSystem.SetNewChargePointHandler(func(chargePointId string) {
-		assert.Equal(t, options.clientId, chargePointId)
+	suite.centralSystem.SetNewChargePointHandler(func(chargePoint ocpp16.ChargePointConnection) {
+		assert.Equal(t, options.clientId, chargePoint.ID())
 	})
 	suite.centralSystem.SetCoreHandler(coreListener)
 	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(options.startReturnArgument)
@@ -575,9 +575,9 @@ func testUnsupportedRequestFromCentralSystem(suite *OcppV16TestSuite, request oc
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: false})
 	coreListener := MockChargePointCoreListener{}
 	setupDefaultChargePointHandlers(suite, coreListener, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(errorJson), forwardWrittenMessage: true})
-	suite.ocppjCentralSystem.SetErrorHandler(func(chargePointId string, err *ocpp.Error, details interface{}) {
+	suite.ocppjCentralSystem.SetErrorHandler(func(chargePoint ws.Channel, err *ocpp.Error, details interface{}) {
 		assert.Equal(t, messageId, err.MessageId)
-		assert.Equal(t, wsId, chargePointId)
+		assert.Equal(t, wsId, chargePoint.ID())
 		assert.Equal(t, ocppj.NotSupported, err.Code)
 		assert.Equal(t, errorDescription, err.Description)
 		assert.Nil(t, details)

--- a/ocpp2.0_test/ocpp2_test.go
+++ b/ocpp2.0_test/ocpp2_test.go
@@ -40,11 +40,11 @@ type MockWebSocket struct {
 	id string
 }
 
-func (websocket MockWebSocket) GetID() string {
+func (websocket MockWebSocket) ID() string {
 	return websocket.id
 }
 
-func (websocket MockWebSocket) GetTLSConnectionState() *tls.ConnectionState {
+func (websocket MockWebSocket) TLSConnectionState() *tls.ConnectionState {
 	return nil
 }
 
@@ -556,7 +556,7 @@ func NewWebsocketServer(t *testing.T, onMessage func(data []byte) ([]byte, error
 			response, err := onMessage(data)
 			assert.Nil(t, err)
 			if response != nil {
-				err = wsServer.Write(ws.GetID(), data)
+				err = wsServer.Write(ws.ID(), data)
 				assert.Nil(t, err)
 			}
 		}
@@ -639,8 +639,8 @@ func setupDefaultCSMSHandlers(suite *OcppV2TestSuite, options expectedCSMSOption
 			suite.csms.SetTransactionsHandler(h.(MockChargingStationTransactionHandler))
 		}
 	}
-	suite.csms.SetNewChargingStationHandler(func(chargingStationId string) {
-		assert.Equal(t, options.clientId, chargingStationId)
+	suite.csms.SetNewChargingStationHandler(func(chargingStation ocpp2.ChargingStationConnection) {
+		assert.Equal(t, options.clientId, chargingStation.ID())
 	})
 	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(options.startReturnArgument)
 	suite.mockWsServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Return(options.writeReturnArgument).Run(func(args mock.Arguments) {
@@ -773,9 +773,9 @@ func testUnsupportedRequestFromCentralSystem(suite *OcppV2TestSuite, request ocp
 
 	setupDefaultCSMSHandlers(suite, expectedCSMSOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: false})
 	setupDefaultChargingStationHandlers(suite, expectedChargingStationOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(errorJson), forwardWrittenMessage: true}, handlers...)
-	suite.ocppjServer.SetErrorHandler(func(chargingStationId string, err *ocpp.Error, details interface{}) {
+	suite.ocppjServer.SetErrorHandler(func(channel ws.Channel, err *ocpp.Error, details interface{}) {
 		assert.Equal(t, messageId, err.MessageId)
-		assert.Equal(t, wsId, chargingStationId)
+		assert.Equal(t, wsId, channel.ID())
 		assert.Equal(t, ocppj.NotSupported, err.Code)
 		assert.Equal(t, errorDescription, err.Description)
 		assert.Nil(t, details)

--- a/ocppj/central_system_test.go
+++ b/ocppj/central_system_test.go
@@ -220,8 +220,8 @@ func (suite *OcppJTestSuite) TestCentralSystemNewClientHandler() {
 	t := suite.T()
 	mockClientID := "1234"
 	connectedC := make(chan bool, 1)
-	suite.centralSystem.SetNewClientHandler(func(clientID string) {
-		assert.Equal(t, mockClientID, clientID)
+	suite.centralSystem.SetNewClientHandler(func(client ws.Channel) {
+		assert.Equal(t, mockClientID, client.ID())
 		connectedC <- true
 	})
 	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return()
@@ -242,12 +242,12 @@ func (suite *OcppJTestSuite) TestCentralSystemDisconnectedHandler() {
 	mockClientID := "1234"
 	connectedC := make(chan bool, 1)
 	disconnectedC := make(chan bool, 1)
-	suite.centralSystem.SetNewClientHandler(func(clientID string) {
-		assert.Equal(t, mockClientID, clientID)
+	suite.centralSystem.SetNewClientHandler(func(client ws.Channel) {
+		assert.Equal(t, mockClientID, client.ID())
 		connectedC <- true
 	})
-	suite.centralSystem.SetDisconnectedClientHandler(func(clientID string) {
-		assert.Equal(t, mockClientID, clientID)
+	suite.centralSystem.SetDisconnectedClientHandler(func(client ws.Channel) {
+		assert.Equal(t, mockClientID, client.ID())
 		disconnectedC <- true
 	})
 	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return()
@@ -270,8 +270,8 @@ func (suite *OcppJTestSuite) TestCentralSystemRequestHandler() {
 	mockUniqueId := "5678"
 	mockValue := "someValue"
 	mockRequest := fmt.Sprintf(`[2,"%v","%v",{"mockValue":"%v"}]`, mockUniqueId, MockFeatureName, mockValue)
-	suite.centralSystem.SetRequestHandler(func(chargePointId string, request ocpp.Request, requestId string, action string) {
-		assert.Equal(t, mockChargePointId, chargePointId)
+	suite.centralSystem.SetRequestHandler(func(chargePoint ws.Channel, request ocpp.Request, requestId string, action string) {
+		assert.Equal(t, mockChargePointId, chargePoint.ID())
 		assert.Equal(t, mockUniqueId, requestId)
 		assert.Equal(t, MockFeatureName, action)
 		assert.NotNil(t, request)
@@ -292,8 +292,8 @@ func (suite *OcppJTestSuite) TestCentralSystemConfirmationHandler() {
 	mockValue := "someValue"
 	mockRequest := newMockRequest("testValue")
 	mockConfirmation := fmt.Sprintf(`[3,"%v",{"mockValue":"%v"}]`, mockUniqueId, mockValue)
-	suite.centralSystem.SetResponseHandler(func(chargePointId string, confirmation ocpp.Response, requestId string) {
-		assert.Equal(t, mockChargePointId, chargePointId)
+	suite.centralSystem.SetResponseHandler(func(chargePoint ws.Channel, confirmation ocpp.Response, requestId string) {
+		assert.Equal(t, mockChargePointId, chargePoint.ID())
 		assert.Equal(t, mockUniqueId, requestId)
 		assert.NotNil(t, confirmation)
 	})
@@ -320,8 +320,8 @@ func (suite *OcppJTestSuite) TestCentralSystemErrorHandler() {
 	mockErrorDetails["details"] = "someValue"
 	mockRequest := newMockRequest("testValue")
 	mockError := fmt.Sprintf(`[4,"%v","%v","%v",{"details":"%v"}]`, mockUniqueId, mockErrorCode, mockErrorDescription, mockValue)
-	suite.centralSystem.SetErrorHandler(func(chargePointId string, err *ocpp.Error, details interface{}) {
-		assert.Equal(t, mockChargePointId, chargePointId)
+	suite.centralSystem.SetErrorHandler(func(chargePoint ws.Channel, err *ocpp.Error, details interface{}) {
+		assert.Equal(t, mockChargePointId, chargePoint.ID())
 		assert.Equal(t, mockUniqueId, err.MessageId)
 		assert.Equal(t, mockErrorCode, err.Code)
 		assert.Equal(t, mockErrorDescription, err.Description)

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -21,11 +21,11 @@ type MockWebSocket struct {
 	id string
 }
 
-func (websocket MockWebSocket) GetID() string {
+func (websocket MockWebSocket) ID() string {
 	return websocket.id
 }
 
-func (websocket MockWebSocket) GetTLSConnectionState() *tls.ConnectionState {
+func (websocket MockWebSocket) TLSConnectionState() *tls.ConnectionState {
 	return nil
 }
 
@@ -207,7 +207,7 @@ func NewWebsocketServer(t *testing.T, onMessage func(data []byte) ([]byte, error
 			response, err := onMessage(data)
 			assert.Nil(t, err)
 			if response != nil {
-				err = wsServer.Write(ws.GetID(), data)
+				err = wsServer.Write(ws.ID(), data)
 				assert.Nil(t, err)
 			}
 		}

--- a/ws/network_test.go
+++ b/ws/network_test.go
@@ -128,7 +128,7 @@ func (s *NetworkTestSuite) TestClientAutoReconnect() {
 	s.server = newWebsocketServer(t, nil)
 	s.server.SetNewClientHandler(func(ws Channel) {
 		assert.NotNil(t, ws)
-		conn := s.server.connections[ws.GetID()]
+		conn := s.server.connections[ws.ID()]
 		require.NotNil(t, conn)
 	})
 	s.server.SetDisconnectedClientHandler(func(ws Channel) {

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -87,8 +87,8 @@ func NewClientTimeoutConfig() ClientTimeoutConfig {
 
 // Channel represents a bi-directional communication channel, which provides at least a unique ID.
 type Channel interface {
-	GetID() string
-	GetTLSConnectionState() *tls.ConnectionState
+	ID() string
+	TLSConnectionState() *tls.ConnectionState
 }
 
 // WebSocket is a wrapper for a single websocket channel.
@@ -105,12 +105,12 @@ type WebSocket struct {
 }
 
 // Retrieves the unique Identifier of the websocket (typically, the URL suffix).
-func (websocket *WebSocket) GetID() string {
+func (websocket *WebSocket) ID() string {
 	return websocket.id
 }
 
 // Returns the TLS connection state of the connection, if any.
-func (websocket *WebSocket) GetTLSConnectionState() *tls.ConnectionState {
+func (websocket *WebSocket) TLSConnectionState() *tls.ConnectionState {
 	return websocket.tlsConnectionState
 }
 
@@ -453,7 +453,7 @@ func (server *Server) readPump(ws *WebSocket) {
 		_, message, err := conn.ReadMessage()
 		if err != nil {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure, websocket.CloseNormalClosure) {
-				server.error(fmt.Errorf("read failed for %s: %w", ws.GetID(), err))
+				server.error(fmt.Errorf("read failed for %s: %w", ws.ID(), err))
 			}
 			// Notify writePump of error. Disconnection will be handled there
 			ws.closeSignal <- err
@@ -467,7 +467,7 @@ func (server *Server) readPump(ws *WebSocket) {
 			var channel Channel = ws
 			err = server.messageHandler(channel, message)
 			if err != nil {
-				server.error(fmt.Errorf("handling failed for %s: %w", ws.GetID(), err))
+				server.error(fmt.Errorf("handling failed for %s: %w", ws.ID(), err))
 				continue
 			}
 		}
@@ -499,14 +499,14 @@ func (server *Server) writePump(ws *WebSocket) {
 
 			err := conn.WriteMessage(websocket.TextMessage, data)
 			if err != nil {
-				server.error(fmt.Errorf("write failed for %s: %w", ws.GetID(), err))
+				server.error(fmt.Errorf("write failed for %s: %w", ws.ID(), err))
 				return
 			}
 		case ping := <-ws.pingMessage:
 			_ = conn.SetWriteDeadline(time.Now().Add(server.timeoutConfig.WriteWait))
 			err := conn.WriteMessage(websocket.PongMessage, ping)
 			if err != nil {
-				server.error(fmt.Errorf("write failed for %s: %w", ws.GetID(), err))
+				server.error(fmt.Errorf("write failed for %s: %w", ws.ID(), err))
 				return
 			}
 		case closed, ok := <-ws.closeSignal:

--- a/ws/websocket_test.go
+++ b/ws/websocket_test.go
@@ -41,7 +41,7 @@ func newWebsocketServer(t *testing.T, onMessage func(data []byte) ([]byte, error
 			response, err := onMessage(data)
 			assert.Nil(t, err)
 			if response != nil {
-				err = wsServer.Write(ws.GetID(), data)
+				err = wsServer.Write(ws.ID(), data)
 				assert.Nil(t, err)
 			}
 		}
@@ -89,7 +89,7 @@ func TestWebsocketEcho(t *testing.T) {
 		return data, nil
 	})
 	wsServer.SetNewClientHandler(func(ws Channel) {
-		tlsState := ws.GetTLSConnectionState()
+		tlsState := ws.TLSConnectionState()
 		assert.Nil(t, tlsState)
 	})
 	wsServer.SetDisconnectedClientHandler(func(ws Channel) {
@@ -144,7 +144,7 @@ func TestTLSWebsocketEcho(t *testing.T) {
 		return data, nil
 	})
 	wsServer.SetNewClientHandler(func(ws Channel) {
-		tlsState := ws.GetTLSConnectionState()
+		tlsState := ws.TLSConnectionState()
 		assert.NotNil(t, tlsState)
 	})
 	wsServer.SetDisconnectedClientHandler(func(ws Channel) {
@@ -274,7 +274,7 @@ func TestWebsocketServerConnectionBreak(t *testing.T) {
 	wsServer := newWebsocketServer(t, nil)
 	wsServer.SetNewClientHandler(func(ws Channel) {
 		assert.NotNil(t, ws)
-		conn := wsServer.connections[ws.GetID()]
+		conn := wsServer.connections[ws.ID()]
 		assert.NotNil(t, conn)
 		// Simulate connection closed as soon client is connected
 		err := conn.connection.Close()


### PR DESCRIPTION
For my purposes at least, it's enough to have the `NewChargePointHandler` accept `ws.Channel`s, so I haven't changed all of the request callbacks. WDYT? I'll update `2.0` if it looks good. @lorenzodonini 