### PR TITLE
Allow StopTransaction with negative meterStop

### DIFF
--- a/ocpp1.6/core/stop_transaction.go
+++ b/ocpp1.6/core/stop_transaction.go
@@ -1,9 +1,10 @@
 package core
 
 import (
+	"reflect"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"gopkg.in/go-playground/validator.v9"
-	"reflect"
 )
 
 // -------------------- Stop Transaction (CP -> CS) --------------------
@@ -40,7 +41,7 @@ func isValidReason(fl validator.FieldLevel) bool {
 // The field definition of the StopTransaction request payload sent by the Charge Point to the Central System.
 type StopTransactionRequest struct {
 	IdTag           string             `json:"idTag,omitempty" validate:"max=20"`
-	MeterStop       int                `json:"meterStop" validate:"gte=0"`
+	MeterStop       int                `json:"meterStop"`
 	Timestamp       *types.DateTime    `json:"timestamp" validate:"required"`
 	TransactionId   int                `json:"transactionId"`
 	Reason          Reason             `json:"reason,omitempty" validate:"omitempty,reason"`

--- a/ocpp1.6_test/stop_transaction_test.go
+++ b/ocpp1.6_test/stop_transaction_test.go
@@ -2,12 +2,13 @@ package ocpp16_test
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"time"
 )
 
 // Test
@@ -25,7 +26,6 @@ func (suite *OcppV16TestSuite) TestStopTransactionRequestValidation() {
 		{core.StopTransactionRequest{MeterStop: 100}, false},
 		{core.StopTransactionRequest{IdTag: "12345", MeterStop: 100, Timestamp: types.NewDateTime(time.Now()), TransactionId: 1, Reason: "invalidReason"}, false},
 		{core.StopTransactionRequest{IdTag: ">20..................", MeterStop: 100, Timestamp: types.NewDateTime(time.Now()), TransactionId: 1}, false},
-		{core.StopTransactionRequest{MeterStop: -1, Timestamp: types.NewDateTime(time.Now()), TransactionId: 1}, false},
 		{core.StopTransactionRequest{MeterStop: 100, Timestamp: types.NewDateTime(time.Now()), TransactionId: 1, TransactionData: []types.MeterValue{{Timestamp: types.NewDateTime(time.Now()), SampledValue: []types.SampledValue{}}}}, false},
 	}
 	ExecuteGenericTestTable(t, requestTable)


### PR DESCRIPTION
Some charging points send -1 there if the value is unknown. Definitely
unexpected, but I actually can't find anything in the spec that
excplicitly says that the value has to be positive (although it's
reasonable to expect it from a meter reading). In any case, the spec
explicitly says that the CS shouldn't reject a StopTransaction even if
sanity checks fail, and this validation prevents the ocpp-go user from
deciding for themselves.