### PR TITLE
Fix nil pointer dereference on call error

### DIFF
--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -295,6 +295,9 @@ func (endpoint *Endpoint) GetProfileForFeature(featureName string) (*ocpp.Profil
 }
 
 func parseRawJsonRequest(raw interface{}, requestType reflect.Type) (ocpp.Request, error) {
+	if raw == nil {
+		raw = &struct{}{}
+	}
 	bytes, err := json.Marshal(raw)
 	if err != nil {
 		return nil, err
@@ -309,6 +312,9 @@ func parseRawJsonRequest(raw interface{}, requestType reflect.Type) (ocpp.Reques
 }
 
 func parseRawJsonConfirmation(raw interface{}, confirmationType reflect.Type) (ocpp.Response, error) {
+	if raw == nil {
+		raw = &struct{}{}
+	}
 	bytes, err := json.Marshal(raw)
 	if err != nil {
 		return nil, err

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -406,11 +406,15 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 		}
 		rawErrorCode := arr[2].(string)
 		errorCode := ocpp.ErrorCode(rawErrorCode)
+		errorDescription := ""
+		if arr[3] != nil {
+			errorDescription = arr[3].(string)
+		}
 		callError := CallError{
 			MessageTypeId:    CALL_ERROR,
 			UniqueId:         uniqueId,
 			ErrorCode:        errorCode,
-			ErrorDescription: arr[3].(string),
+			ErrorDescription: errorDescription,
 			ErrorDetails:     details,
 		}
 		err := Validate.Struct(callError)

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -407,8 +407,8 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 		rawErrorCode := arr[2].(string)
 		errorCode := ocpp.ErrorCode(rawErrorCode)
 		errorDescription := ""
-		if arr[3] != nil {
-			errorDescription = arr[3].(string)
+		if v, ok := arr[3].(string); ok {
+			errorDescription = v
 		}
 		callError := CallError{
 			MessageTypeId:    CALL_ERROR,


### PR DESCRIPTION
Fixes a panic for chargepoints that do not respond a valid errorDescription when issueing a faulty request.