### PR TITLE
Don't prevent ocppj goroutine from closing

### DIFF
--- a/ocppj/central_system_test.go
+++ b/ocppj/central_system_test.go
@@ -47,6 +47,7 @@ func (suite *OcppJTestSuite) TestServerStoppedError() {
 	// Stop server
 	suite.centralSystem.Stop()
 	// Send message. Expected error
+	time.Sleep(20 * time.Millisecond)
 	assert.False(t, suite.serverDispatcher.IsRunning())
 	req := newMockRequest("somevalue")
 	err := suite.centralSystem.SendRequest(mockChargePointId, req)

--- a/ocppj/charge_point_test.go
+++ b/ocppj/charge_point_test.go
@@ -57,6 +57,7 @@ func (suite *OcppJTestSuite) TestClientStoppedError() {
 	// Stop client
 	suite.chargePoint.Stop()
 	// Send message. Expected error
+	time.Sleep(20 * time.Millisecond)
 	assert.False(t, suite.clientDispatcher.IsRunning())
 	req := newMockRequest("somevalue")
 	err = suite.chargePoint.SendRequest(req)

--- a/ocppj/dispatcher.go
+++ b/ocppj/dispatcher.go
@@ -142,7 +142,6 @@ func (d *DefaultClientDispatcher) Stop() {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 	close(d.requestChannel)
-	d.requestChannel = nil
 	// TODO: clear pending requests?
 }
 
@@ -370,7 +369,6 @@ func (d *DefaultServerDispatcher) Stop() {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 	close(d.requestChannel)
-	d.requestChannel = nil
 	// TODO: clear pending requests?
 }
 


### PR DESCRIPTION
I was just playing around with `go.uber.org/goleak` and saw `messagePump` hanging around quite often. If we immediately set `d.requestChannel` to `nil` and `messagePump` isn't already waiting to select from `d.requestChannel`, it will never `return`. `messagePump` already sets the channel to `nil` as well.