### PR TITLE
Start websocket writePump before newClientHandler

### DIFF
--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -484,11 +484,11 @@ out:
 	server.connections[ws.id] = &ws
 	server.connMutex.Unlock()
 	// Read and write routines are started in separate goroutines and function will return immediately
+	go server.writePump(&ws)
 	if server.newClientHandler != nil {
 		var channel Channel = &ws
 		server.newClientHandler(channel)
 	}
-	go server.writePump(&ws)
 	go server.readPump(&ws)
 }
 

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -485,11 +485,11 @@ out:
 	server.connMutex.Unlock()
 	// Read and write routines are started in separate goroutines and function will return immediately
 	go server.writePump(&ws)
+	go server.readPump(&ws)
 	if server.newClientHandler != nil {
 		var channel Channel = &ws
 		server.newClientHandler(channel)
 	}
-	go server.readPump(&ws)
 }
 
 func (server *Server) readPump(ws *WebSocket) {


### PR DESCRIPTION
This fixes sending messages to the client by newClientHandler function.