### PR TITLE
Improve websocket subprotocol checks

### DIFF
--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -427,12 +427,6 @@ out:
 	// Handle client authentication
 	if server.basicAuthHandler != nil {
 		username, password, ok := r.BasicAuth()
-		if !ok {
-			server.error(fmt.Errorf("basic auth failed: credentials not found"))
-			w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
 		ok = server.basicAuthHandler(username, password)
 		if !ok {
 			server.error(fmt.Errorf("basic auth failed: credentials invalid"))


### PR DESCRIPTION
- Subprotocols are now correctly handled and enforced by the server, 
- New connections with unsupported subprotocol now get closed only after completing the handshake