### PR TITLE
Make ConfigurationKey struct's ReadOnly element as required param

### DIFF
--- a/ocpp1.6/core/get_configuration.go
+++ b/ocpp1.6/core/get_configuration.go
@@ -11,7 +11,7 @@ const GetConfigurationFeatureName = "GetConfiguration"
 // Contains information about a specific configuration key. It is returned in GetConfigurationConfirmation
 type ConfigurationKey struct {
 	Key      string  `json:"key" validate:"required,max=50"`
-	Readonly bool    `json:"readonly"`
+	Readonly bool    `json:"readonly" validate:"required,max=5"`
 	Value    *string `json:"value,omitempty" validate:"max=500"`
 }
 


### PR DESCRIPTION
Fixes #108

Makes `ConfigurationKey` struct's `ReadOnly` element as required param

Signed-off-by: Utsav Anand <utsavanand2@gmail.com>
