### PR TITLE
Fix send on closed channel with ws.Client.Stop

### DIFF
--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -943,11 +943,16 @@ func (client *Client) Start(urlStr string) error {
 }
 
 func (client *Client) Stop() {
-	if client.IsConnected() {
-		client.setConnected(false)
+	client.mutex.Lock()
+	if client.connected {
+		client.connected = false
 		// Send signal for gracefully shutting down the connection
-		client.webSocket.closeC <- websocket.CloseError{Code: websocket.CloseNormalClosure, Text: ""}
+		select {
+		case client.webSocket.closeC <- websocket.CloseError{Code: websocket.CloseNormalClosure, Text: ""}:
+		default:
+		}
 	}
+	client.mutex.Unlock()
 	// Notify reconnection goroutine to stop (if any)
 	close(client.reconnectC)
 	if client.errC != nil {


### PR DESCRIPTION
We need to send the error in a critical section, otherwise it races with `Client.cleanup`.