### PR TITLE
Refactor websocket close logic

### DIFF
--- a/ocpp1.6/core/get_configuration.go
+++ b/ocpp1.6/core/get_configuration.go
@@ -62,7 +62,7 @@ func NewGetConfigurationRequest(keys []string) *GetConfigurationRequest {
 	return &GetConfigurationRequest{Key: keys}
 }
 
-// Creates a new ClearCacheConfirmation, containing all required fields. Optional fields may be set afterwards.
+// Creates a new GetConfigurationConfirmation, containing all required fields. Optional fields may be set afterwards.
 func NewGetConfigurationConfirmation(configurationKey []ConfigurationKey) *GetConfigurationConfirmation {
 	return &GetConfigurationConfirmation{ConfigurationKey: configurationKey}
 }


### PR DESCRIPTION
- Fixes potential deadlocks and panics, that may occur when closing websockets
- Streamlines websocket close logic for client and server
- Gracefully closes all clients, after calling `Stop` on the websocket server
- Fixed typos in documentation