### PR TITLE
Test closing a websocket connection on server side

### DIFF
--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -171,7 +171,7 @@ type WsServer interface {
 	// Shuts down a running websocket server.
 	// All open channels will be forcefully closed, and the previously called Start function will return.
 	Stop()
-	// Closes a specific websocket connection
+	// Closes a specific websocket connection.
 	StopConnection(id string, closeError websocket.CloseError) error
 	// Errors returns a channel for error messages. If it doesn't exist it es created.
 	// The channel is closed by the server when stopped.


### PR DESCRIPTION
Follow-up of https://github.com/lorenzodonini/ocpp-go/pull/83.

Add test for closing client websocket connection from `ws.WsServer`, using the new `StopConnection` method.