### PR TITLE
feat(spec): Don't omit empty string Values

### DIFF
--- a/ocpp1.6/core/get_configuration.go
+++ b/ocpp1.6/core/get_configuration.go
@@ -10,9 +10,9 @@ const GetConfigurationFeatureName = "GetConfiguration"
 
 // Contains information about a specific configuration key. It is returned in GetConfigurationConfirmation
 type ConfigurationKey struct {
-	Key      string `json:"key" validate:"required,max=50"`
-	Readonly bool   `json:"readonly"`
-	Value    string `json:"value,omitempty" validate:"max=500"`
+	Key      string  `json:"key" validate:"required,max=50"`
+	Readonly bool    `json:"readonly"`
+	Value    *string `json:"value,omitempty" validate:"max=500"`
 }
 
 // The field definition of the GetConfiguration request payload sent by the Central System to the Charge Point.


### PR DESCRIPTION
To omit a value means the key is known but not set whereas an empty
string may have a semantic value.