### PR TITLE
Disable message validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,56 @@ Then run the following:
 docker-compose -f example/1.6/docker-compose.tls.yml up charge-point
 ```
 
+## Advanced Features
+
+The library offers several advanced features, especially at websocket and ocpp-j level.
+
+### Automatic message validation
+
+All incoming and outgoing messages are validated by default, using the [validator](gopkg.in/go-playground/validator) package.
+Constraints are defined on every request/response struct, as per OCPP specs.
+
+Validation may be disabled at a package level if needed:
+```go
+ocppj.SetMessageValidation(false)
+``` 
+
+Use at your own risk, as this will disable validation for all messages!
+
+> I will be evaluating the possibility to selectively disable validation for a specific message, 
+> e.g. by passing message options.
+
+### Verbose logging
+
+The `ws` and `ocppj` packages offer the possibility to enable verbose logs, via your logger of choice, e.g.:
+```go
+// Setup your own logger
+log = logrus.New()
+log.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+log.SetLevel(logrus.DebugLevel) // Debug level needed to see all logs
+// Pass own logger to ws and ocppj packages
+ws.SetLogger(log.WithField("logger", "websocket"))
+ocppj.SetLogger(log.WithField("logger", "ocppj"))
+```
+The logger you pass needs to conform to the `logging.Logger` interface.
+Commonly used logging libraries, such as zap or logrus, adhere to this interface out-of-the-box.
+
+If you are using a logger, that isn't conform, you can simply write an adapter between the `Logger` interface and your own logging system.
+
+### Websocket ping-pong
+
+The websocket package currently supports client-initiated pings only. 
+
+If your setup requires the server to be the initiator of a ping-pong (e.g. for web-based charge points),
+you may disable ping-pong entirely and just rely on the heartbeat mechanism:
+```go
+cfg := ws.NewServerTimeoutConfig()
+cfg.PingWait = 0 // this instructs the server to wait forever
+websocketServer.SetTimeoutConfig(cfg)
+```
+
+> A server-initiated ping may be supported in a future release.
+
 ## OCPP 2.0 Usage
 
 Documentation will follow, once the protocol is fully implemented.

--- a/ocppj/client.go
+++ b/ocppj/client.go
@@ -129,10 +129,6 @@ func (c *Client) SendRequest(request ocpp.Request) error {
 	if !c.dispatcher.IsRunning() {
 		return fmt.Errorf("ocppj client is not started, couldn't send request")
 	}
-	err := Validate.Struct(request)
-	if err != nil {
-		return err
-	}
 	call, err := c.CreateCall(request)
 	if err != nil {
 		return err
@@ -161,10 +157,6 @@ func (c *Client) SendRequest(request ocpp.Request) error {
 //
 // - a network error occurred
 func (c *Client) SendResponse(requestId string, response ocpp.Response) error {
-	err := Validate.Struct(response)
-	if err != nil {
-		return err
-	}
 	callResult, err := c.CreateCallResult(response, requestId)
 	if err != nil {
 		return err
@@ -190,8 +182,7 @@ func (c *Client) SendResponse(requestId string, response ocpp.Response) error {
 //
 // - a network error occurred
 func (c *Client) SendError(requestId string, errorCode ocpp.ErrorCode, description string, details interface{}) error {
-	callError := c.CreateCallError(requestId, errorCode, description, details)
-	err := Validate.Struct(callError)
+	callError, err := c.CreateCallError(requestId, errorCode, description, details)
 	if err != nil {
 		return err
 	}

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -492,7 +492,8 @@ func (suite *OcppJTestSuite) TestCreateCallError() {
 		DetailString string
 	}
 	mockDetails := MockDetails{DetailString: mockDetailString}
-	callError := suite.chargePoint.CreateCallError(mockUniqueId, ocppj.GenericError, mockDescription, mockDetails)
+	callError, err := suite.chargePoint.CreateCallError(mockUniqueId, ocppj.GenericError, mockDescription, mockDetails)
+	assert.Nil(t, err)
 	assert.NotNil(t, callError)
 	CheckCallError(t, callError, mockUniqueId, ocppj.GenericError, mockDescription, mockDetails)
 }

--- a/ocppj/server.go
+++ b/ocppj/server.go
@@ -129,10 +129,6 @@ func (s *Server) SendRequest(clientID string, request ocpp.Request) error {
 	if !s.dispatcher.IsRunning() {
 		return fmt.Errorf("ocppj server is not started, couldn't send request")
 	}
-	err := Validate.Struct(request)
-	if err != nil {
-		return err
-	}
 	call, err := s.CreateCall(request.(ocpp.Request))
 	if err != nil {
 		return err
@@ -161,10 +157,6 @@ func (s *Server) SendRequest(clientID string, request ocpp.Request) error {
 //
 // - a network error occurred
 func (s *Server) SendResponse(clientID string, requestId string, response ocpp.Response) error {
-	err := Validate.Struct(response)
-	if err != nil {
-		return err
-	}
 	callResult, err := s.CreateCallResult(response, requestId)
 	if err != nil {
 		return err
@@ -190,8 +182,7 @@ func (s *Server) SendResponse(clientID string, requestId string, response ocpp.R
 //
 // - a network error occurred
 func (s *Server) SendError(clientID string, requestId string, errorCode ocpp.ErrorCode, description string, details interface{}) error {
-	callError := s.CreateCallError(requestId, errorCode, description, details)
-	err := Validate.Struct(callError)
+	callError, err := s.CreateCallError(requestId, errorCode, description, details)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds the possibility to disable message validation at a package-level.

Validation can now be toggled with:
```go
ocppj.SetMessageValidation(false)
```

Closes #129