### PR TITLE
Fix cp 1.6 example with pointer config values

### DIFF
--- a/example/1.6/cp/config.go
+++ b/example/1.6/cp/config.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/localauth"
@@ -9,7 +11,6 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/reservation"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/smartcharging"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"strconv"
 )
 
 const (
@@ -49,7 +50,7 @@ type ConfigMap map[string]core.ConfigurationKey
 func (c ConfigMap) updateInt(key string, i int64) {
 	configKey, ok := c[key]
 	if ok {
-		configKey.Value = strconv.FormatInt(i, 10)
+		configKey.Value = newString(strconv.FormatInt(i, 10))
 	}
 	c[key] = configKey
 }
@@ -57,7 +58,7 @@ func (c ConfigMap) updateInt(key string, i int64) {
 func (c ConfigMap) updateBool(key string, b bool) {
 	configKey, ok := c[key]
 	if ok {
-		configKey.Value = strconv.FormatBool(b)
+		configKey.Value = newString(strconv.FormatBool(b))
 	}
 	c[key] = configKey
 }
@@ -67,7 +68,7 @@ func (c ConfigMap) getInt(key string) (int, bool) {
 	if !ok {
 		return 0, ok
 	}
-	result, err := strconv.ParseInt(configKey.Value, 10, 32)
+	result, err := strconv.ParseInt(*configKey.Value, 10, 32)
 	if err != nil {
 		return 0, false
 	}
@@ -79,44 +80,48 @@ func (c ConfigMap) getBool(key string) (bool, bool) {
 	if !ok {
 		return false, ok
 	}
-	result, err := strconv.ParseBool(configKey.Value)
+	result, err := strconv.ParseBool(*configKey.Value)
 	if err != nil {
 		return false, false
 	}
 	return result, true
 }
 
+func newString(s string) *string {
+	return &s
+}
+
 func getDefaultConfig() ConfigMap {
 	intBase := 10
 	cfg := map[string]core.ConfigurationKey{}
-	cfg[AuthorizeRemoteTxRequests] = core.ConfigurationKey{Key: AuthorizeRemoteTxRequests, Readonly: true, Value: strconv.FormatBool(false)}
-	cfg[ClockAlignedDataInterval] = core.ConfigurationKey{Key: ClockAlignedDataInterval, Readonly: false, Value: strconv.FormatInt(0, intBase)}
-	cfg[ConnectionTimeOut] = core.ConfigurationKey{Key: ConnectionTimeOut, Readonly: false, Value: strconv.FormatInt(60, intBase)}
-	cfg[ConnectorPhaseRotation] = core.ConfigurationKey{Key: ConnectorPhaseRotation, Readonly: false, Value: "Unknown"}
-	cfg[GetConfigurationMaxKeys] = core.ConfigurationKey{Key: GetConfigurationMaxKeys, Readonly: true, Value: strconv.FormatInt(50, intBase)}
-	cfg[HeartbeatInterval] = core.ConfigurationKey{Key: HeartbeatInterval, Readonly: false, Value: strconv.FormatInt(86400, intBase)}
-	cfg[LocalAuthorizeOffline] = core.ConfigurationKey{Key: LocalAuthorizeOffline, Readonly: false, Value: strconv.FormatBool(true)}
-	cfg[LocalPreAuthorize] = core.ConfigurationKey{Key: LocalPreAuthorize, Readonly: false, Value: strconv.FormatBool(false)}
-	cfg[MeterValuesAlignedData] = core.ConfigurationKey{Key: MeterValuesAlignedData, Readonly: false, Value: string(types.MeasurandEnergyActiveExportRegister)}
-	cfg[MeterValuesSampledData] = core.ConfigurationKey{Key: MeterValuesSampledData, Readonly: false, Value: string(types.MeasurandEnergyActiveExportRegister)}
-	cfg[MeterValueSampleInterval] = core.ConfigurationKey{Key: MeterValueSampleInterval, Readonly: false, Value: strconv.FormatInt(5, intBase)}
-	cfg[NumberOfConnectors] = core.ConfigurationKey{Key: NumberOfConnectors, Readonly: true, Value: strconv.FormatInt(1, intBase)}
-	cfg[ResetRetries] = core.ConfigurationKey{Key: ResetRetries, Readonly: false, Value: strconv.FormatInt(10, intBase)}
-	cfg[StopTransactionOnEVSideDisconnect] = core.ConfigurationKey{Key: StopTransactionOnEVSideDisconnect, Readonly: false, Value: strconv.FormatBool(true)}
-	cfg[StopTransactionOnInvalidId] = core.ConfigurationKey{Key: StopTransactionOnInvalidId, Readonly: false, Value: strconv.FormatBool(true)}
-	cfg[StopTxnAlignedData] = core.ConfigurationKey{Key: StopTxnAlignedData, Readonly: false, Value: strconv.FormatBool(true)}
-	cfg[StopTxnSampledData] = core.ConfigurationKey{Key: StopTxnSampledData, Readonly: false, Value: string(types.MeasurandEnergyActiveExportRegister)}
-	cfg[SupportedFeatureProfiles] = core.ConfigurationKey{Key: SupportedFeatureProfiles, Readonly: true, Value: fmt.Sprintf("%v,%v,%v,%v,%v,%v", core.ProfileName, firmware.ProfileName, localauth.ProfileName, reservation.ProfileName, remotetrigger.ProfileName, smartcharging.ProfileName)}
-	cfg[TransactionMessageAttempts] = core.ConfigurationKey{Key: TransactionMessageAttempts, Readonly: false, Value: strconv.FormatInt(5, intBase)}
-	cfg[TransactionMessageRetryInterval] = core.ConfigurationKey{Key: TransactionMessageRetryInterval, Readonly: false, Value: strconv.FormatInt(60, intBase)}
-	cfg[UnlockConnectorOnEVSideDisconnect] = core.ConfigurationKey{Key: UnlockConnectorOnEVSideDisconnect, Readonly: false, Value: strconv.FormatBool(true)}
-	cfg[WebSocketPingInterval] = core.ConfigurationKey{Key: WebSocketPingInterval, Readonly: false, Value: strconv.FormatInt(54, intBase)}
-	cfg[LocalAuthListEnabled] = core.ConfigurationKey{Key: LocalAuthListEnabled, Readonly: false, Value: strconv.FormatBool(true)}
-	cfg[LocalAuthListMaxLength] = core.ConfigurationKey{Key: LocalAuthListMaxLength, Readonly: true, Value: strconv.FormatInt(100, intBase)}
-	cfg[SendLocalListMaxLength] = core.ConfigurationKey{Key: SendLocalListMaxLength, Readonly: true, Value: strconv.FormatInt(20, intBase)}
-	cfg[ChargeProfileMaxStackLevel] = core.ConfigurationKey{Key: ChargeProfileMaxStackLevel, Readonly: true, Value: strconv.FormatInt(10, intBase)}
-	cfg[ChargingScheduleAllowedChargingRateUnit] = core.ConfigurationKey{Key: ChargingScheduleAllowedChargingRateUnit, Readonly: true, Value: "Power"}
-	cfg[ChargingScheduleMaxPeriods] = core.ConfigurationKey{Key: ChargingScheduleMaxPeriods, Readonly: true, Value: strconv.FormatInt(5, intBase)}
-	cfg[MaxChargingProfilesInstalled] = core.ConfigurationKey{Key: MaxChargingProfilesInstalled, Readonly: true, Value: strconv.FormatInt(10, intBase)}
+	cfg[AuthorizeRemoteTxRequests] = core.ConfigurationKey{Key: AuthorizeRemoteTxRequests, Readonly: true, Value: newString(strconv.FormatBool(false))}
+	cfg[ClockAlignedDataInterval] = core.ConfigurationKey{Key: ClockAlignedDataInterval, Readonly: false, Value: newString(strconv.FormatInt(0, intBase))}
+	cfg[ConnectionTimeOut] = core.ConfigurationKey{Key: ConnectionTimeOut, Readonly: false, Value: newString(strconv.FormatInt(60, intBase))}
+	cfg[ConnectorPhaseRotation] = core.ConfigurationKey{Key: ConnectorPhaseRotation, Readonly: false, Value: newString("Unknown")}
+	cfg[GetConfigurationMaxKeys] = core.ConfigurationKey{Key: GetConfigurationMaxKeys, Readonly: true, Value: newString(strconv.FormatInt(50, intBase))}
+	cfg[HeartbeatInterval] = core.ConfigurationKey{Key: HeartbeatInterval, Readonly: false, Value: newString(strconv.FormatInt(86400, intBase))}
+	cfg[LocalAuthorizeOffline] = core.ConfigurationKey{Key: LocalAuthorizeOffline, Readonly: false, Value: newString(strconv.FormatBool(true))}
+	cfg[LocalPreAuthorize] = core.ConfigurationKey{Key: LocalPreAuthorize, Readonly: false, Value: newString(strconv.FormatBool(false))}
+	cfg[MeterValuesAlignedData] = core.ConfigurationKey{Key: MeterValuesAlignedData, Readonly: false, Value: newString(string(types.MeasurandEnergyActiveExportRegister))}
+	cfg[MeterValuesSampledData] = core.ConfigurationKey{Key: MeterValuesSampledData, Readonly: false, Value: newString(string(types.MeasurandEnergyActiveExportRegister))}
+	cfg[MeterValueSampleInterval] = core.ConfigurationKey{Key: MeterValueSampleInterval, Readonly: false, Value: newString(strconv.FormatInt(5, intBase))}
+	cfg[NumberOfConnectors] = core.ConfigurationKey{Key: NumberOfConnectors, Readonly: true, Value: newString(strconv.FormatInt(1, intBase))}
+	cfg[ResetRetries] = core.ConfigurationKey{Key: ResetRetries, Readonly: false, Value: newString(strconv.FormatInt(10, intBase))}
+	cfg[StopTransactionOnEVSideDisconnect] = core.ConfigurationKey{Key: StopTransactionOnEVSideDisconnect, Readonly: false, Value: newString(strconv.FormatBool(true))}
+	cfg[StopTransactionOnInvalidId] = core.ConfigurationKey{Key: StopTransactionOnInvalidId, Readonly: false, Value: newString(strconv.FormatBool(true))}
+	cfg[StopTxnAlignedData] = core.ConfigurationKey{Key: StopTxnAlignedData, Readonly: false, Value: newString(strconv.FormatBool(true))}
+	cfg[StopTxnSampledData] = core.ConfigurationKey{Key: StopTxnSampledData, Readonly: false, Value: newString(string(types.MeasurandEnergyActiveExportRegister))}
+	cfg[SupportedFeatureProfiles] = core.ConfigurationKey{Key: SupportedFeatureProfiles, Readonly: true, Value: newString(fmt.Sprintf("%v,%v,%v,%v,%v,%v", core.ProfileName, firmware.ProfileName, localauth.ProfileName, reservation.ProfileName, remotetrigger.ProfileName, smartcharging.ProfileName))}
+	cfg[TransactionMessageAttempts] = core.ConfigurationKey{Key: TransactionMessageAttempts, Readonly: false, Value: newString(strconv.FormatInt(5, intBase))}
+	cfg[TransactionMessageRetryInterval] = core.ConfigurationKey{Key: TransactionMessageRetryInterval, Readonly: false, Value: newString(strconv.FormatInt(60, intBase))}
+	cfg[UnlockConnectorOnEVSideDisconnect] = core.ConfigurationKey{Key: UnlockConnectorOnEVSideDisconnect, Readonly: false, Value: newString(strconv.FormatBool(true))}
+	cfg[WebSocketPingInterval] = core.ConfigurationKey{Key: WebSocketPingInterval, Readonly: false, Value: newString(strconv.FormatInt(54, intBase))}
+	cfg[LocalAuthListEnabled] = core.ConfigurationKey{Key: LocalAuthListEnabled, Readonly: false, Value: newString(strconv.FormatBool(true))}
+	cfg[LocalAuthListMaxLength] = core.ConfigurationKey{Key: LocalAuthListMaxLength, Readonly: true, Value: newString(strconv.FormatInt(100, intBase))}
+	cfg[SendLocalListMaxLength] = core.ConfigurationKey{Key: SendLocalListMaxLength, Readonly: true, Value: newString(strconv.FormatInt(20, intBase))}
+	cfg[ChargeProfileMaxStackLevel] = core.ConfigurationKey{Key: ChargeProfileMaxStackLevel, Readonly: true, Value: newString(strconv.FormatInt(10, intBase))}
+	cfg[ChargingScheduleAllowedChargingRateUnit] = core.ConfigurationKey{Key: ChargingScheduleAllowedChargingRateUnit, Readonly: true, Value: newString("Power")}
+	cfg[ChargingScheduleMaxPeriods] = core.ConfigurationKey{Key: ChargingScheduleMaxPeriods, Readonly: true, Value: newString(strconv.FormatInt(5, intBase))}
+	cfg[MaxChargingProfilesInstalled] = core.ConfigurationKey{Key: MaxChargingProfilesInstalled, Readonly: true, Value: newString(strconv.FormatInt(10, intBase))}
 	return cfg
 }

--- a/example/1.6/cp/handler.go
+++ b/example/1.6/cp/handler.go
@@ -72,7 +72,7 @@ func (handler *ChargePointHandler) OnChangeConfiguration(request *core.ChangeCon
 		logDefault(request.GetFeatureName()).Errorf("couldn't change configuration for readonly parameter %v", configKey.Key)
 		return core.NewChangeConfigurationConfirmation(core.ConfigurationStatusRejected), nil
 	}
-	configKey.Value = request.Value
+	configKey.Value = &request.Value
 	handler.configuration[request.Key] = configKey
 	logDefault(request.GetFeatureName()).Infof("changed configuration for parameter %v to %v", configKey.Key, configKey.Value)
 	return core.NewChangeConfigurationConfirmation(core.ConfigurationStatusAccepted), nil
@@ -94,7 +94,7 @@ func (handler *ChargePointHandler) OnGetConfiguration(request *core.GetConfigura
 	for _, key := range request.Key {
 		configKey, ok := handler.configuration[key]
 		if !ok {
-			unknownKeys = append(unknownKeys, configKey.Value)
+			unknownKeys = append(unknownKeys, *configKey.Value)
 		} else {
 			resultKeys = append(resultKeys, configKey)
 		}


### PR DESCRIPTION
Follow-up on https://github.com/lorenzodonini/ocpp-go/pull/88, which broke the charge point example for v1.6