### PR TITLE
Set ocppj.Dispatcher OnRequestCanceled handler in ocpp1.6 and ocpp2.0

### DIFF
--- a/ocpp1.6/v16.go
+++ b/ocpp1.6/v16.go
@@ -144,13 +144,15 @@ func NewChargePoint(id string, endpoint *ocppj.Client, client ws.WsClient) Charg
 		}
 	})
 	cp := chargePoint{confirmationHandler: make(chan ocpp.Response, 1), errorHandler: make(chan error, 1), callbacks: callbackqueue.New()}
+
 	if endpoint == nil {
 		dispatcher := ocppj.NewDefaultClientDispatcher(ocppj.NewFIFOClientQueue(0))
-		// Callback invoked by dispatcher, whenever a queued request is canceled, due to timeout.
-		dispatcher.SetOnRequestCanceled(cp.onRequestTimeout)
 		endpoint = ocppj.NewClient(id, client, dispatcher, nil, core.Profile, localauth.Profile, firmware.Profile, reservation.Profile, remotetrigger.Profile, smartcharging.Profile)
 	}
+	// Callback invoked by dispatcher, whenever a queued request is canceled, due to timeout.
+	endpoint.SetOnRequestCanceled(cp.onRequestTimeout)
 	cp.client = endpoint
+
 	cp.client.SetResponseHandler(func(confirmation ocpp.Response, requestId string) {
 		cp.confirmationHandler <- confirmation
 	})

--- a/ocpp2.0/v2.go
+++ b/ocpp2.0/v2.go
@@ -173,13 +173,16 @@ func NewChargingStation(id string, endpoint *ocppj.Client, client ws.WsClient) C
 		}
 	})
 	cs := chargingStation{responseHandler: make(chan ocpp.Response, 1), errorHandler: make(chan error, 1), callbacks: callbackqueue.New()}
+
 	if endpoint == nil {
 		dispatcher := ocppj.NewDefaultClientDispatcher(ocppj.NewFIFOClientQueue(0))
-		// Callback invoked by dispatcher, whenever a queued request is canceled, due to timeout.
-		dispatcher.SetOnRequestCanceled(cs.onRequestTimeout)
 		endpoint = ocppj.NewClient(id, client, dispatcher, nil, authorization.Profile, availability.Profile, data.Profile, diagnostics.Profile, display.Profile, firmware.Profile, iso15118.Profile, localauth.Profile, meter.Profile, provisioning.Profile, remotecontrol.Profile, reservation.Profile, security.Profile, smartcharging.Profile, tariffcost.Profile, transactions.Profile)
 	}
+
+	// Callback invoked by dispatcher, whenever a queued request is canceled, due to timeout.
+	endpoint.SetOnRequestCanceled(cs.onRequestTimeout)
 	cs.client = endpoint
+
 	cs.client.SetResponseHandler(func(confirmation ocpp.Response, requestId string) {
 		cs.responseHandler <- confirmation
 	})

--- a/ocppj/client.go
+++ b/ocppj/client.go
@@ -60,6 +60,11 @@ func (c *Client) SetErrorHandler(handler func(err *ocpp.Error, details interface
 	c.errorHandler = handler
 }
 
+// Registers the handler to be called on timeout.
+func (c *Client) SetOnRequestCanceled(handler CanceledRequestHandler) {
+	c.dispatcher.SetOnRequestCanceled(handler)
+}
+
 // Connects to the given serverURL and starts running the I/O loop for the underlying connection.
 //
 // If the connection is established successfully, the function returns control to the caller immediately.

--- a/ocppj/dispatcher.go
+++ b/ocppj/dispatcher.go
@@ -49,7 +49,7 @@ type ClientDispatcher interface {
 	// Calling Stop on the dispatcher will not trigger this callback.
 	//
 	// If no callback is set, a request will still be removed from the dispatcher when a timeout occurs.
-	SetOnRequestCanceled(cb func(string, string, ocpp.Request))
+	SetOnRequestCanceled(cb CanceledRequestHandler)
 	// Sets the network client, so the dispatcher may send requests using the networking layer directly.
 	//
 	// This needs to be set before calling the Start method. If not, sending requests will fail.
@@ -81,6 +81,8 @@ type pendingRequest struct {
 	startTime time.Time
 }
 
+type CanceledRequestHandler func(id string, action string, request ocpp.Request)
+
 // DefaultClientDispatcher is a default implementation of the ClientDispatcher interface.
 //
 // The dispatcher implements the ClientState as well for simplicity.
@@ -92,7 +94,7 @@ type DefaultClientDispatcher struct {
 	pendingRequestState ClientState
 	network             ws.WsClient
 	mutex               sync.RWMutex
-	onRequestCancel     func(string, string, ocpp.Request)
+	onRequestCancel     CanceledRequestHandler
 	timer               *time.Timer
 	paused              bool
 	timeout             time.Duration
@@ -112,7 +114,7 @@ func NewDefaultClientDispatcher(queue RequestQueue) *DefaultClientDispatcher {
 	}
 }
 
-func (d *DefaultClientDispatcher) SetOnRequestCanceled(cb func(string, string, ocpp.Request)) {
+func (d *DefaultClientDispatcher) SetOnRequestCanceled(cb CanceledRequestHandler) {
 	d.onRequestCancel = cb
 }
 


### PR DESCRIPTION
Without this, any `endpoint` passed into `NewChargePoint` doesn't have the request canceled handler set.