### PR TITLE
Use contexts to pop requests when a msg at context.Done is received

### DIFF
--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -1,6 +1,7 @@
 package ocpp16
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/lorenzodonini/ocpp-go/internal/callbackqueue"
@@ -51,7 +52,7 @@ func (cs *centralSystem) Errors() <-chan error {
 	return cs.errC
 }
 
-func (cs *centralSystem) ChangeAvailability(clientId string, callback func(confirmation *core.ChangeAvailabilityConfirmation, err error), connectorId int, availabilityType core.AvailabilityType, props ...func(request *core.ChangeAvailabilityRequest)) error {
+func (cs *centralSystem) ChangeAvailability(ctx context.Context, clientId string, callback func(confirmation *core.ChangeAvailabilityConfirmation, err error), connectorId int, availabilityType core.AvailabilityType, props ...func(request *core.ChangeAvailabilityRequest)) error {
 	request := core.NewChangeAvailabilityRequest(connectorId, availabilityType)
 	for _, fn := range props {
 		fn(request)
@@ -63,10 +64,10 @@ func (cs *centralSystem) ChangeAvailability(clientId string, callback func(confi
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) ChangeConfiguration(clientId string, callback func(confirmation *core.ChangeConfigurationConfirmation, err error), key string, value string, props ...func(request *core.ChangeConfigurationRequest)) error {
+func (cs *centralSystem) ChangeConfiguration(ctx context.Context, clientId string, callback func(confirmation *core.ChangeConfigurationConfirmation, err error), key string, value string, props ...func(request *core.ChangeConfigurationRequest)) error {
 	request := core.NewChangeConfigurationRequest(key, value)
 	for _, fn := range props {
 		fn(request)
@@ -78,10 +79,10 @@ func (cs *centralSystem) ChangeConfiguration(clientId string, callback func(conf
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) ClearCache(clientId string, callback func(confirmation *core.ClearCacheConfirmation, err error), props ...func(*core.ClearCacheRequest)) error {
+func (cs *centralSystem) ClearCache(ctx context.Context, clientId string, callback func(confirmation *core.ClearCacheConfirmation, err error), props ...func(*core.ClearCacheRequest)) error {
 	request := core.NewClearCacheRequest()
 	for _, fn := range props {
 		fn(request)
@@ -93,10 +94,10 @@ func (cs *centralSystem) ClearCache(clientId string, callback func(confirmation 
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) DataTransfer(clientId string, callback func(confirmation *core.DataTransferConfirmation, err error), vendorId string, props ...func(request *core.DataTransferRequest)) error {
+func (cs *centralSystem) DataTransfer(ctx context.Context, clientId string, callback func(confirmation *core.DataTransferConfirmation, err error), vendorId string, props ...func(request *core.DataTransferRequest)) error {
 	request := core.NewDataTransferRequest(vendorId)
 	for _, fn := range props {
 		fn(request)
@@ -108,10 +109,10 @@ func (cs *centralSystem) DataTransfer(clientId string, callback func(confirmatio
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) GetConfiguration(clientId string, callback func(confirmation *core.GetConfigurationConfirmation, err error), keys []string, props ...func(request *core.GetConfigurationRequest)) error {
+func (cs *centralSystem) GetConfiguration(ctx context.Context, clientId string, callback func(confirmation *core.GetConfigurationConfirmation, err error), keys []string, props ...func(request *core.GetConfigurationRequest)) error {
 	request := core.NewGetConfigurationRequest(keys)
 	for _, fn := range props {
 		fn(request)
@@ -123,10 +124,10 @@ func (cs *centralSystem) GetConfiguration(clientId string, callback func(confirm
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) RemoteStartTransaction(clientId string, callback func(*core.RemoteStartTransactionConfirmation, error), idTag string, props ...func(*core.RemoteStartTransactionRequest)) error {
+func (cs *centralSystem) RemoteStartTransaction(ctx context.Context, clientId string, callback func(*core.RemoteStartTransactionConfirmation, error), idTag string, props ...func(*core.RemoteStartTransactionRequest)) error {
 	request := core.NewRemoteStartTransactionRequest(idTag)
 	for _, fn := range props {
 		fn(request)
@@ -138,10 +139,10 @@ func (cs *centralSystem) RemoteStartTransaction(clientId string, callback func(*
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) RemoteStopTransaction(clientId string, callback func(*core.RemoteStopTransactionConfirmation, error), transactionId int, props ...func(request *core.RemoteStopTransactionRequest)) error {
+func (cs *centralSystem) RemoteStopTransaction(ctx context.Context, clientId string, callback func(*core.RemoteStopTransactionConfirmation, error), transactionId int, props ...func(request *core.RemoteStopTransactionRequest)) error {
 	request := core.NewRemoteStopTransactionRequest(transactionId)
 	for _, fn := range props {
 		fn(request)
@@ -153,10 +154,10 @@ func (cs *centralSystem) RemoteStopTransaction(clientId string, callback func(*c
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) Reset(clientId string, callback func(*core.ResetConfirmation, error), resetType core.ResetType, props ...func(request *core.ResetRequest)) error {
+func (cs *centralSystem) Reset(ctx context.Context, clientId string, callback func(*core.ResetConfirmation, error), resetType core.ResetType, props ...func(request *core.ResetRequest)) error {
 	request := core.NewResetRequest(resetType)
 	for _, fn := range props {
 		fn(request)
@@ -168,10 +169,10 @@ func (cs *centralSystem) Reset(clientId string, callback func(*core.ResetConfirm
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) UnlockConnector(clientId string, callback func(*core.UnlockConnectorConfirmation, error), connectorId int, props ...func(*core.UnlockConnectorRequest)) error {
+func (cs *centralSystem) UnlockConnector(ctx context.Context, clientId string, callback func(*core.UnlockConnectorConfirmation, error), connectorId int, props ...func(*core.UnlockConnectorRequest)) error {
 	request := core.NewUnlockConnectorRequest(connectorId)
 	for _, fn := range props {
 		fn(request)
@@ -183,10 +184,10 @@ func (cs *centralSystem) UnlockConnector(clientId string, callback func(*core.Un
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) GetLocalListVersion(clientId string, callback func(*localauth.GetLocalListVersionConfirmation, error), props ...func(request *localauth.GetLocalListVersionRequest)) error {
+func (cs *centralSystem) GetLocalListVersion(ctx context.Context, clientId string, callback func(*localauth.GetLocalListVersionConfirmation, error), props ...func(request *localauth.GetLocalListVersionRequest)) error {
 	request := localauth.NewGetLocalListVersionRequest()
 	for _, fn := range props {
 		fn(request)
@@ -198,10 +199,10 @@ func (cs *centralSystem) GetLocalListVersion(clientId string, callback func(*loc
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) SendLocalList(clientId string, callback func(*localauth.SendLocalListConfirmation, error), version int, updateType localauth.UpdateType, props ...func(request *localauth.SendLocalListRequest)) error {
+func (cs *centralSystem) SendLocalList(ctx context.Context, clientId string, callback func(*localauth.SendLocalListConfirmation, error), version int, updateType localauth.UpdateType, props ...func(request *localauth.SendLocalListRequest)) error {
 	request := localauth.NewSendLocalListRequest(version, updateType)
 	for _, fn := range props {
 		fn(request)
@@ -213,10 +214,10 @@ func (cs *centralSystem) SendLocalList(clientId string, callback func(*localauth
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) GetDiagnostics(clientId string, callback func(*firmware.GetDiagnosticsConfirmation, error), location string, props ...func(request *firmware.GetDiagnosticsRequest)) error {
+func (cs *centralSystem) GetDiagnostics(ctx context.Context, clientId string, callback func(*firmware.GetDiagnosticsConfirmation, error), location string, props ...func(request *firmware.GetDiagnosticsRequest)) error {
 	request := firmware.NewGetDiagnosticsRequest(location)
 	for _, fn := range props {
 		fn(request)
@@ -228,10 +229,10 @@ func (cs *centralSystem) GetDiagnostics(clientId string, callback func(*firmware
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) UpdateFirmware(clientId string, callback func(*firmware.UpdateFirmwareConfirmation, error), location string, retrieveDate *types.DateTime, props ...func(request *firmware.UpdateFirmwareRequest)) error {
+func (cs *centralSystem) UpdateFirmware(ctx context.Context, clientId string, callback func(*firmware.UpdateFirmwareConfirmation, error), location string, retrieveDate *types.DateTime, props ...func(request *firmware.UpdateFirmwareRequest)) error {
 	request := firmware.NewUpdateFirmwareRequest(location, retrieveDate)
 	for _, fn := range props {
 		fn(request)
@@ -243,10 +244,10 @@ func (cs *centralSystem) UpdateFirmware(clientId string, callback func(*firmware
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) ReserveNow(clientId string, callback func(*reservation.ReserveNowConfirmation, error), connectorId int, expiryDate *types.DateTime, idTag string, reservationId int, props ...func(request *reservation.ReserveNowRequest)) error {
+func (cs *centralSystem) ReserveNow(ctx context.Context, clientId string, callback func(*reservation.ReserveNowConfirmation, error), connectorId int, expiryDate *types.DateTime, idTag string, reservationId int, props ...func(request *reservation.ReserveNowRequest)) error {
 	request := reservation.NewReserveNowRequest(connectorId, expiryDate, idTag, reservationId)
 	for _, fn := range props {
 		fn(request)
@@ -258,10 +259,10 @@ func (cs *centralSystem) ReserveNow(clientId string, callback func(*reservation.
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) CancelReservation(clientId string, callback func(*reservation.CancelReservationConfirmation, error), reservationId int, props ...func(request *reservation.CancelReservationRequest)) error {
+func (cs *centralSystem) CancelReservation(ctx context.Context, clientId string, callback func(*reservation.CancelReservationConfirmation, error), reservationId int, props ...func(request *reservation.CancelReservationRequest)) error {
 	request := reservation.NewCancelReservationRequest(reservationId)
 	for _, fn := range props {
 		fn(request)
@@ -273,10 +274,10 @@ func (cs *centralSystem) CancelReservation(clientId string, callback func(*reser
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) TriggerMessage(clientId string, callback func(*remotetrigger.TriggerMessageConfirmation, error), requestedMessage remotetrigger.MessageTrigger, props ...func(request *remotetrigger.TriggerMessageRequest)) error {
+func (cs *centralSystem) TriggerMessage(ctx context.Context, clientId string, callback func(*remotetrigger.TriggerMessageConfirmation, error), requestedMessage remotetrigger.MessageTrigger, props ...func(request *remotetrigger.TriggerMessageRequest)) error {
 	request := remotetrigger.NewTriggerMessageRequest(requestedMessage)
 	for _, fn := range props {
 		fn(request)
@@ -288,10 +289,10 @@ func (cs *centralSystem) TriggerMessage(clientId string, callback func(*remotetr
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) SetChargingProfile(clientId string, callback func(*smartcharging.SetChargingProfileConfirmation, error), connectorId int, chargingProfile *types.ChargingProfile, props ...func(request *smartcharging.SetChargingProfileRequest)) error {
+func (cs *centralSystem) SetChargingProfile(ctx context.Context, clientId string, callback func(*smartcharging.SetChargingProfileConfirmation, error), connectorId int, chargingProfile *types.ChargingProfile, props ...func(request *smartcharging.SetChargingProfileRequest)) error {
 	request := smartcharging.NewSetChargingProfileRequest(connectorId, chargingProfile)
 	for _, fn := range props {
 		fn(request)
@@ -303,10 +304,10 @@ func (cs *centralSystem) SetChargingProfile(clientId string, callback func(*smar
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) ClearChargingProfile(clientId string, callback func(*smartcharging.ClearChargingProfileConfirmation, error), props ...func(request *smartcharging.ClearChargingProfileRequest)) error {
+func (cs *centralSystem) ClearChargingProfile(ctx context.Context, clientId string, callback func(*smartcharging.ClearChargingProfileConfirmation, error), props ...func(request *smartcharging.ClearChargingProfileRequest)) error {
 	request := smartcharging.NewClearChargingProfileRequest()
 	for _, fn := range props {
 		fn(request)
@@ -318,10 +319,10 @@ func (cs *centralSystem) ClearChargingProfile(clientId string, callback func(*sm
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
-func (cs *centralSystem) GetCompositeSchedule(clientId string, callback func(*smartcharging.GetCompositeScheduleConfirmation, error), connectorId int, duration int, props ...func(request *smartcharging.GetCompositeScheduleRequest)) error {
+func (cs *centralSystem) GetCompositeSchedule(ctx context.Context, clientId string, callback func(*smartcharging.GetCompositeScheduleConfirmation, error), connectorId int, duration int, props ...func(request *smartcharging.GetCompositeScheduleRequest)) error {
 	request := smartcharging.NewGetCompositeScheduleRequest(connectorId, duration)
 	for _, fn := range props {
 		fn(request)
@@ -333,7 +334,7 @@ func (cs *centralSystem) GetCompositeSchedule(clientId string, callback func(*sm
 			callback(nil, protoError)
 		}
 	}
-	return cs.SendRequestAsync(clientId, request, genericCallback)
+	return cs.SendRequestAsync(ctx, clientId, request, genericCallback)
 }
 
 func (cs *centralSystem) SetCoreHandler(handler core.CentralSystemHandler) {
@@ -376,7 +377,7 @@ func (cs *centralSystem) SetChargePointDisconnectedHandler(handler ChargePointCo
 	})
 }
 
-func (cs *centralSystem) SendRequestAsync(clientId string, request ocpp.Request, callback func(confirmation ocpp.Response, err error)) error {
+func (cs *centralSystem) SendRequestAsync(ctx context.Context, clientId string, request ocpp.Request, callback func(confirmation ocpp.Response, err error)) error {
 	featureName := request.GetFeatureName()
 	if _, found := cs.server.GetProfileForFeature(featureName); !found {
 		return fmt.Errorf("feature %v is unsupported on central system (missing profile), cannot send request", featureName)
@@ -393,7 +394,7 @@ func (cs *centralSystem) SendRequestAsync(clientId string, request ocpp.Request,
 	}
 
 	send := func() error {
-		return cs.server.SendRequest(clientId, request)
+		return cs.server.SendRequestCtx(ctx, clientId, request)
 	}
 	return cs.callbackQueue.TryQueue(clientId, send, callback)
 }

--- a/ocpp1.6/charge_point.go
+++ b/ocpp1.6/charge_point.go
@@ -1,6 +1,7 @@
 package ocpp16
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/lorenzodonini/ocpp-go/internal/callbackqueue"
@@ -238,7 +239,7 @@ func (cp *chargePoint) SendRequest(request ocpp.Request) (ocpp.Response, error) 
 	}
 }
 
-func (cp *chargePoint) SendRequestAsync(request ocpp.Request, callback func(confirmation ocpp.Response, err error)) error {
+func (cp *chargePoint) SendRequestAsync(ctx context.Context, request ocpp.Request, callback func(confirmation ocpp.Response, err error)) error {
 	featureName := request.GetFeatureName()
 	if _, found := cp.client.GetProfileForFeature(featureName); !found {
 		return fmt.Errorf("feature %v is unsupported on charge point (missing profile), cannot send request", featureName)
@@ -252,7 +253,7 @@ func (cp *chargePoint) SendRequestAsync(request ocpp.Request, callback func(conf
 	}
 	// Response will be retrieved asynchronously via asyncHandler
 	send := func() error {
-		return cp.client.SendRequest(request)
+		return cp.client.SendRequestCtx(ctx, request)
 	}
 	err := cp.callbacks.TryQueue("main", send, callback)
 	return err

--- a/ocpp1.6_test/ocpp16_test.go
+++ b/ocpp1.6_test/ocpp16_test.go
@@ -1,6 +1,7 @@
 package ocpp16_test
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"reflect"
@@ -550,7 +551,7 @@ func testUnsupportedRequestFromChargePoint(suite *OcppV16TestSuite, request ocpp
 	err := suite.chargePoint.Start(wsUrl)
 	assert.Nil(t, err)
 	// Run request test, expecting an error
-	err = suite.chargePoint.SendRequestAsync(request, func(confirmation ocpp.Response, err error) {
+	err = suite.chargePoint.SendRequestAsync(context.Background(), request, func(confirmation ocpp.Response, err error) {
 		t.Fail()
 	})
 	assert.Error(t, err)

--- a/ocpp2.0.1/charging_station.go
+++ b/ocpp2.0.1/charging_station.go
@@ -1,6 +1,7 @@
 package ocpp2
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/lorenzodonini/ocpp-go/internal/callbackqueue"
@@ -489,7 +490,7 @@ func (cs *chargingStation) SendRequest(request ocpp.Request) (ocpp.Response, err
 	return asyncResult.r, asyncResult.e
 }
 
-func (cs *chargingStation) SendRequestAsync(request ocpp.Request, callback func(response ocpp.Response, err error)) error {
+func (cs *chargingStation) SendRequestAsync(ctx context.Context, request ocpp.Request, callback func(response ocpp.Response, err error)) error {
 	featureName := request.GetFeatureName()
 	if _, found := cs.client.GetProfileForFeature(featureName); !found {
 		return fmt.Errorf("feature %v is unsupported on charging station (missing profile), cannot send request", featureName)
@@ -526,7 +527,7 @@ func (cs *chargingStation) SendRequestAsync(request ocpp.Request, callback func(
 	}
 	// Response will be retrieved asynchronously via asyncHandler
 	send := func() error {
-		return cs.client.SendRequest(request)
+		return cs.client.SendRequestCtx(ctx, request)
 	}
 	err := cs.callbacks.TryQueue("main", send, callback)
 	return err

--- a/ocpp2.0.1/v2.go
+++ b/ocpp2.0.1/v2.go
@@ -2,6 +2,7 @@
 package ocpp2
 
 import (
+	"context"
 	"crypto/tls"
 
 	"github.com/gorilla/websocket"
@@ -150,7 +151,7 @@ type ChargingStation interface {
 	// This result is propagated via a callback, called asynchronously.
 	//
 	// In case of network issues (i.e. the remote host couldn't be reached), the function returns an error directly. In this case, the callback is never invoked.
-	SendRequestAsync(request ocpp.Request, callback func(confirmation ocpp.Response, protoError error)) error
+	SendRequestAsync(ctx context.Context, request ocpp.Request, callback func(confirmation ocpp.Response, protoError error)) error
 	// Connects to the CSMS and starts the charging station routine.
 	// The function doesn't block and returns right away, after having attempted to open a connection to the CSMS.
 	// If the connection couldn't be opened, an error is returned.

--- a/ocpp2.0.1_test/ocpp2_test.go
+++ b/ocpp2.0.1_test/ocpp2_test.go
@@ -1,6 +1,7 @@
 package ocpp2_test
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"reflect"
@@ -984,7 +985,7 @@ func testUnsupportedRequestFromChargingStation(suite *OcppV2TestSuite, request o
 	err := suite.chargingStation.Start(wsUrl)
 	require.Nil(t, err)
 	// Run request test
-	err = suite.chargingStation.SendRequestAsync(request, func(confirmation ocpp.Response, err error) {
+	err = suite.chargingStation.SendRequestAsync(context.Background(), request, func(confirmation ocpp.Response, err error) {
 		t.Fail()
 	})
 	require.Error(t, err)

--- a/ocppj/client.go
+++ b/ocppj/client.go
@@ -1,6 +1,7 @@
 package ocppj
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp"
@@ -108,7 +109,7 @@ func (c *Client) Stop() {
 // - the endpoint doesn't support the feature
 //
 // - the output queue is full
-func (c *Client) SendRequest(request ocpp.Request) error {
+func (c *Client) SendRequestCtx(ctx context.Context, request ocpp.Request) error {
 	if !c.dispatcher.IsRunning() {
 		return fmt.Errorf("ocppj client is not started, couldn't send request")
 	}
@@ -125,12 +126,16 @@ func (c *Client) SendRequest(request ocpp.Request) error {
 		return err
 	}
 	// Message will be processed by dispatcher. A dedicated mechanism allows to delegate the message queue handling.
-	if err := c.dispatcher.SendRequest(RequestBundle{Call: call, Data: jsonMessage}); err != nil {
+	if err := c.dispatcher.SendRequest(RequestBundle{Call: call, Data: jsonMessage, Ctx: ctx}); err != nil {
 		log.Errorf("request %v - %v: %v", call.UniqueId, call.Action, err)
 		return err
 	}
 	log.Debugf("enqueued request %v - %v", call.UniqueId, call.Action)
 	return nil
+}
+
+func (c *Client) SendRequest(request ocpp.Request) error {
+	return c.SendRequestCtx(context.Background(), request)
 }
 
 // Sends an OCPP Response to the server.
@@ -205,15 +210,23 @@ func (c *Client) ocppMessageHandler(data []byte) error {
 			c.requestHandler(call.Payload, call.UniqueId, call.Action)
 		case CALL_RESULT:
 			callResult := message.(*CallResult)
-			c.dispatcher.CompleteRequest(callResult.GetUniqueId()) // Remove current request from queue and send next one
-			if c.responseHandler != nil {
-				c.responseHandler(callResult.Payload, callResult.UniqueId)
+			done := c.dispatcher.CompleteRequest(callResult.GetUniqueId()) // Remove current request from queue and send next one
+			select {
+			case <-done:
+			default:
+				if c.responseHandler != nil {
+					c.responseHandler(callResult.Payload, callResult.UniqueId)
+				}
 			}
 		case CALL_ERROR:
 			callError := message.(*CallError)
-			c.dispatcher.CompleteRequest(callError.GetUniqueId()) // Remove current request from queue and send next one
-			if c.errorHandler != nil {
-				c.errorHandler(ocpp.NewError(callError.ErrorCode, callError.ErrorDescription, callError.UniqueId), callError.ErrorDetails)
+			done := c.dispatcher.CompleteRequest(callError.GetUniqueId()) // Remove current request from queue and send next one
+			select {
+			case <-done:
+			default:
+				if c.errorHandler != nil {
+					c.errorHandler(ocpp.NewError(callError.ErrorCode, callError.ErrorDescription, callError.UniqueId), callError.ErrorDetails)
+				}
 			}
 		}
 	}

--- a/ocppj/queue.go
+++ b/ocppj/queue.go
@@ -1,6 +1,7 @@
 package ocppj
 
 import (
+	"context"
 	"fmt"
 	"sync"
 )
@@ -10,6 +11,7 @@ import (
 type RequestBundle struct {
 	Call *Call
 	Data []byte
+	Ctx  context.Context
 }
 
 // RequestQueue can be arbitrarily implemented, as long as it conforms to the Queue interface.


### PR DESCRIPTION
Ref issue #66

Hi @lorenzodonini ! I created a PR for cancelling and removing request that originate from server to client, with ref to the in progress PR already done by @michaelbeaumont for cancelling requests. (Thanks Mike!).

I tried my changes with a Raspberry Pi that sleeps for 30 secs for some requests which is more than the timeout of the context that I pass with `context.WithTimeout()`. From the logs I can see the request getting removed, but for some reason the next requests still remain pending. I don't know what I'm missing, I'm fairly new to the library so I would really appreciate any guidance or help to make it better.

Thanks!

<img width="1066" alt="Screenshot 2021-08-13 at 7 47 19 PM" src="https://user-images.githubusercontent.com/25264581/129370972-cca9225f-6b63-4a38-9469-7cd3aed342ad.png">


Signed-off-by: Utsav Anand <utsavanand2@gmail.com>