### PR TITLE
Fix empty request and response bodies

### DIFF
--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -295,6 +295,9 @@ func (endpoint *Endpoint) GetProfileForFeature(featureName string) (*ocpp.Profil
 }
 
 func parseRawJsonRequest(raw interface{}, requestType reflect.Type) (ocpp.Request, error) {
+	if raw == nil {
+		raw = &struct{}{}
+	}
 	bytes, err := json.Marshal(raw)
 	if err != nil {
 		return nil, err
@@ -309,6 +312,9 @@ func parseRawJsonRequest(raw interface{}, requestType reflect.Type) (ocpp.Reques
 }
 
 func parseRawJsonConfirmation(raw interface{}, confirmationType reflect.Type) (ocpp.Response, error) {
+	if raw == nil {
+		raw = &struct{}{}
+	}
 	bytes, err := json.Marshal(raw)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I noticed some charge points send an empty body rather than an empty object '{}' for requests that do not have properties. E.g. Heartbeat.

This causes a panic in the library.
I fixed this by creating an empty object when the input is a nil pointer.