### PR TITLE
Run websocket newClientHandler before starting pump goroutines

### DIFF
--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -436,12 +436,12 @@ func (server *Server) wsHandler(w http.ResponseWriter, r *http.Request) {
 	server.connections[ws.id] = &ws
 	server.connMutex.Unlock()
 	// Read and write routines are started in separate goroutines and function will return immediately
-	go server.writePump(&ws)
-	go server.readPump(&ws)
 	if server.newClientHandler != nil {
 		var channel Channel = &ws
 		server.newClientHandler(channel)
 	}
+	go server.writePump(&ws)
+	go server.readPump(&ws)
 }
 
 func (server *Server) readPump(ws *WebSocket) {


### PR DESCRIPTION
I think the expected behavior is to have `newClientHandler` finish running before requests and responses start coming, which isn't a given without this PR.