### PR TITLE
OCPP 2.0.1 examples

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ldonini/ocpp2.0.1-chargingstation:latest
+          tags: ldonini/ocpp2.0.1-charging-station:latest
           file: example/2.0.1/chargingstation/Dockerfile
           platforms: linux/amd64,linux/arm64
           context: .

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,24 +8,44 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - uses: docker/setup-buildx-action@v1
+        uses: actions/checkout@v3
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build Central System 1.6 example
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           tags: ldonini/ocpp1.6-central-system:latest
           file: example/1.6/cs/Dockerfile
+          platforms: linux/amd64,linux/arm64
           context: .
       - name: Build Charge Point 1.6 example
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           tags: ldonini/ocpp1.6-charge-point:latest
           file: example/1.6/cp/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          context: .
+      - name: Build CSMS 2.0.1 example
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ldonini/ocpp2.0.1-csms:latest
+          file: example/2.0.1/csms/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          context: .
+      - name: Build Charging Station 2.0.1 example
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ldonini/ocpp2.0.1-chargingstation:latest
+          file: example/2.0.1/chargingstation/Dockerfile
+          platforms: linux/amd64,linux/arm64
           context: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,9 @@ jobs:
         run: |
           go test ./ws ./ocppj -v -covermode=count -coverprofile=coverage.out
           go test -v -covermode=count -coverprofile=ocpp16.out -coverpkg=github.com/lorenzodonini/ocpp-go/ocpp1.6/... github.com/lorenzodonini/ocpp-go/ocpp1.6_test
-          go test -v -covermode=count -coverprofile=ocpp20.out -coverpkg=github.com/lorenzodonini/ocpp-go/ocpp2.0.1/... github.com/lorenzodonini/ocpp-go/ocpp2.0.1_test
+          go test -v -covermode=count -coverprofile=ocpp201.out -coverpkg=github.com/lorenzodonini/ocpp-go/ocpp2.0.1/... github.com/lorenzodonini/ocpp-go/ocpp2.0.1_test
           sed '1d;$d' ocpp16.out >> coverage.out
-          sed '1d;$d' ocpp20.out >> coverage.out
+          sed '1d;$d' ocpp201.out >> coverage.out
       - name: Publish coverage
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,24 +7,42 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - uses: docker/setup-buildx-action@v1
+        uses: actions/checkout@v3
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Release Central System 1.6 example
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           tags: ldonini/ocpp1.6-central-system:${{ github.event.release.tag_name }}
           file: example/1.6/cs/Dockerfile
           context: .
       - name: Release Charge Point 1.6 example
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           tags: ldonini/ocpp1.6-charge-point:${{ github.event.release.tag_name }}
           file: example/1.6/cp/Dockerfile
+          context: .
+      - name: Release CSMS 2.0.1 example
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ldonini/ocpp2.0.1-csms:${{ github.event.release.tag_name }}
+          file: example/2.0.1/csms/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          context: .
+      - name: Release charging station 2.0.1 example
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ldonini/ocpp2.0.1-chargingstation:${{ github.event.release.tag_name }}
+          file: example/2.0.1/chargingstation/Dockerfile
+          platforms: linux/amd64,linux/arm64
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: ldonini/ocpp2.0.1-chargingstation:${{ github.event.release.tag_name }}
+          tags: ldonini/ocpp2.0.1-charging-station:${{ github.event.release.tag_name }}
           file: example/2.0.1/chargingstation/Dockerfile
           platforms: linux/amd64,linux/arm64
           context: .

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ There are currently no plans of supporting OCPP-S.
 Planned milestones and features:
 
 - [x] OCPP 1.6
-- [ ] OCPP 2.0 
+- [x] OCPP 2.0.1 (examples working, but will need more real-world testing)
+- [ ] Dedicated package for configuration management
 
 ## OCPP 1.6 Usage
 
@@ -228,8 +229,9 @@ To send requests to the central station, you have two options. You may either us
 bootConf, err := chargePoint.BootNotification("model1", "vendor1")
 if err != nil {
 	log.Fatal(err)
+} else {
+	log.Printf("status: %v, interval: %v, current time: %v", bootConf.Status, bootConf.Interval, bootConf.CurrentTime.String())
 }
-log.Printf("status: %v, interval: %v, current time: %v", bootConf.Status, bootConf.Interval, bootConf.CurrentTime.String())
 // ... do something with the confirmation
 ```
 
@@ -357,6 +359,130 @@ websocketServer.SetTimeoutConfig(cfg)
 
 > A server-initiated ping may be supported in a future release.
 
-## OCPP 2.0 Usage
+## OCPP 2.0.1 Usage
 
-Documentation will follow, once the protocol is fully implemented.
+Experimental support for version 2.0.1 is now supported!
+
+> Version 2.0 was skipped entirely, since it is considered obsolete.
+
+Requests and responses in OCPP 2.0.1 are handled the same way they were in v1.6.
+The notable change is that there are now significantly more supported messages and profiles (feature sets), 
+which also require their own handlers to be implemented.
+
+The library API to the lower websocket and ocpp-j layers remains unchanged.
+
+Below are very minimal setup code snippets, to get you started.
+CSMS is now the equivalent of the Central System,
+while the Charging Station is the new equivalent of a Charge Point.
+
+Refer to the [examples folder](example/2.0.1) for a full working example.
+More in-depth documentation for v2.0.1 will follow.
+
+**Bug reports for this version are welcome.**
+
+### CSMS
+
+To start a CSMS instance, run the following:
+```go
+import "github.com/lorenzodonini/ocpp-go/ocpp2.0.1"
+
+csms := ocpp2.NewCSMS(nil, nil)
+
+// Set callback handlers for connect/disconnect
+csms.SetNewChargingStationHandler(func(chargingStation ocpp2.ChargingStationConnection) {
+	log.Printf("new charging station %v connected", chargingStation.ID())
+})
+csms.SetChargingStationDisconnectedHandler(func(chargingStation ocpp2.ChargingStationConnection) {
+	log.Printf("charging station %v disconnected", chargingStation.ID())
+})
+
+// Set handler for profile callbacks
+handler := &CSMSHandler{}
+csms.SetAuthorizationHandler(handler)
+csms.SetAvailabilityHandler(handler)
+csms.SetDiagnosticsHandler(handler)
+csms.SetFirmwareHandler(handler)
+csms.SetLocalAuthListHandler(handler)
+csms.SetMeterHandler(handler)
+csms.SetProvisioningHandler(handler)
+csms.SetRemoteControlHandler(handler)
+csms.SetReservationHandler(handler)
+csms.SetTariffCostHandler(handler)
+csms.SetTransactionsHandler(handler)
+
+// Start central system
+listenPort := 8887
+log.Printf("starting CSMS")
+csms.Start(listenPort, "/{ws}") // This call starts server in daemon mode and is blocking
+log.Println("stopped CSMS")
+```
+
+#### Sending requests
+
+Similarly to v1.6, you may send requests using the simplified API, e.g.
+```go
+err := csms.GetLocalListVersion(chargingStationID, myCallback)
+if err != nil {
+	log.Printf("error sending message: %v", err)
+}
+```
+
+Or you may build requests manually and send them using the asynchronous API.
+
+#### Docker image
+
+There is a Dockerfile and a docker image available upstream.
+Feel free 
+
+### Charging Station
+
+To start a charging station instance, simply run the following:
+```go
+chargingStationID := "cs0001"
+csmsUrl = "ws://localhost:8887"
+chargingStation := ocpp2.NewChargingStation(chargingStationID, nil, nil)
+
+// Set a handler for all callback functions
+handler := &ChargingStationHandler{}
+chargingStation.SetAvailabilityHandler(handler)
+chargingStation.SetAuthorizationHandler(handler)
+chargingStation.SetDataHandler(handler)
+chargingStation.SetDiagnosticsHandler(handler)
+chargingStation.SetDisplayHandler(handler)
+chargingStation.SetFirmwareHandler(handler)
+chargingStation.SetISO15118Handler(handler)
+chargingStation.SetLocalAuthListHandler(handler)
+chargingStation.SetProvisioningHandler(handler)
+chargingStation.SetRemoteControlHandler(handler)
+chargingStation.SetReservationHandler(handler)
+chargingStation.SetSmartChargingHandler(handler)
+chargingStation.SetTariffCostHandler(handler)
+chargingStation.SetTransactionsHandler(handler)
+
+// Connects to CSMS
+err := chargingStation.Start(csmsUrl)
+if err != nil {
+	log.Println(err)
+} else {
+	log.Printf("connected to CSMS at %v", csmsUrl) 
+	mainRoutine() // ... your program logic goes here
+}
+
+// Disconnect
+chargingStation.Stop()
+log.Println("disconnected from CSMS")
+```
+
+#### Sending requests
+
+Similarly to v1.6 you may send requests using the simplified API (recommended), e.g.
+```go
+bootResp, err := chargingStation.BootNotification(provisioning.BootReasonPowerUp, "model1", "vendor1")
+if err != nil {
+	log.Printf("error sending message: %v", err)
+} else {
+	log.Printf("status: %v, interval: %v, current time: %v", bootResp.Status, bootResp.Interval, bootResp.CurrentTime.String())
+}
+```
+
+Or you may build requests manually and send them using either the synchronous or asynchronous API.

--- a/example/1.6/cp/Dockerfile
+++ b/example/1.6/cp/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 # Fetch dependencies.
 RUN go mod download
 # Build the binary.
-RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/charge_point example/1.6/cp/*.go
+RUN go build -ldflags="-w -s" -o /go/bin/charge_point example/1.6/cp/*.go
 
 ############################
 # STEP 2 build a small image

--- a/example/1.6/create-test-certificates.sh
+++ b/example/1.6/create-test-certificates.sh
@@ -4,12 +4,12 @@ mkdir -p certs/cs
 mkdir -p certs/cp
 cd certs
 # Create CA
-openssl req -new -x509 -nodes -days 120 -extensions v3_ca -keyout ca.key -out ca.crt -subj "/CN=ocpp-go-example"
+openssl req -new -x509 -nodes -sha256 -days 120 -extensions v3_ca -keyout ca.key -out ca.crt -subj "/CN=ocpp-go-example"
 # Generate self-signed central-system certificate
 openssl genrsa -out cs/central-system.key 4096
-openssl req -new -out cs/central-system.csr -key cs/central-system.key -config ../openssl-cs.conf
-openssl x509 -req -in cs/central-system.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out cs/central-system.crt -days 120 -extensions req_ext -extfile ../openssl-cs.conf
+openssl req -new -out cs/central-system.csr -key cs/central-system.key -config ../openssl-cs.conf -sha256
+openssl x509 -req -in cs/central-system.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out cs/central-system.crt -days 120 -extensions req_ext -extfile ../openssl-cs.conf -sha256
 # Generate self-signed charge-point certificate
 openssl genrsa -out cp/charge-point.key 4096
-openssl req -new -out cp/charge-point.csr -key cp/charge-point.key -config ../openssl-cp.conf
-openssl x509 -req -in cp/charge-point.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out cp/charge-point.crt -days 120 -extensions req_ext -extfile ../openssl-cp.conf
+openssl req -new -out cp/charge-point.csr -key cp/charge-point.key -config ../openssl-cp.conf -sha256
+openssl x509 -req -in cp/charge-point.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out cp/charge-point.crt -days 120 -extensions req_ext -extfile ../openssl-cp.conf -sha256

--- a/example/1.6/cs/Dockerfile
+++ b/example/1.6/cs/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 # Fetch dependencies.
 RUN go mod download
 # Build the binary.
-RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/central_system example/1.6/cs/*.go
+RUN go build -ldflags="-w -s" -o /go/bin/central_system example/1.6/cs/*.go
 
 ############################
 # STEP 2 build a small image

--- a/example/2.0.1/chargingstation/Dockerfile
+++ b/example/2.0.1/chargingstation/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 # Fetch dependencies.
 RUN go mod download
 # Build the binary.
-RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/charging_station example/2.0.1/chargingstation/*.go
+RUN go build -ldflags="-w -s" -o /go/bin/charging_station example/2.0.1/chargingstation/*.go
 
 ############################
 # STEP 2 build a small image
@@ -23,4 +23,4 @@ COPY --from=builder /go/bin/charging_station /bin/charging_station
 # Ignore the warning.
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/* && update-ca-certificates
 
-CMD [ "charge_point" ]
+CMD [ "charging_station" ]

--- a/example/2.0.1/chargingstation/Dockerfile
+++ b/example/2.0.1/chargingstation/Dockerfile
@@ -1,0 +1,26 @@
+############################
+# STEP 1 build executable binary
+############################
+FROM golang:alpine AS builder
+
+ENV GO111MODULE on
+WORKDIR $GOPATH/src/github.com/lorenzodonini/ocpp-go
+COPY . .
+# Fetch dependencies.
+RUN go mod download
+# Build the binary.
+RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/charging_station example/2.0.1/chargingstation/*.go
+
+############################
+# STEP 2 build a small image
+############################
+FROM alpine
+
+COPY --from=builder /go/bin/charging_station /bin/charging_station
+
+# Add CA certificates
+# It currently throws a warning on alpine: WARNING: ca-certificates.crt does not contain exactly one certificate or CRL: skipping.
+# Ignore the warning.
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/* && update-ca-certificates
+
+CMD [ "charge_point" ]

--- a/example/2.0.1/chargingstation/authorization_handler.go
+++ b/example/2.0.1/chargingstation/authorization_handler.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/authorization"
+)
+
+func (handler *ChargingStationHandler) OnClearCache(request *authorization.ClearCacheRequest) (response *authorization.ClearCacheResponse, err error) {
+	logDefault(request.GetFeatureName()).Infof("cleared mocked cache")
+	return authorization.NewClearCacheResponse(authorization.ClearCacheStatusAccepted), nil
+}

--- a/example/2.0.1/chargingstation/availability_handler.go
+++ b/example/2.0.1/chargingstation/availability_handler.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/availability"
+)
+
+func (handler *ChargingStationHandler) OnChangeAvailability(request *availability.ChangeAvailabilityRequest) (response *availability.ChangeAvailabilityResponse, err error) {
+	if request.Evse == nil {
+		// Changing availability for the entire charging station
+		handler.availability = request.OperationalStatus
+		// TODO: recursively update the availability for all evse/connectors
+		response = availability.NewChangeAvailabilityResponse(availability.ChangeAvailabilityStatusAccepted)
+		return
+	}
+	reqEvse := request.Evse
+	if e, ok := handler.evse[reqEvse.ID]; ok {
+		// Changing availability for a specific EVSE
+		if reqEvse.ConnectorID != nil {
+			// Changing availability for a specific connector
+			if !e.hasConnector(*reqEvse.ConnectorID) {
+				response = availability.NewChangeAvailabilityResponse(availability.ChangeAvailabilityStatusRejected)
+			} else {
+				e.connectors[*reqEvse.ConnectorID].availability = request.OperationalStatus
+				response = availability.NewChangeAvailabilityResponse(availability.ChangeAvailabilityStatusAccepted)
+			}
+			return
+		}
+		e.availability = request.OperationalStatus
+		response = availability.NewChangeAvailabilityResponse(availability.ChangeAvailabilityStatusAccepted)
+		return
+	}
+	// No EVSE with such ID found
+	response = availability.NewChangeAvailabilityResponse(availability.ChangeAvailabilityStatusRejected)
+	return
+}

--- a/example/2.0.1/chargingstation/availability_handler.go
+++ b/example/2.0.1/chargingstation/availability_handler.go
@@ -20,7 +20,9 @@ func (handler *ChargingStationHandler) OnChangeAvailability(request *availabilit
 			if !e.hasConnector(*reqEvse.ConnectorID) {
 				response = availability.NewChangeAvailabilityResponse(availability.ChangeAvailabilityStatusRejected)
 			} else {
-				e.connectors[*reqEvse.ConnectorID].availability = request.OperationalStatus
+				connector := e.connectors[*reqEvse.ConnectorID]
+				connector.availability = request.OperationalStatus
+				e.connectors[*reqEvse.ConnectorID] = connector
 				response = availability.NewChangeAvailabilityResponse(availability.ChangeAvailabilityStatusAccepted)
 			}
 			return

--- a/example/2.0.1/chargingstation/charging_station_sim.go
+++ b/example/2.0.1/chargingstation/charging_station_sim.go
@@ -33,11 +33,11 @@ const (
 
 var log *logrus.Logger
 
-func setupChargePoint(chargePointID string) ocpp2.ChargingStation {
-	return ocpp2.NewChargingStation(chargePointID, nil, nil)
+func setupChargingStation(chargingStationID string) ocpp2.ChargingStation {
+	return ocpp2.NewChargingStation(chargingStationID, nil, nil)
 }
 
-func setupTlsChargePoint(chargePointID string) ocpp2.ChargingStation {
+func setupTlsChargingStation(chargingStationID string) ocpp2.ChargingStation {
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
 		log.Fatal(err)
@@ -71,10 +71,11 @@ func setupTlsChargePoint(chargePointID string) ocpp2.ChargingStation {
 		RootCAs:      certPool,
 		Certificates: clientCertificates,
 	})
-	return ocpp2.NewChargingStation(chargePointID, nil, client)
+	return ocpp2.NewChargingStation(chargingStationID, nil, client)
 }
 
-// exampleRoutine simulates a charge point flow, where
+// exampleRoutine simulates a charging station flow, where a dummy transaction is started.
+// The simulation runs for about 5 minutes.
 func exampleRoutine(chargingStation ocpp2.ChargingStation, stateHandler *ChargingStationHandler) {
 	dummyClientIdToken := types.IdToken{
 		IdToken: "12345",
@@ -198,11 +199,11 @@ func main() {
 	// Check if TLS enabled
 	t, _ := os.LookupEnv(envVarTls)
 	tlsEnabled, _ := strconv.ParseBool(t)
-	// Prepare OCPP 1.6 charge point (chargePoint variable is defined in handler.go)
+	// Prepare OCPP 2.0.1 charging station (chargingStation variable is defined in handler.go)
 	if tlsEnabled {
-		chargingStation = setupTlsChargePoint(id)
+		chargingStation = setupTlsChargingStation(id)
 	} else {
-		chargingStation = setupChargePoint(id)
+		chargingStation = setupChargingStation(id)
 	}
 	// Setup some basic state management
 	evse := EVSEInfo{

--- a/example/2.0.1/chargingstation/charging_station_sim.go
+++ b/example/2.0.1/chargingstation/charging_station_sim.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/provisioning"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/localauth"
+	"github.com/lorenzodonini/ocpp-go/ocppj"
+	"github.com/lorenzodonini/ocpp-go/ws"
+)
+
+const (
+	envVarClientID             = "CLIENT_ID"
+	envVarCentralSystemUrl     = "CENTRAL_SYSTEM_URL"
+	envVarTls                  = "TLS_ENABLED"
+	envVarCACertificate        = "CA_CERTIFICATE_PATH"
+	envVarClientCertificate    = "CLIENT_CERTIFICATE_PATH"
+	envVarClientCertificateKey = "CLIENT_CERTIFICATE_KEY_PATH"
+)
+
+var log *logrus.Logger
+
+func setupChargePoint(chargePointID string) ocpp2.ChargingStation {
+	return ocpp2.NewChargingStation(chargePointID, nil, nil)
+}
+
+func setupTlsChargePoint(chargePointID string) ocpp2.ChargingStation {
+	certPool, err := x509.SystemCertPool()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Load CA cert
+	caPath, ok := os.LookupEnv(envVarCACertificate)
+	if ok {
+		caCert, err := ioutil.ReadFile(caPath)
+		if err != nil {
+			log.Warn(err)
+		} else if !certPool.AppendCertsFromPEM(caCert) {
+			log.Info("no ca.cert file found, will use system CA certificates")
+		}
+	} else {
+		log.Info("no ca.cert file found, will use system CA certificates")
+	}
+	// Load client certificate
+	clientCertPath, ok1 := os.LookupEnv(envVarClientCertificate)
+	clientKeyPath, ok2 := os.LookupEnv(envVarClientCertificateKey)
+	var clientCertificates []tls.Certificate
+	if ok1 && ok2 {
+		certificate, err := tls.LoadX509KeyPair(clientCertPath, clientKeyPath)
+		if err == nil {
+			clientCertificates = []tls.Certificate{certificate}
+		} else {
+			log.Infof("couldn't load client TLS certificate: %v", err)
+		}
+	}
+	// Create client with TLS config
+	client := ws.NewTLSClient(&tls.Config{
+		RootCAs:      certPool,
+		Certificates: clientCertificates,
+	})
+	return ocpp2.NewChargingStation(chargePointID, nil, client)
+}
+
+// exampleRoutine simulates a charge point flow, where
+func exampleRoutine(chargingStation ocpp2.ChargingStation, stateHandler *ChargingStationHandler) {
+	dummyClientIdTag := "12345"
+	chargingConnector := 1
+	// Boot
+	bootConf, err := chargingStation.BootNotification(provisioning.BootReasonPowerUp, "model1", "vendor1")
+	checkError(err)
+	logDefault(bootConf.GetFeatureName()).Infof("status: %v, interval: %v, current time: %v", bootConf.Status, bootConf.Interval, bootConf.CurrentTime.String())
+	// Notify connector status
+	updateStatus(stateHandler, 0, core.ChargePointStatusAvailable)
+	// Wait for some time ...
+	time.Sleep(5 * time.Second)
+	// Simulate charging for connector 1
+	authResp, err := chargingStation.Authorize(dummyClientIdTag, types.IdTokenTypeKeyCode)
+	checkError(err)
+	logDefault(authResp.GetFeatureName()).Infof("status: %v %v", authResp.IdTokenInfo.Status, getExpiryDate(authResp.IdTokenInfo))
+	// Update connector status
+	updateStatus(stateHandler, chargingConnector, core.ChargePointStatusPreparing)
+	// Start transaction
+	startConf, err := chargingStation.StartTransaction(chargingConnector, dummyClientIdTag, stateHandler.meterValue, types.NewDateTime(time.Now()))
+	checkError(err)
+	logDefault(startConf.GetFeatureName()).Infof("status: %v, transaction %v %v", startConf.IdTagInfo.Status, startConf.TransactionId, getExpiryDate(startConf.IdTagInfo))
+	stateHandler.connectors[chargingConnector].currentTransaction = startConf.TransactionId
+	// Update connector status
+	updateStatus(stateHandler, chargingConnector, core.ChargePointStatusCharging)
+	// Periodically send meter values
+	for i := 0; i < 5; i++ {
+		sampleInterval, ok := stateHandler.configuration.getInt(MeterValueSampleInterval)
+		if !ok {
+			sampleInterval = 5
+		}
+		time.Sleep(time.Second * time.Duration(sampleInterval))
+		stateHandler.meterValue += 10
+		sampledValue := types.SampledValue{Value: fmt.Sprintf("%v", stateHandler.meterValue), Unit: types.UnitOfMeasureWh, Format: types.ValueFormatRaw, Measurand: types.MeasurandEnergyActiveExportRegister, Context: types.ReadingContextSamplePeriodic, Location: types.LocationOutlet}
+		meterValue := types.MeterValue{Timestamp: types.NewDateTime(time.Now()), SampledValue: []types.SampledValue{sampledValue}}
+		meterConf, err := chargingStation.MeterValues(chargingConnector, []types.MeterValue{meterValue})
+		checkError(err)
+		logDefault(meterConf.GetFeatureName()).Infof("sent updated %v", sampledValue.Measurand)
+	}
+	stateHandler.meterValue += 2
+	// Stop charging for connector 1
+	updateStatus(stateHandler, chargingConnector, core.ChargePointStatusFinishing)
+	stopConf, err := chargingStation.StopTransaction(stateHandler.meterValue, types.NewDateTime(time.Now()), startConf.TransactionId, func(request *core.StopTransactionRequest) {
+		sampledValue := types.SampledValue{Value: fmt.Sprintf("%v", stateHandler.meterValue), Unit: types.UnitOfMeasureWh, Format: types.ValueFormatRaw, Measurand: types.MeasurandEnergyActiveExportRegister, Context: types.ReadingContextSamplePeriodic, Location: types.LocationOutlet}
+		meterValue := types.MeterValue{Timestamp: types.NewDateTime(time.Now()), SampledValue: []types.SampledValue{sampledValue}}
+		request.TransactionData = []types.MeterValue{meterValue}
+		request.Reason = core.ReasonEVDisconnected
+	})
+	checkError(err)
+	logDefault(stopConf.GetFeatureName()).Infof("transaction %v stopped", startConf.TransactionId)
+	// Update connector status
+	updateStatus(stateHandler, chargingConnector, core.ChargePointStatusAvailable)
+	// Wait for some time ...
+	time.Sleep(5 * time.Minute)
+}
+
+// Start function
+func main() {
+	// Load config
+	id, ok := os.LookupEnv(envVarClientID)
+	if !ok {
+		log.Printf("no %v environment variable found, exiting...", envVarClientID)
+		return
+	}
+	csUrl, ok := os.LookupEnv(envVarCentralSystemUrl)
+	if !ok {
+		log.Printf("no %v environment variable found, exiting...", envVarCentralSystemUrl)
+		return
+	}
+	// Check if TLS enabled
+	t, _ := os.LookupEnv(envVarTls)
+	tlsEnabled, _ := strconv.ParseBool(t)
+	// Prepare OCPP 1.6 charge point (chargePoint variable is defined in handler.go)
+	if tlsEnabled {
+		chargingStation = setupTlsChargePoint(id)
+	} else {
+		chargingStation = setupChargePoint(id)
+	}
+	// Setup some basic state management
+	connectors := map[int]*ConnectorInfo{
+		1: {status: core.ChargePointStatusAvailable, availability: core.AvailabilityTypeOperative, currentTransaction: 0},
+	}
+	handler := &ChargingStationHandler{
+		status:               core.ChargePointStatusAvailable,
+		connectors:           connectors,
+		configuration:        getDefaultConfig(),
+		errorCode:            core.NoError,
+		localAuthList:        []localauth.AuthorizationData{},
+		localAuthListVersion: 0}
+	// Support callbacks for all OCPP 1.6 profiles
+	chargingStation.SetCoreHandler(handler)
+	chargingStation.SetFirmwareManagementHandler(handler)
+	chargingStation.SetLocalAuthListHandler(handler)
+	chargingStation.SetReservationHandler(handler)
+	chargingStation.SetRemoteTriggerHandler(handler)
+	chargingStation.SetSmartChargingHandler(handler)
+	ocppj.SetLogger(log)
+	// Connects to central system
+	err := chargingStation.Start(csUrl)
+	if err != nil {
+		log.Errorln(err)
+	} else {
+		log.Infof("connected to central system at %v", csUrl)
+		exampleRoutine(chargingStation, handler)
+		// Disconnect
+		chargingStation.Stop()
+		log.Infof("disconnected from central system")
+	}
+}
+
+func init() {
+	log = logrus.New()
+	log.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+	log.SetLevel(logrus.InfoLevel)
+}
+
+// Utility functions
+func logDefault(feature string) *logrus.Entry {
+	return log.WithField("message", feature)
+}

--- a/example/2.0.1/chargingstation/config.go
+++ b/example/2.0.1/chargingstation/config.go
@@ -1,127 +1,18 @@
 package main
 
 import (
+	"crypto/rand"
 	"fmt"
-	"strconv"
-
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/localauth"
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/remotetrigger"
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/reservation"
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/smartcharging"
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 )
 
-const (
-	AuthorizeRemoteTxRequests               string = "AuthorizeRemoteTxRequests"
-	ClockAlignedDataInterval                string = "ClockAlignedDataInterval"
-	ConnectionTimeOut                       string = "ConnectionTimeOut"
-	ConnectorPhaseRotation                  string = "ConnectorPhaseRotation"
-	GetConfigurationMaxKeys                 string = "GetConfigurationMaxKeys"
-	HeartbeatInterval                       string = "HeartbeatInterval"
-	LocalAuthorizeOffline                   string = "LocalAuthorizeOffline"
-	LocalPreAuthorize                       string = "LocalPreAuthorize"
-	MeterValuesAlignedData                  string = "MeterValuesAlignedData"
-	MeterValuesSampledData                  string = "MeterValuesSampledData"
-	MeterValueSampleInterval                string = "MeterValueSampleInterval"
-	NumberOfConnectors                      string = "NumberOfConnectors"
-	ResetRetries                            string = "ResetRetries"
-	StopTransactionOnEVSideDisconnect       string = "StopTransactionOnEVSideDisconnect"
-	StopTransactionOnInvalidId              string = "StopTransactionOnInvalidId"
-	StopTxnAlignedData                      string = "StopTxnAlignedData"
-	StopTxnSampledData                      string = "StopTxnSampledData"
-	SupportedFeatureProfiles                string = "SupportedFeatureProfiles"
-	TransactionMessageAttempts              string = "TransactionMessageAttempts"
-	TransactionMessageRetryInterval         string = "TransactionMessageRetryInterval"
-	UnlockConnectorOnEVSideDisconnect       string = "UnlockConnectorOnEVSideDisconnect"
-	WebSocketPingInterval                   string = "WebSocketPingInterval"
-	LocalAuthListEnabled                    string = "LocalAuthListEnabled"
-	LocalAuthListMaxLength                  string = "LocalAuthListMaxLength"
-	SendLocalListMaxLength                  string = "SendLocalListMaxLength"
-	ChargeProfileMaxStackLevel              string = "ChargeProfileMaxStackLevel"
-	ChargingScheduleAllowedChargingRateUnit string = "ChargingScheduleAllowedChargingRateUnit"
-	ChargingScheduleMaxPeriods              string = "ChargingScheduleMaxPeriods"
-	MaxChargingProfilesInstalled            string = "MaxChargingProfilesInstalled"
-)
-
-type ConfigMap map[string]core.ConfigurationKey
-
-func (c ConfigMap) updateInt(key string, i int64) {
-	configKey, ok := c[key]
-	if ok {
-		configKey.Value = newString(strconv.FormatInt(i, 10))
-	}
-	c[key] = configKey
-}
-
-func (c ConfigMap) updateBool(key string, b bool) {
-	configKey, ok := c[key]
-	if ok {
-		configKey.Value = newString(strconv.FormatBool(b))
-	}
-	c[key] = configKey
-}
-
-func (c ConfigMap) getInt(key string) (int, bool) {
-	configKey, ok := c[key]
-	if !ok {
-		return 0, ok
-	}
-	result, err := strconv.ParseInt(*configKey.Value, 10, 32)
+// Generates a pseudo UUID. Not RFC 4122 compliant, but useful for this example.
+func pseudoUUID() (uuid string) {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
 	if err != nil {
-		return 0, false
+		fmt.Println("Error: ", err)
+		return
 	}
-	return int(result), true
-}
-
-func (c ConfigMap) getBool(key string) (bool, bool) {
-	configKey, ok := c[key]
-	if !ok {
-		return false, ok
-	}
-	result, err := strconv.ParseBool(*configKey.Value)
-	if err != nil {
-		return false, false
-	}
-	return result, true
-}
-
-func newString(s string) *string {
-	return &s
-}
-
-func getDefaultConfig() ConfigMap {
-	intBase := 10
-	cfg := map[string]core.ConfigurationKey{}
-	cfg[AuthorizeRemoteTxRequests] = core.ConfigurationKey{Key: AuthorizeRemoteTxRequests, Readonly: true, Value: newString(strconv.FormatBool(false))}
-	cfg[ClockAlignedDataInterval] = core.ConfigurationKey{Key: ClockAlignedDataInterval, Readonly: false, Value: newString(strconv.FormatInt(0, intBase))}
-	cfg[ConnectionTimeOut] = core.ConfigurationKey{Key: ConnectionTimeOut, Readonly: false, Value: newString(strconv.FormatInt(60, intBase))}
-	cfg[ConnectorPhaseRotation] = core.ConfigurationKey{Key: ConnectorPhaseRotation, Readonly: false, Value: newString("Unknown")}
-	cfg[GetConfigurationMaxKeys] = core.ConfigurationKey{Key: GetConfigurationMaxKeys, Readonly: true, Value: newString(strconv.FormatInt(50, intBase))}
-	cfg[HeartbeatInterval] = core.ConfigurationKey{Key: HeartbeatInterval, Readonly: false, Value: newString(strconv.FormatInt(86400, intBase))}
-	cfg[LocalAuthorizeOffline] = core.ConfigurationKey{Key: LocalAuthorizeOffline, Readonly: false, Value: newString(strconv.FormatBool(true))}
-	cfg[LocalPreAuthorize] = core.ConfigurationKey{Key: LocalPreAuthorize, Readonly: false, Value: newString(strconv.FormatBool(false))}
-	cfg[MeterValuesAlignedData] = core.ConfigurationKey{Key: MeterValuesAlignedData, Readonly: false, Value: newString(string(types.MeasurandEnergyActiveExportRegister))}
-	cfg[MeterValuesSampledData] = core.ConfigurationKey{Key: MeterValuesSampledData, Readonly: false, Value: newString(string(types.MeasurandEnergyActiveExportRegister))}
-	cfg[MeterValueSampleInterval] = core.ConfigurationKey{Key: MeterValueSampleInterval, Readonly: false, Value: newString(strconv.FormatInt(5, intBase))}
-	cfg[NumberOfConnectors] = core.ConfigurationKey{Key: NumberOfConnectors, Readonly: true, Value: newString(strconv.FormatInt(1, intBase))}
-	cfg[ResetRetries] = core.ConfigurationKey{Key: ResetRetries, Readonly: false, Value: newString(strconv.FormatInt(10, intBase))}
-	cfg[StopTransactionOnEVSideDisconnect] = core.ConfigurationKey{Key: StopTransactionOnEVSideDisconnect, Readonly: false, Value: newString(strconv.FormatBool(true))}
-	cfg[StopTransactionOnInvalidId] = core.ConfigurationKey{Key: StopTransactionOnInvalidId, Readonly: false, Value: newString(strconv.FormatBool(true))}
-	cfg[StopTxnAlignedData] = core.ConfigurationKey{Key: StopTxnAlignedData, Readonly: false, Value: newString(strconv.FormatBool(true))}
-	cfg[StopTxnSampledData] = core.ConfigurationKey{Key: StopTxnSampledData, Readonly: false, Value: newString(string(types.MeasurandEnergyActiveExportRegister))}
-	cfg[SupportedFeatureProfiles] = core.ConfigurationKey{Key: SupportedFeatureProfiles, Readonly: true, Value: newString(fmt.Sprintf("%v,%v,%v,%v,%v,%v", core.ProfileName, firmware.ProfileName, localauth.ProfileName, reservation.ProfileName, remotetrigger.ProfileName, smartcharging.ProfileName))}
-	cfg[TransactionMessageAttempts] = core.ConfigurationKey{Key: TransactionMessageAttempts, Readonly: false, Value: newString(strconv.FormatInt(5, intBase))}
-	cfg[TransactionMessageRetryInterval] = core.ConfigurationKey{Key: TransactionMessageRetryInterval, Readonly: false, Value: newString(strconv.FormatInt(60, intBase))}
-	cfg[UnlockConnectorOnEVSideDisconnect] = core.ConfigurationKey{Key: UnlockConnectorOnEVSideDisconnect, Readonly: false, Value: newString(strconv.FormatBool(true))}
-	cfg[WebSocketPingInterval] = core.ConfigurationKey{Key: WebSocketPingInterval, Readonly: false, Value: newString(strconv.FormatInt(54, intBase))}
-	cfg[LocalAuthListEnabled] = core.ConfigurationKey{Key: LocalAuthListEnabled, Readonly: false, Value: newString(strconv.FormatBool(true))}
-	cfg[LocalAuthListMaxLength] = core.ConfigurationKey{Key: LocalAuthListMaxLength, Readonly: true, Value: newString(strconv.FormatInt(100, intBase))}
-	cfg[SendLocalListMaxLength] = core.ConfigurationKey{Key: SendLocalListMaxLength, Readonly: true, Value: newString(strconv.FormatInt(20, intBase))}
-	cfg[ChargeProfileMaxStackLevel] = core.ConfigurationKey{Key: ChargeProfileMaxStackLevel, Readonly: true, Value: newString(strconv.FormatInt(10, intBase))}
-	cfg[ChargingScheduleAllowedChargingRateUnit] = core.ConfigurationKey{Key: ChargingScheduleAllowedChargingRateUnit, Readonly: true, Value: newString("Power")}
-	cfg[ChargingScheduleMaxPeriods] = core.ConfigurationKey{Key: ChargingScheduleMaxPeriods, Readonly: true, Value: newString(strconv.FormatInt(5, intBase))}
-	cfg[MaxChargingProfilesInstalled] = core.ConfigurationKey{Key: MaxChargingProfilesInstalled, Readonly: true, Value: newString(strconv.FormatInt(10, intBase))}
-	return cfg
+	uuid = fmt.Sprintf("%X-%X-%X-%X-%X", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+	return
 }

--- a/example/2.0.1/chargingstation/config.go
+++ b/example/2.0.1/chargingstation/config.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/localauth"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/remotetrigger"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/reservation"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/smartcharging"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+)
+
+const (
+	AuthorizeRemoteTxRequests               string = "AuthorizeRemoteTxRequests"
+	ClockAlignedDataInterval                string = "ClockAlignedDataInterval"
+	ConnectionTimeOut                       string = "ConnectionTimeOut"
+	ConnectorPhaseRotation                  string = "ConnectorPhaseRotation"
+	GetConfigurationMaxKeys                 string = "GetConfigurationMaxKeys"
+	HeartbeatInterval                       string = "HeartbeatInterval"
+	LocalAuthorizeOffline                   string = "LocalAuthorizeOffline"
+	LocalPreAuthorize                       string = "LocalPreAuthorize"
+	MeterValuesAlignedData                  string = "MeterValuesAlignedData"
+	MeterValuesSampledData                  string = "MeterValuesSampledData"
+	MeterValueSampleInterval                string = "MeterValueSampleInterval"
+	NumberOfConnectors                      string = "NumberOfConnectors"
+	ResetRetries                            string = "ResetRetries"
+	StopTransactionOnEVSideDisconnect       string = "StopTransactionOnEVSideDisconnect"
+	StopTransactionOnInvalidId              string = "StopTransactionOnInvalidId"
+	StopTxnAlignedData                      string = "StopTxnAlignedData"
+	StopTxnSampledData                      string = "StopTxnSampledData"
+	SupportedFeatureProfiles                string = "SupportedFeatureProfiles"
+	TransactionMessageAttempts              string = "TransactionMessageAttempts"
+	TransactionMessageRetryInterval         string = "TransactionMessageRetryInterval"
+	UnlockConnectorOnEVSideDisconnect       string = "UnlockConnectorOnEVSideDisconnect"
+	WebSocketPingInterval                   string = "WebSocketPingInterval"
+	LocalAuthListEnabled                    string = "LocalAuthListEnabled"
+	LocalAuthListMaxLength                  string = "LocalAuthListMaxLength"
+	SendLocalListMaxLength                  string = "SendLocalListMaxLength"
+	ChargeProfileMaxStackLevel              string = "ChargeProfileMaxStackLevel"
+	ChargingScheduleAllowedChargingRateUnit string = "ChargingScheduleAllowedChargingRateUnit"
+	ChargingScheduleMaxPeriods              string = "ChargingScheduleMaxPeriods"
+	MaxChargingProfilesInstalled            string = "MaxChargingProfilesInstalled"
+)
+
+type ConfigMap map[string]core.ConfigurationKey
+
+func (c ConfigMap) updateInt(key string, i int64) {
+	configKey, ok := c[key]
+	if ok {
+		configKey.Value = newString(strconv.FormatInt(i, 10))
+	}
+	c[key] = configKey
+}
+
+func (c ConfigMap) updateBool(key string, b bool) {
+	configKey, ok := c[key]
+	if ok {
+		configKey.Value = newString(strconv.FormatBool(b))
+	}
+	c[key] = configKey
+}
+
+func (c ConfigMap) getInt(key string) (int, bool) {
+	configKey, ok := c[key]
+	if !ok {
+		return 0, ok
+	}
+	result, err := strconv.ParseInt(*configKey.Value, 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return int(result), true
+}
+
+func (c ConfigMap) getBool(key string) (bool, bool) {
+	configKey, ok := c[key]
+	if !ok {
+		return false, ok
+	}
+	result, err := strconv.ParseBool(*configKey.Value)
+	if err != nil {
+		return false, false
+	}
+	return result, true
+}
+
+func newString(s string) *string {
+	return &s
+}
+
+func getDefaultConfig() ConfigMap {
+	intBase := 10
+	cfg := map[string]core.ConfigurationKey{}
+	cfg[AuthorizeRemoteTxRequests] = core.ConfigurationKey{Key: AuthorizeRemoteTxRequests, Readonly: true, Value: newString(strconv.FormatBool(false))}
+	cfg[ClockAlignedDataInterval] = core.ConfigurationKey{Key: ClockAlignedDataInterval, Readonly: false, Value: newString(strconv.FormatInt(0, intBase))}
+	cfg[ConnectionTimeOut] = core.ConfigurationKey{Key: ConnectionTimeOut, Readonly: false, Value: newString(strconv.FormatInt(60, intBase))}
+	cfg[ConnectorPhaseRotation] = core.ConfigurationKey{Key: ConnectorPhaseRotation, Readonly: false, Value: newString("Unknown")}
+	cfg[GetConfigurationMaxKeys] = core.ConfigurationKey{Key: GetConfigurationMaxKeys, Readonly: true, Value: newString(strconv.FormatInt(50, intBase))}
+	cfg[HeartbeatInterval] = core.ConfigurationKey{Key: HeartbeatInterval, Readonly: false, Value: newString(strconv.FormatInt(86400, intBase))}
+	cfg[LocalAuthorizeOffline] = core.ConfigurationKey{Key: LocalAuthorizeOffline, Readonly: false, Value: newString(strconv.FormatBool(true))}
+	cfg[LocalPreAuthorize] = core.ConfigurationKey{Key: LocalPreAuthorize, Readonly: false, Value: newString(strconv.FormatBool(false))}
+	cfg[MeterValuesAlignedData] = core.ConfigurationKey{Key: MeterValuesAlignedData, Readonly: false, Value: newString(string(types.MeasurandEnergyActiveExportRegister))}
+	cfg[MeterValuesSampledData] = core.ConfigurationKey{Key: MeterValuesSampledData, Readonly: false, Value: newString(string(types.MeasurandEnergyActiveExportRegister))}
+	cfg[MeterValueSampleInterval] = core.ConfigurationKey{Key: MeterValueSampleInterval, Readonly: false, Value: newString(strconv.FormatInt(5, intBase))}
+	cfg[NumberOfConnectors] = core.ConfigurationKey{Key: NumberOfConnectors, Readonly: true, Value: newString(strconv.FormatInt(1, intBase))}
+	cfg[ResetRetries] = core.ConfigurationKey{Key: ResetRetries, Readonly: false, Value: newString(strconv.FormatInt(10, intBase))}
+	cfg[StopTransactionOnEVSideDisconnect] = core.ConfigurationKey{Key: StopTransactionOnEVSideDisconnect, Readonly: false, Value: newString(strconv.FormatBool(true))}
+	cfg[StopTransactionOnInvalidId] = core.ConfigurationKey{Key: StopTransactionOnInvalidId, Readonly: false, Value: newString(strconv.FormatBool(true))}
+	cfg[StopTxnAlignedData] = core.ConfigurationKey{Key: StopTxnAlignedData, Readonly: false, Value: newString(strconv.FormatBool(true))}
+	cfg[StopTxnSampledData] = core.ConfigurationKey{Key: StopTxnSampledData, Readonly: false, Value: newString(string(types.MeasurandEnergyActiveExportRegister))}
+	cfg[SupportedFeatureProfiles] = core.ConfigurationKey{Key: SupportedFeatureProfiles, Readonly: true, Value: newString(fmt.Sprintf("%v,%v,%v,%v,%v,%v", core.ProfileName, firmware.ProfileName, localauth.ProfileName, reservation.ProfileName, remotetrigger.ProfileName, smartcharging.ProfileName))}
+	cfg[TransactionMessageAttempts] = core.ConfigurationKey{Key: TransactionMessageAttempts, Readonly: false, Value: newString(strconv.FormatInt(5, intBase))}
+	cfg[TransactionMessageRetryInterval] = core.ConfigurationKey{Key: TransactionMessageRetryInterval, Readonly: false, Value: newString(strconv.FormatInt(60, intBase))}
+	cfg[UnlockConnectorOnEVSideDisconnect] = core.ConfigurationKey{Key: UnlockConnectorOnEVSideDisconnect, Readonly: false, Value: newString(strconv.FormatBool(true))}
+	cfg[WebSocketPingInterval] = core.ConfigurationKey{Key: WebSocketPingInterval, Readonly: false, Value: newString(strconv.FormatInt(54, intBase))}
+	cfg[LocalAuthListEnabled] = core.ConfigurationKey{Key: LocalAuthListEnabled, Readonly: false, Value: newString(strconv.FormatBool(true))}
+	cfg[LocalAuthListMaxLength] = core.ConfigurationKey{Key: LocalAuthListMaxLength, Readonly: true, Value: newString(strconv.FormatInt(100, intBase))}
+	cfg[SendLocalListMaxLength] = core.ConfigurationKey{Key: SendLocalListMaxLength, Readonly: true, Value: newString(strconv.FormatInt(20, intBase))}
+	cfg[ChargeProfileMaxStackLevel] = core.ConfigurationKey{Key: ChargeProfileMaxStackLevel, Readonly: true, Value: newString(strconv.FormatInt(10, intBase))}
+	cfg[ChargingScheduleAllowedChargingRateUnit] = core.ConfigurationKey{Key: ChargingScheduleAllowedChargingRateUnit, Readonly: true, Value: newString("Power")}
+	cfg[ChargingScheduleMaxPeriods] = core.ConfigurationKey{Key: ChargingScheduleMaxPeriods, Readonly: true, Value: newString(strconv.FormatInt(5, intBase))}
+	cfg[MaxChargingProfilesInstalled] = core.ConfigurationKey{Key: MaxChargingProfilesInstalled, Readonly: true, Value: newString(strconv.FormatInt(10, intBase))}
+	return cfg
+}

--- a/example/2.0.1/chargingstation/data_handler.go
+++ b/example/2.0.1/chargingstation/data_handler.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/data"
+)
+
+type DataSample struct {
+	SampleString string  `json:"sample_string"`
+	SampleValue  float64 `json:"sample_value"`
+}
+
+func (handler *ChargingStationHandler) OnDataTransfer(request *data.DataTransferRequest) (response *data.DataTransferResponse, err error) {
+	var dataSample DataSample
+	err = json.Unmarshal(request.Data.([]byte), &dataSample)
+	if err != nil {
+		logDefault(request.GetFeatureName()).
+			Errorf("invalid data received: %v", request.Data)
+		return nil, err
+	}
+	logDefault(request.GetFeatureName()).
+		Infof("data received: %v, %v", dataSample.SampleString, dataSample.SampleValue)
+	return data.NewDataTransferResponse(data.DataTransferStatusAccepted), nil
+}

--- a/example/2.0.1/chargingstation/diagnostics_handler.go
+++ b/example/2.0.1/chargingstation/diagnostics_handler.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/diagnostics"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+)
+
+func (handler *ChargingStationHandler) OnClearVariableMonitoring(request *diagnostics.ClearVariableMonitoringRequest) (response *diagnostics.ClearVariableMonitoringResponse, err error) {
+	logDefault(request.GetFeatureName()).Infof("cleared variables %v", request.ID)
+	clearMonitoringResult := make([]diagnostics.ClearMonitoringResult, len(request.ID))
+	for i, req := range request.ID {
+		res := diagnostics.ClearMonitoringResult{
+			ID:     req,
+			Status: diagnostics.ClearMonitoringStatusAccepted,
+		}
+		clearMonitoringResult[i] = res
+	}
+	return diagnostics.NewClearVariableMonitoringResponse(clearMonitoringResult), nil
+}
+
+func (handler *ChargingStationHandler) OnCustomerInformation(request *diagnostics.CustomerInformationRequest) (response *diagnostics.CustomerInformationResponse, err error) {
+	logDefault(request.GetFeatureName()).Infof("request %d for customer %s (clear %v, report %v)", request.RequestID, request.CustomerIdentifier, request.Clear, request.Report)
+	return diagnostics.NewCustomerInformationResponse(diagnostics.CustomerInformationStatusAccepted), nil
+}
+
+func (handler *ChargingStationHandler) OnGetLog(request *diagnostics.GetLogRequest) (response *diagnostics.GetLogResponse, err error) {
+	logDefault(request.GetFeatureName()).Infof("request %d to upload logs %v to %v accepted", request.RequestID, request.LogType, request.Log.RemoteLocation)
+	// TODO: start asynchronous log upload
+	return diagnostics.NewGetLogResponse(diagnostics.LogStatusAccepted), nil
+}
+
+func (handler *ChargingStationHandler) OnGetMonitoringReport(request *diagnostics.GetMonitoringReportRequest) (response *diagnostics.GetMonitoringReportResponse, err error) {
+	logDefault(request.GetFeatureName()).Infof("request %d to upload report with criteria %v, component variables %v", request.RequestID, request.MonitoringCriteria, request.ComponentVariable)
+	// TODO: start asynchronous report upload via NotifyMonitoringReportRequest
+	return diagnostics.NewGetMonitoringReportResponse(types.GenericDeviceModelStatusAccepted), nil
+}
+
+func (handler *ChargingStationHandler) OnSetMonitoringBase(request *diagnostics.SetMonitoringBaseRequest) (response *diagnostics.SetMonitoringBaseResponse, err error) {
+	logDefault(request.GetFeatureName()).Infof("monitoring base %s set successfully", request.MonitoringBase)
+	return diagnostics.NewSetMonitoringBaseResponse(types.GenericDeviceModelStatusAccepted), nil
+}
+
+func (handler *ChargingStationHandler) OnSetMonitoringLevel(request *diagnostics.SetMonitoringLevelRequest) (response *diagnostics.SetMonitoringLevelResponse, err error) {
+	handler.monitoringLevel = request.Severity
+	logDefault(request.GetFeatureName()).Infof("set monitoring severity level to %d", handler.monitoringLevel)
+	return diagnostics.NewSetMonitoringLevelResponse(types.GenericDeviceModelStatusAccepted), nil
+}
+
+func (handler *ChargingStationHandler) OnSetVariableMonitoring(request *diagnostics.SetVariableMonitoringRequest) (response *diagnostics.SetVariableMonitoringResponse, err error) {
+	setMonitoringResult := make([]diagnostics.SetMonitoringResult, len(request.MonitoringData))
+	for i, req := range request.MonitoringData {
+		// TODO: configure custom monitoring rules internal for the received SetMonitoringData parameters
+		logDefault(request.GetFeatureName()).Infof("set monitoring for component %v, variable %v to type %v = %v, severity %v",
+			req.Component.Name, req.Variable.Name, req.Type, req.Value, req.Severity)
+		res := diagnostics.SetMonitoringResult{
+			ID:        req.ID,
+			Status:    diagnostics.SetMonitoringStatusAccepted,
+			Type:      req.Type,
+			Severity:  req.Severity,
+			Component: req.Component,
+			Variable:  req.Variable,
+		}
+		setMonitoringResult[i] = res
+	}
+	return diagnostics.NewSetVariableMonitoringResponse(setMonitoringResult), nil
+}

--- a/example/2.0.1/chargingstation/display_handler.go
+++ b/example/2.0.1/chargingstation/display_handler.go
@@ -1,13 +1,21 @@
 package main
 
-func (handler *ChargingStationHandler) OnClearDisplay(request *ClearDisplayRequest) (confirmation *ClearDisplayResponse, err error) {
+import "github.com/lorenzodonini/ocpp-go/ocpp2.0.1/display"
 
+func (handler *ChargingStationHandler) OnClearDisplay(request *display.ClearDisplayRequest) (response *display.ClearDisplayResponse, err error) {
+	logDefault(request.GetFeatureName()).Infof("cleared display message %v", request.ID)
+	response = display.NewClearDisplayResponse(display.ClearMessageStatusAccepted)
+	return
 }
 
-func (handler *ChargingStationHandler) OnGetDisplayMessages(request *GetDisplayMessagesRequest) (confirmation *GetDisplayMessagesResponse, err error) {
-
+func (handler *ChargingStationHandler) OnGetDisplayMessages(request *display.GetDisplayMessagesRequest) (response *display.GetDisplayMessagesResponse, err error) {
+	logDefault(request.GetFeatureName()).Infof("request %v to send display messages ignored", request.RequestID)
+	response = display.NewGetDisplayMessagesResponse(display.MessageStatusUnknown)
+	return
 }
 
-func (handler *ChargingStationHandler) OnSetDisplayMessage(request *SetDisplayMessageRequest) (response *SetDisplayMessageResponse, err error) {
-
+func (handler *ChargingStationHandler) OnSetDisplayMessage(request *display.SetDisplayMessageRequest) (response *display.SetDisplayMessageResponse, err error) {
+	logDefault(request.GetFeatureName()).Infof("accepted request to display message %v: %v", request.Message.ID, request.Message.Message.Content)
+	response = display.NewSetDisplayMessageResponse(display.DisplayMessageStatusAccepted)
+	return
 }

--- a/example/2.0.1/chargingstation/display_handler.go
+++ b/example/2.0.1/chargingstation/display_handler.go
@@ -1,0 +1,13 @@
+package main
+
+func (handler *ChargingStationHandler) OnClearDisplay(request *ClearDisplayRequest) (confirmation *ClearDisplayResponse, err error) {
+
+}
+
+func (handler *ChargingStationHandler) OnGetDisplayMessages(request *GetDisplayMessagesRequest) (confirmation *GetDisplayMessagesResponse, err error) {
+
+}
+
+func (handler *ChargingStationHandler) OnSetDisplayMessage(request *SetDisplayMessageRequest) (response *SetDisplayMessageResponse, err error) {
+
+}

--- a/example/2.0.1/chargingstation/firmware_handler.go
+++ b/example/2.0.1/chargingstation/firmware_handler.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"github.com/lorenzodonini/ocpp-go/ocpp"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/firmware"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/ocppj"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+func (handler *ChargingStationHandler) OnPublishFirmware(request *firmware.PublishFirmwareRequest) (response *firmware.PublishFirmwareResponse, err error) {
+	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (handler *ChargingStationHandler) OnUnpublishFirmware(request *firmware.UnpublishFirmwareRequest) (response *firmware.UnpublishFirmwareResponse, err error) {
+	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (handler *ChargingStationHandler) OnUpdateFirmware(request *firmware.UpdateFirmwareRequest) (response *firmware.UpdateFirmwareResponse, err error) {
+	retries := 0
+	retryInterval := 30
+	if request.Retries != nil {
+		retries = *request.Retries
+	}
+	if request.RetryInterval != nil {
+		retryInterval = *request.RetryInterval
+	}
+	logDefault(request.GetFeatureName()).Infof("starting update firmware procedure")
+	go updateFirmware(request.Firmware.Location, request.Firmware.RetrieveDateTime, request.Firmware.InstallDateTime, retries, retryInterval)
+	return firmware.NewUpdateFirmwareResponse(firmware.UpdateFirmwareStatusAccepted), nil
+}
+
+func updateFirmwareStatus(status firmware.FirmwareStatus, props ...func(request *firmware.FirmwareStatusNotificationRequest)) {
+	statusConfirmation, err := chargingStation.FirmwareStatusNotification(status, props...)
+	checkError(err)
+	logDefault(statusConfirmation.GetFeatureName()).Infof("firmware status updated to %v", status)
+}
+
+// Retrieve data and install date are ignored for this test function.
+func updateFirmware(location string, retrieveDate *types.DateTime, installDate *types.DateTime, retries int, retryInterval int) {
+	updateFirmwareStatus(firmware.FirmwareStatusDownloading)
+	err := downloadFile("/tmp/out.bin", location)
+	if err != nil {
+		logDefault(firmware.UpdateFirmwareFeatureName).Errorf("error while downloading file %v", err)
+		updateFirmwareStatus(firmware.FirmwareStatusDownloadFailed)
+		return
+	}
+	updateFirmwareStatus(firmware.FirmwareStatusDownloaded)
+	// Simulate installation
+	updateFirmwareStatus(firmware.FirmwareStatusInstalling)
+	time.Sleep(time.Second * 5)
+	// Notify completion
+	updateFirmwareStatus(firmware.FirmwareStatusInstalled)
+}
+
+func downloadFile(filepath string, url string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	return err
+}

--- a/example/2.0.1/chargingstation/handler.go
+++ b/example/2.0.1/chargingstation/handler.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"fmt"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/availability"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/localauth"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/reservation"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"time"
+)
+
+// ConnectorInfo contains some simple state about a single connector.
+type ConnectorInfo struct {
+	status       availability.ConnectorStatus
+	availability availability.OperationalStatus
+	typ          reservation.ConnectorType
+}
+
+// EVSEInfo contains some simple state
+type EVSEInfo struct {
+	availability       availability.OperationalStatus
+	currentTransaction string
+	currentReservation int
+	connectors         []ConnectorInfo
+}
+
+// ChargingStationHandler contains some simple state that a charge point needs to keep.
+// In production this will typically be replaced by database/API calls.
+type ChargingStationHandler struct {
+	status               core.ChargePointStatus
+	availability         availability.OperationalStatus
+	evse                 map[int]*EVSEInfo
+	errorCode            core.ChargePointErrorCode
+	model                string
+	vendor               string
+	meterValue           int
+	localAuthList        []localauth.AuthorizationData
+	localAuthListVersion int
+	monitoringLevel      int
+}
+
+var chargingStation ocpp2.ChargingStation
+
+func (evse *EVSEInfo) hasConnector(ID int) bool {
+	return ID > 0 && len(evse.connectors) > ID
+}
+
+func (evse *EVSEInfo) getConnectorOfType(typ reservation.ConnectorType) int {
+	for i, c := range evse.connectors {
+		if c.typ == typ {
+			return i
+		}
+	}
+	return -1
+}
+
+var transactionID = 0
+
+func nextTransactionID() string {
+	transactionID++
+	return fmt.Sprintf("%d", transactionID)
+}
+
+func checkError(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func getExpiryDate(info *types.IdTokenInfo) string {
+	if info.CacheExpiryDateTime != nil {
+		return fmt.Sprintf("authorized until %v", info.CacheExpiryDateTime.String())
+	}
+	return ""
+}
+
+func updateOperationalStatus(stateHandler *ChargingStationHandler, evseID int, status availability.OperationalStatus) {
+	if evseID == 0 {
+		stateHandler.availability = status
+		log.Infof("operational status for charging station updated to: %v", status)
+	} else if evse, ok := stateHandler.evse[evseID]; !ok {
+		log.Errorf("couldn't update operational status for invalid evse %d", evseID)
+		return
+	} else {
+		evse.availability = status
+		log.Infof("operational status for evse %d updated to: %v", evseID, status)
+	}
+}
+
+func updateConnectorStatus(stateHandler *ChargingStationHandler, evseID int, connector int, status availability.ConnectorStatus) {
+	if evse, ok := stateHandler.evse[evseID]; !ok {
+		log.Errorf("couldn't update connector status for invalid evse %d", evseID)
+		return
+	} else if connector < 0 || connector > len(evse.connectors) {
+		log.Errorf("couldn't update status for evse %d with invalid connector %d", evseID, connector)
+		return
+	} else {
+		evse.connectors[connector].status = status
+		// Send asynchronous status update
+		response, err := chargingStation.StatusNotification(types.NewDateTime(time.Now()), status, evseID, connector)
+		checkError(err)
+		logDefault(response.GetFeatureName()).Infof("status for evse %d - connector %d updated to: %v", evseID, connector, status)
+	}
+}

--- a/example/2.0.1/chargingstation/iso15118_handler.go
+++ b/example/2.0.1/chargingstation/iso15118_handler.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/lorenzodonini/ocpp-go/ocpp"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/iso15118"
+	"github.com/lorenzodonini/ocpp-go/ocppj"
+)
+
+func (handler *ChargingStationHandler) OnDeleteCertificate(request *iso15118.DeleteCertificateRequest) (response *iso15118.DeleteCertificateResponse, err error) {
+	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (handler *ChargingStationHandler) OnGetInstalledCertificateIds(request *iso15118.GetInstalledCertificateIdsRequest) (response *iso15118.GetInstalledCertificateIdsResponse, err error) {
+	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (handler *ChargingStationHandler) OnInstallCertificate(request *iso15118.InstallCertificateRequest) (response *iso15118.InstallCertificateResponse, err error) {
+	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}

--- a/example/2.0.1/chargingstation/localauth_handler.go
+++ b/example/2.0.1/chargingstation/localauth_handler.go
@@ -1,0 +1,26 @@
+package main
+
+import "github.com/lorenzodonini/ocpp-go/ocpp2.0.1/localauth"
+
+func (handler *ChargingStationHandler) OnGetLocalListVersion(request *localauth.GetLocalListVersionRequest) (response *localauth.GetLocalListVersionResponse, err error) {
+	logDefault(request.GetFeatureName()).Infof("returning current local list version: %v", handler.localAuthListVersion)
+	return localauth.NewGetLocalListVersionResponse(handler.localAuthListVersion), nil
+}
+
+func (handler *ChargingStationHandler) OnSendLocalList(request *localauth.SendLocalListRequest) (response *localauth.SendLocalListResponse, err error) {
+	if request.VersionNumber <= handler.localAuthListVersion {
+		logDefault(request.GetFeatureName()).
+			Errorf("requested listVersion %v is lower/equal than the current list version %v", request.VersionNumber, handler.localAuthListVersion)
+		return localauth.NewSendLocalListResponse(localauth.SendLocalListStatusVersionMismatch), nil
+	}
+	if request.UpdateType == localauth.UpdateTypeFull {
+		handler.localAuthList = request.LocalAuthorizationList
+		handler.localAuthListVersion = request.VersionNumber
+	} else if request.UpdateType == localauth.UpdateTypeDifferential {
+		handler.localAuthList = append(handler.localAuthList, request.LocalAuthorizationList...)
+		handler.localAuthListVersion = request.VersionNumber
+	}
+	logDefault(request.GetFeatureName()).Errorf("accepted new local authorization list %v, %v",
+		request.VersionNumber, request.UpdateType)
+	return localauth.NewSendLocalListResponse(localauth.SendLocalListStatusAccepted), nil
+}

--- a/example/2.0.1/chargingstation/provisioning_handler.go
+++ b/example/2.0.1/chargingstation/provisioning_handler.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"github.com/lorenzodonini/ocpp-go/ocpp"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/provisioning"
+	"github.com/lorenzodonini/ocpp-go/ocppj"
+)
+
+func (handler *ChargingStationHandler) OnGetBaseReport(request *provisioning.GetBaseReportRequest) (response *provisioning.GetBaseReportResponse, err error) {
+	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (handler *ChargingStationHandler) OnGetReport(request *provisioning.GetReportRequest) (response *provisioning.GetReportResponse, err error) {
+	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (handler *ChargingStationHandler) OnGetVariables(request *provisioning.GetVariablesRequest) (response *provisioning.GetVariablesResponse, err error) {
+	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (handler *ChargingStationHandler) OnReset(request *provisioning.ResetRequest) (response *provisioning.ResetResponse, err error) {
+	logDefault(request.GetFeatureName()).Info("reset handled")
+	response = provisioning.NewResetResponse(provisioning.ResetStatusAccepted)
+	return
+}
+
+func (handler *ChargingStationHandler) OnSetNetworkProfile(request *provisioning.SetNetworkProfileRequest) (response *provisioning.SetNetworkProfileResponse, err error) {
+	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (handler *ChargingStationHandler) OnSetVariables(request *provisioning.SetVariablesRequest) (response *provisioning.SetVariablesResponse, err error) {
+	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+//func (handler *ChargingStationHandler) OnChangeConfiguration(request *core.ChangeConfigurationRequest) (confirmation *core.ChangeConfigurationConfirmation, err error) {
+//	configKey, ok := handler.configuration[request.Key]
+//	if !ok {
+//		logDefault(request.GetFeatureName()).Errorf("couldn't change configuration for unsupported parameter %v", configKey.Key)
+//		return core.NewChangeConfigurationConfirmation(core.ConfigurationStatusNotSupported), nil
+//	} else if configKey.Readonly {
+//		logDefault(request.GetFeatureName()).Errorf("couldn't change configuration for readonly parameter %v", configKey.Key)
+//		return core.NewChangeConfigurationConfirmation(core.ConfigurationStatusRejected), nil
+//	}
+//	configKey.Value = &request.Value
+//	handler.configuration[request.Key] = configKey
+//	logDefault(request.GetFeatureName()).Infof("changed configuration for parameter %v to %v", configKey.Key, configKey.Value)
+//	return core.NewChangeConfigurationConfirmation(core.ConfigurationStatusAccepted), nil
+//}
+//
+//func (handler *ChargingStationHandler) OnGetConfiguration(request *core.GetConfigurationRequest) (confirmation *core.GetConfigurationConfirmation, err error) {
+//	var resultKeys []core.ConfigurationKey
+//	var unknownKeys []string
+//	for _, key := range request.Key {
+//		configKey, ok := handler.configuration[key]
+//		if !ok {
+//			unknownKeys = append(unknownKeys, *configKey.Value)
+//		} else {
+//			resultKeys = append(resultKeys, configKey)
+//		}
+//	}
+//	if len(request.Key) == 0 {
+//		// Return config for all keys∂
+//		for _, v := range handler.configuration {
+//			resultKeys = append(resultKeys, v)
+//		}
+//	}
+//	logDefault(request.GetFeatureName()).Infof("returning configuration for requested keys: %v", request.Key)
+//	conf := core.NewGetConfigurationConfirmation(resultKeys)
+//	conf.UnknownKey = unknownKeys
+//	return conf, nil
+//}

--- a/example/2.0.1/chargingstation/remotecontrol_handler.go
+++ b/example/2.0.1/chargingstation/remotecontrol_handler.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"fmt"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/availability"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/diagnostics"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/provisioning"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/remotecontrol"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"math/rand"
+	"time"
+)
+
+func (handler *ChargingStationHandler) OnRequestStartTransaction(request *remotecontrol.RequestStartTransactionRequest) (response *remotecontrol.RequestStartTransactionResponse, err error) {
+	if request.EvseID != nil {
+		evse, ok := handler.evse[*request.EvseID]
+		if !ok || evse.availability != availability.OperationalStatusOperative {
+			return remotecontrol.NewRequestStartTransactionResponse(remotecontrol.RequestStartStopStatusRejected), nil
+		}
+		// Find occupied connector
+		connectorID := 0
+		for i, c := range evse.connectors {
+			if c.status == availability.ConnectorStatusOccupied {
+				connectorID = i
+				break
+			}
+		}
+		evse.currentTransaction = nextTransactionID()
+		logDefault(request.GetFeatureName()).Infof("started transaction %v on evse %v, connector %v", evse.currentTransaction, *request.EvseID, connectorID)
+		response = remotecontrol.NewRequestStartTransactionResponse(remotecontrol.RequestStartStopStatusAccepted)
+		response.TransactionID = fmt.Sprintf("%s", evse.currentTransaction)
+		return response, nil
+	}
+	logDefault(request.GetFeatureName()).Errorf("couldn't start a transaction for token %v without an evseID", request.IDToken)
+	return remotecontrol.NewRequestStartTransactionResponse(remotecontrol.RequestStartStopStatusRejected), nil
+}
+
+func (handler *ChargingStationHandler) OnRequestStopTransaction(request *remotecontrol.RequestStopTransactionRequest) (response *remotecontrol.RequestStopTransactionResponse, err error) {
+	for key, evse := range handler.evse {
+		if evse.currentTransaction == request.TransactionID {
+			logDefault(request.GetFeatureName()).Infof("stopped transaction %v on evse %v", evse.currentTransaction, key)
+			evse.currentTransaction = ""
+			evse.currentReservation = 0
+			// Find the currently occupied connector
+			for i, c := range evse.connectors {
+				if c.status == availability.ConnectorStatusOccupied {
+					evse.connectors[i].status = availability.ConnectorStatusAvailable
+					break
+				}
+			}
+			return remotecontrol.NewRequestStopTransactionResponse(remotecontrol.RequestStartStopStatusAccepted), nil
+		}
+	}
+	logDefault(request.GetFeatureName()).Errorf("couldn't stop transaction %v, no such transaction is ongoing", request.TransactionID)
+	return remotecontrol.NewRequestStopTransactionResponse(remotecontrol.RequestStartStopStatusRejected), nil
+}
+
+func (handler *ChargingStationHandler) OnTriggerMessage(request *remotecontrol.TriggerMessageRequest) (response *remotecontrol.TriggerMessageResponse, err error) {
+	logDefault(request.GetFeatureName()).Infof("received trigger for %v", request.RequestedMessage)
+	status := remotecontrol.TriggerMessageStatusRejected
+	switch request.RequestedMessage {
+	case remotecontrol.MessageTriggerBootNotification:
+		// Boot Notification
+		go func() {
+			_, e := chargingStation.BootNotification(provisioning.BootReasonTriggered, handler.model, handler.vendor)
+			checkError(e)
+			logDefault(provisioning.BootNotificationFeatureName).Info("boot notification completed")
+		}()
+		status = remotecontrol.TriggerMessageStatusAccepted
+	case remotecontrol.MessageTriggerLogStatusNotification:
+		// Log Status Notification
+		go func() {
+			reqID := rand.Int()
+			_, e := chargingStation.LogStatusNotification(diagnostics.UploadLogStatusUploading, reqID)
+			checkError(e)
+			logDefault(firmware.DiagnosticsStatusNotificationFeatureName).Info("diagnostics status notified")
+		}()
+		status = remotecontrol.TriggerMessageStatusAccepted
+	case remotecontrol.MessageTriggerFirmwareStatusNotification:
+		//TODO: schedule firmware status notification message
+		status = remotecontrol.TriggerMessageStatusAccepted
+	case remotecontrol.MessageTriggerHeartbeat:
+		// Schedule heartbeat request
+		go func() {
+			resp, e := chargingStation.Heartbeat()
+			checkError(e)
+			logDefault(availability.HeartbeatFeatureName).Infof("clock synchronized: %v", resp.CurrentTime.FormatTimestamp())
+		}()
+		status = remotecontrol.TriggerMessageStatusAccepted
+	case core.MeterValuesFeatureName:
+		// Schedule meter values update
+		//TODO: schedule meter values message
+		break
+	case remotecontrol.MessageTriggerStatusNotification:
+		// Schedule connector status notification
+		if request.Evse != nil {
+			connectorStatus := availability.ConnectorStatusUnavailable
+			evse, ok := handler.evse[request.Evse.ID]
+			if !ok {
+				status = remotecontrol.TriggerMessageStatusRejected
+				break
+			}
+			if request.Evse.ConnectorID != nil {
+				if !evse.hasConnector(*request.Evse.ConnectorID) {
+					status = remotecontrol.TriggerMessageStatusRejected
+					break
+				}
+				connectorStatus = evse.connectors[*request.Evse.ConnectorID].status
+			} else {
+				status = remotecontrol.TriggerMessageStatusRejected
+				break
+			}
+			// Update asynchronously
+			go func() {
+				_, e := chargingStation.StatusNotification(types.NewDateTime(time.Now()), connectorStatus, request.Evse.ID, *request.Evse.ConnectorID)
+				checkError(e)
+				logDefault(availability.HeartbeatFeatureName).Infof("status for connector %v sent: %v", *request.Evse.ConnectorID, connectorStatus)
+			}()
+			status = remotecontrol.TriggerMessageStatusAccepted
+		} else {
+			status = remotecontrol.TriggerMessageStatusRejected
+		}
+	case remotecontrol.MessageTriggerTransactionEvent:
+		// TODO:
+		break
+	default:
+		// We're not implementing support for other messages
+		status = remotecontrol.TriggerMessageStatusNotImplemented
+	}
+	return remotecontrol.NewTriggerMessageResponse(status), nil
+}
+
+func (handler *ChargingStationHandler) OnUnlockConnector(request *remotecontrol.UnlockConnectorRequest) (response *remotecontrol.UnlockConnectorResponse, err error) {
+	evse, ok := handler.evse[request.EvseID]
+	if !ok || !evse.hasConnector(request.ConnectorID) {
+		logDefault(request.GetFeatureName()).Errorf("couldn't unlock unknown connector %d for EVSE %d", request.ConnectorID, request.EvseID)
+		return remotecontrol.NewUnlockConnectorResponse(remotecontrol.UnlockStatusUnknownConnector), nil
+	}
+	connector := evse.connectors[request.ConnectorID]
+	// TODO: unlock connector internally
+	connector.status = availability.ConnectorStatusAvailable
+	logDefault(request.GetFeatureName()).Infof("unlocked connector %v for EVSE %d", request.ConnectorID, request.EvseID)
+	return remotecontrol.NewUnlockConnectorResponse(remotecontrol.UnlockStatusUnlocked), nil
+}

--- a/example/2.0.1/chargingstation/reservation_handler.go
+++ b/example/2.0.1/chargingstation/reservation_handler.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"fmt"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/availability"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/reservation"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+)
+
+func (handler *ChargingStationHandler) OnCancelReservation(request *reservation.CancelReservationRequest) (resp *reservation.CancelReservationResponse, err error) {
+	for i, e := range handler.evse {
+		if e.currentReservation == request.ReservationID {
+			// Found reservation -> cancel
+			e.currentReservation = -1
+			for j := range e.connectors {
+				if e.connectors[j].status == availability.ConnectorStatusReserved {
+					go updateConnectorStatus(handler, i, j, availability.ConnectorStatusAvailable)
+					break
+				}
+			}
+			logDefault(request.GetFeatureName()).Infof("reservation %v for evse %d canceled", request.ReservationID, i)
+			resp = reservation.NewCancelReservationResponse(reservation.CancelReservationStatusAccepted)
+			return
+		}
+	}
+	// Didn't find reservation -> reject
+	logDefault(request.GetFeatureName()).Infof("couldn't cancel reservation %v: reservation not found!", request.ReservationID)
+	resp = reservation.NewCancelReservationResponse(reservation.CancelReservationStatusRejected)
+	return
+}
+
+func (handler *ChargingStationHandler) OnReserveNow(request *reservation.ReserveNowRequest) (resp *reservation.ReserveNowResponse, err error) {
+	var reservedEvse int
+	var reservedConnector int
+	var status reservation.ReserveNowStatus
+
+	status, reservedEvse, reservedConnector, err = handler.findConnector(request.EvseID, request.ConnectorType)
+	if err != nil {
+		logDefault(request.GetFeatureName()).Error(err)
+	}
+	resp = reservation.NewReserveNowResponse(status)
+	if resp.Status != reservation.ReserveNowStatusAccepted {
+		resp.StatusInfo = types.NewStatusInfo("code", err.Error())
+		return
+	}
+	// Complete reservation
+	evse := handler.evse[reservedEvse]
+	evse.currentReservation = request.ID
+	logDefault(request.GetFeatureName()).Infof("reservation %v accepted for evse %v, connector %v",
+		request.ID, reservedEvse, reservedConnector)
+	go updateConnectorStatus(handler, reservedEvse, reservedConnector, availability.ConnectorStatusReserved)
+
+	// TODO: the logic above is incomplete. Advanced support for reservation management is missing.
+	// TODO: automatically remove reservation after expiryDate
+	return
+}
+
+func (handler *ChargingStationHandler) findConnector(requestedEVSE *int, connectorType reservation.ConnectorType) (status reservation.ReserveNowStatus, evseID int, connectorID int, err error) {
+	status = reservation.ReserveNowStatusAccepted
+	if requestedEVSE != nil {
+		evseID = *requestedEVSE
+		evse, ok := handler.evse[evseID]
+		if !ok {
+			status = reservation.ReserveNowStatusRejected
+			err = fmt.Errorf("couldn't reserve a connector for invalid evse %d", evseID)
+			return
+		} else if evse.currentReservation != 0 {
+			status = reservation.ReserveNowStatusOccupied
+			err = fmt.Errorf("evse %v already has a pending reservation", evseID)
+			return
+		} else if evse.availability == availability.OperationalStatusInoperative {
+			status = reservation.ReserveNowStatusUnavailable
+			err = fmt.Errorf("evse %v is currently not operative", evseID)
+			return
+		}
+		for i, c := range evse.connectors {
+			if connectorType != "" && c.typ != connectorType {
+				continue
+			}
+			switch c.status {
+			case availability.ConnectorStatusReserved, availability.ConnectorStatusOccupied:
+				status = reservation.ReserveNowStatusOccupied
+			case availability.ConnectorStatusUnavailable:
+				status = reservation.ReserveNowStatusUnavailable
+			case availability.ConnectorStatusFaulted:
+				status = reservation.ReserveNowStatusUnavailable
+			case availability.ConnectorStatusAvailable:
+				// Found an available connector
+				status = reservation.ReserveNowStatusAccepted
+				connectorID = i
+				return
+			}
+		}
+	} else {
+		// Find suitable evse + connector
+		for j, e := range handler.evse {
+			evseID = j
+			if e.currentReservation != 0 {
+				status = reservation.ReserveNowStatusOccupied
+				err = fmt.Errorf("evse %v already has a pending reservation", evseID)
+				return
+			} else if e.availability == availability.OperationalStatusInoperative {
+				status = reservation.ReserveNowStatusUnavailable
+				err = fmt.Errorf("evse %v is currently not operative", evseID)
+				return
+			}
+			for i, c := range e.connectors {
+				if connectorType != "" && c.typ != connectorType {
+					continue
+				}
+				switch c.status {
+				case availability.ConnectorStatusReserved, availability.ConnectorStatusOccupied:
+					status = reservation.ReserveNowStatusOccupied
+				case availability.ConnectorStatusUnavailable:
+					status = reservation.ReserveNowStatusUnavailable
+				case availability.ConnectorStatusFaulted:
+					status = reservation.ReserveNowStatusUnavailable
+				case availability.ConnectorStatusAvailable:
+					// Found an available connector
+					status = reservation.ReserveNowStatusAccepted
+					connectorID = i
+					return
+				}
+			}
+		}
+		if status == "" {
+			status = reservation.ReserveNowStatusRejected
+			err = fmt.Errorf("no available evse found")
+		}
+	}
+	return
+}

--- a/example/2.0.1/chargingstation/smartcharging_handler.go
+++ b/example/2.0.1/chargingstation/smartcharging_handler.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"github.com/lorenzodonini/ocpp-go/ocpp"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/smartcharging"
+	"github.com/lorenzodonini/ocpp-go/ocppj"
+)
+
+func (handler *ChargingStationHandler) OnClearChargingProfile(request *smartcharging.ClearChargingProfileRequest) (response *smartcharging.ClearChargingProfileResponse, err error) {
+	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (handler *ChargingStationHandler) OnGetChargingProfiles(request *smartcharging.GetChargingProfilesRequest) (response *smartcharging.GetChargingProfilesResponse, err error) {
+	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (handler *ChargingStationHandler) OnGetCompositeSchedule(request *smartcharging.GetCompositeScheduleRequest) (response *smartcharging.GetCompositeScheduleResponse, err error) {
+	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (handler *ChargingStationHandler) OnSetChargingProfile(request *smartcharging.SetChargingProfileRequest) (response *smartcharging.SetChargingProfileResponse, err error) {
+	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}

--- a/example/2.0.1/chargingstation/tariffcost_handler.go
+++ b/example/2.0.1/chargingstation/tariffcost_handler.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/tariffcost"
+)
+
+func (handler *ChargingStationHandler) OnCostUpdated(request *tariffcost.CostUpdatedRequest) (response *tariffcost.CostUpdatedResponse, err error) {
+	logDefault(request.GetFeatureName()).Infof("accepted request to display cost for transaction %v: %v", request.TransactionID, request.TotalCost)
+	// TODO: update internal display to show updated cost for transaction
+	return tariffcost.NewCostUpdatedResponse(), nil
+}

--- a/example/2.0.1/chargingstation/transactions_handler.go
+++ b/example/2.0.1/chargingstation/transactions_handler.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/lorenzodonini/ocpp-go/ocpp"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/transactions"
+	"github.com/lorenzodonini/ocpp-go/ocppj"
+)
+
+func (handler *ChargingStationHandler) OnGetTransactionStatus(request *transactions.GetTransactionStatusRequest) (response *transactions.GetTransactionStatusResponse, err error) {
+	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}

--- a/example/2.0.1/create-test-certificates.sh
+++ b/example/2.0.1/create-test-certificates.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+mkdir -p certs/csms
+mkdir -p certs/chargingstation
+cd certs
+# Create CA
+openssl req -new -x509 -nodes -days 120 -extensions v3_ca -keyout ca.key -out ca.crt -subj "/CN=ocpp-go-example"
+# Generate self-signed CSMS certificate
+openssl genrsa -out csms/csms.key 4096
+openssl req -new -out csms/csms.csr -key csms/csms.key -config ../openssl-csms.conf -sha256
+openssl x509 -req -in csms/csms.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out csms/csms.crt -days 120 -extensions req_ext -extfile ../openssl-csms.conf -sha256
+# Generate self-signed charging-station certificate
+openssl genrsa -out chargingstation/charging-station.key 4096
+openssl req -new -out chargingstation/charging-station.csr -key chargingstation/charging-station.key -config ../openssl-chargingstation.conf -sha256
+openssl x509 -req -in chargingstation/charging-station.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out chargingstation/charging-station.crt -days 120 -extensions req_ext -extfile ../openssl-chargingstation.conf -sha256

--- a/example/2.0.1/create-test-certificates.sh
+++ b/example/2.0.1/create-test-certificates.sh
@@ -4,7 +4,7 @@ mkdir -p certs/csms
 mkdir -p certs/chargingstation
 cd certs
 # Create CA
-openssl req -new -x509 -nodes -days 120 -extensions v3_ca -keyout ca.key -out ca.crt -subj "/CN=ocpp-go-example"
+openssl req -new -x509 -nodes -sha256 -days 120 -extensions v3_ca -keyout ca.key -out ca.crt -subj "/CN=ocpp-go-example"
 # Generate self-signed CSMS certificate
 openssl genrsa -out csms/csms.key 4096
 openssl req -new -out csms/csms.csr -key csms/csms.key -config ../openssl-csms.conf -sha256

--- a/example/2.0.1/csms/Dockerfile
+++ b/example/2.0.1/csms/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 # Fetch dependencies.
 RUN go mod download
 # Build the binary.
-RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/csms example/2.0.1/csms/*.go
+RUN go build -ldflags="-w -s" -o /go/bin/csms example/2.0.1/csms/*.go
 
 ############################
 # STEP 2 build a small image

--- a/example/2.0.1/csms/Dockerfile
+++ b/example/2.0.1/csms/Dockerfile
@@ -1,0 +1,25 @@
+############################
+# STEP 1 build executable binary
+############################
+FROM golang:alpine AS builder
+
+ENV GO111MODULE on
+WORKDIR $GOPATH/src/github.com/lorenzodonini/ocpp-go
+COPY . .
+# Fetch dependencies.
+RUN go mod download
+# Build the binary.
+RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/csms example/2.0.1/csms/*.go
+
+############################
+# STEP 2 build a small image
+############################
+FROM alpine
+
+COPY --from=builder /go/bin/csms /bin/csms
+
+# Ports on which the service may be exposed.
+EXPOSE 8887
+EXPOSE 443
+
+CMD [ "csms" ]

--- a/example/2.0.1/csms/authorization_handler.go
+++ b/example/2.0.1/csms/authorization_handler.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/authorization"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+)
+
+func (c *CSMSHandler) OnAuthorize(chargingStationID string, request *authorization.AuthorizeRequest) (response *authorization.AuthorizeResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Infof("client with token %v authorized", request.IdToken)
+	response = authorization.NewAuthorizationResponse(*types.NewIdTokenInfo(types.AuthorizationStatusAccepted))
+	return
+}

--- a/example/2.0.1/csms/availability_handler.go
+++ b/example/2.0.1/csms/availability_handler.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/availability"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"time"
+)
+
+func (c *CSMSHandler) OnHeartbeat(chargingStationID string, request *availability.HeartbeatRequest) (response *availability.HeartbeatResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Infof("heartbeat handled")
+	response = availability.NewHeartbeatResponse(types.DateTime{Time: time.Now()})
+	return
+}
+
+func (c *CSMSHandler) OnStatusNotification(chargingStationID string, request *availability.StatusNotificationRequest) (response *availability.StatusNotificationResponse, err error) {
+	info, ok := c.chargingStations[chargingStationID]
+	if !ok {
+		return nil, fmt.Errorf("unknown charging station %v", chargingStationID)
+	}
+	if request.ConnectorID > 0 {
+		connectorInfo := info.getConnector(request.ConnectorID)
+		connectorInfo.status = request.ConnectorStatus
+		logDefault(chargingStationID, request.GetFeatureName()).Infof("connector %v updated status to %v", request.ConnectorID, request.ConnectorStatus)
+	} else {
+		logDefault(chargingStationID, request.GetFeatureName()).Infof("couldn't update status for invalid connector %v", request.ConnectorID)
+	}
+	response = availability.NewStatusNotificationResponse()
+	return
+}

--- a/example/2.0.1/csms/csms_sim.go
+++ b/example/2.0.1/csms/csms_sim.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/availability"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/diagnostics"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/localauth"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/provisioning"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/remotecontrol"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/reservation"
+	types2 "github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/ocppj"
+	"github.com/lorenzodonini/ocpp-go/ws"
+)
+
+const (
+	defaultListenPort          = 8887
+	defaultHeartbeatInterval   = 600
+	envVarServerPort           = "SERVER_LISTEN_PORT"
+	envVarTls                  = "TLS_ENABLED"
+	envVarCaCertificate        = "CA_CERTIFICATE_PATH"
+	envVarServerCertificate    = "SERVER_CERTIFICATE_PATH"
+	envVarServerCertificateKey = "SERVER_CERTIFICATE_KEY_PATH"
+)
+
+var log *logrus.Logger
+var csms ocpp2.CSMS
+
+func setupCentralSystem() ocpp2.CSMS {
+	return ocpp2.NewCSMS(nil, nil)
+}
+
+func setupTlsCentralSystem() ocpp2.CSMS {
+	var certPool *x509.CertPool
+	// Load CA certificates
+	caCertificate, ok := os.LookupEnv(envVarCaCertificate)
+	if !ok {
+		log.Infof("no %v found, using system CA pool", envVarCaCertificate)
+		systemPool, err := x509.SystemCertPool()
+		if err != nil {
+			log.Fatalf("couldn't get system CA pool: %v", err)
+		}
+		certPool = systemPool
+	} else {
+		certPool = x509.NewCertPool()
+		data, err := ioutil.ReadFile(caCertificate)
+		if err != nil {
+			log.Fatalf("couldn't read CA certificate from %v: %v", caCertificate, err)
+		}
+		ok = certPool.AppendCertsFromPEM(data)
+		if !ok {
+			log.Fatalf("couldn't read CA certificate from %v", caCertificate)
+		}
+	}
+	certificate, ok := os.LookupEnv(envVarServerCertificate)
+	if !ok {
+		log.Fatalf("no required %v found", envVarServerCertificate)
+	}
+	key, ok := os.LookupEnv(envVarServerCertificateKey)
+	if !ok {
+		log.Fatalf("no required %v found", envVarServerCertificateKey)
+	}
+	server := ws.NewTLSServer(certificate, key, &tls.Config{
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  certPool,
+	})
+	return ocpp2.NewCSMS(nil, server)
+}
+
+// Run for every connected Charge Point, to simulate some functionality
+func exampleRoutine(chargePointID string, handler *CSMSHandler) {
+	// Wait for some time
+	time.Sleep(2 * time.Second)
+	// Reserve a connector
+	reservationID := 42
+	clientIDTokenType := types2.IdTokenTypeKeyCode
+	clientIdTag := "l33t"
+	connectorID := 1
+	expiryDate := types2.NewDateTime(time.Now().Add(1 * time.Hour))
+	cb1 := func(confirmation *reservation.ReserveNowResponse, err error) {
+		if err != nil {
+			logDefault(chargePointID, reservation.ReserveNowFeatureName).Errorf("error on request: %v", err)
+		} else if confirmation.Status == reservation.ReserveNowStatusAccepted {
+			logDefault(chargePointID, confirmation.GetFeatureName()).Infof("connector %v reserved for client %v until %v (reservation ID %d)", connectorID, clientIdTag, expiryDate.FormatTimestamp(), reservationID)
+		} else {
+			logDefault(chargePointID, confirmation.GetFeatureName()).Infof("couldn't reserve connector %v: %v", connectorID, confirmation.Status)
+		}
+	}
+	e := csms.ReserveNow(chargePointID, cb1, reservationID, expiryDate, clientIDTokenType)
+	if e != nil {
+		logDefault(chargePointID, reservation.ReserveNowFeatureName).Errorf("couldn't send message: %v", e)
+		return
+	}
+	// Wait for some time
+	time.Sleep(1 * time.Second)
+	// Cancel the reservation
+	cb2 := func(confirmation *reservation.CancelReservationResponse, err error) {
+		if err != nil {
+			logDefault(chargePointID, reservation.CancelReservationFeatureName).Errorf("error on request: %v", err)
+		} else if confirmation.Status == reservation.CancelReservationStatusAccepted {
+			logDefault(chargePointID, confirmation.GetFeatureName()).Infof("reservation %v canceled successfully", reservationID)
+		} else {
+			logDefault(chargePointID, confirmation.GetFeatureName()).Infof("couldn't cancel reservation %v", reservationID)
+		}
+	}
+	e = csms.CancelReservation(chargePointID, cb2, reservationID)
+	if e != nil {
+		logDefault(chargePointID, reservation.ReserveNowFeatureName).Errorf("couldn't send message: %v", e)
+		return
+	}
+	// Wait for some time
+	time.Sleep(5 * time.Second)
+	// Get current local list version
+	cb3 := func(confirmation *localauth.GetLocalListVersionResponse, err error) {
+		if err != nil {
+			logDefault(chargePointID, localauth.GetLocalListVersionFeatureName).Errorf("error on request: %v", err)
+		} else {
+			logDefault(chargePointID, confirmation.GetFeatureName()).Infof("current local list version: %v", confirmation.VersionNumber)
+		}
+	}
+	e = csms.GetLocalListVersion(chargePointID, cb3)
+	if e != nil {
+		logDefault(chargePointID, localauth.GetLocalListVersionFeatureName).Errorf("couldn't send message: %v", e)
+		return
+	}
+	// Wait for some time
+	time.Sleep(5 * time.Second)
+	setVariableData := []provisioning.SetVariableData{
+		{
+			AttributeType:  types2.AttributeTarget,
+			AttributeValue: "10",
+			Component:      types2.Component{Name: "OCPPCommCtrlr"},
+			Variable:       types2.Variable{Name: "HeartbeatInterval"},
+		},
+		{
+			AttributeType:  types2.AttributeTarget,
+			AttributeValue: "true",
+			Component:      types2.Component{Name: "AuthCtrlr"},
+			Variable:       types2.Variable{Name: "Enabled"},
+		},
+	}
+	// Change meter sampling values time
+	cb4 := func(confirmation *provisioning.SetVariablesResponse, err error) {
+		if err != nil {
+			logDefault(chargePointID, provisioning.SetVariablesFeatureName).Errorf("error on request: %v", err)
+		}
+		for _, r := range confirmation.SetVariableResult {
+			if r.AttributeStatus == provisioning.SetVariableStatusNotSupported {
+				logDefault(chargePointID, confirmation.GetFeatureName()).Warnf("couldn't update variable %v for component %v: unsupported", r.Variable.Name, r.Component.Name)
+			} else if r.AttributeStatus == provisioning.SetVariableStatusUnknownComponent {
+				logDefault(chargePointID, confirmation.GetFeatureName()).Warnf("couldn't update variable for unknown component %v", r.Component.Name)
+			} else if r.AttributeStatus == provisioning.SetVariableStatusUnknownVariable {
+				logDefault(chargePointID, confirmation.GetFeatureName()).Warnf("couldn't update unknown variable %v for component %v", r.Variable.Name, r.Component.Name)
+			} else if r.AttributeStatus == provisioning.SetVariableStatusRejected {
+				logDefault(chargePointID, confirmation.GetFeatureName()).Warnf("couldn't update variable %v for key: %v", r.Variable.Name, r.Component.Name)
+			} else {
+				logDefault(chargePointID, confirmation.GetFeatureName()).Infof("updated variable %v for component %v", r.Variable.Name, r.Component.Name)
+			}
+		}
+	}
+	e = csms.SetVariables(chargePointID, cb4, setVariableData)
+	if e != nil {
+		logDefault(chargePointID, localauth.GetLocalListVersionFeatureName).Errorf("couldn't send message: %v", e)
+		return
+	}
+
+	// Wait for some time
+	time.Sleep(5 * time.Second)
+	// Trigger a heartbeat message
+	cb5 := func(confirmation *remotecontrol.TriggerMessageResponse, err error) {
+		if err != nil {
+			logDefault(chargePointID, remotecontrol.TriggerMessageFeatureName).Errorf("error on request: %v", err)
+		} else if confirmation.Status == remotecontrol.TriggerMessageStatusAccepted {
+			logDefault(chargePointID, confirmation.GetFeatureName()).Infof("%v triggered successfully", availability.HeartbeatFeatureName)
+		} else if confirmation.Status == remotecontrol.TriggerMessageStatusRejected {
+			logDefault(chargePointID, confirmation.GetFeatureName()).Infof("%v trigger was rejected", availability.HeartbeatFeatureName)
+		}
+	}
+	e = csms.TriggerMessage(chargePointID, cb5, core.HeartbeatFeatureName)
+	if e != nil {
+		logDefault(chargePointID, remotecontrol.TriggerMessageFeatureName).Errorf("couldn't send message: %v", e)
+		return
+	}
+
+	// Wait for some time
+	time.Sleep(5 * time.Second)
+	// Trigger a diagnostics status notification
+	cb6 := func(confirmation *remotecontrol.TriggerMessageResponse, err error) {
+		if err != nil {
+			logDefault(chargePointID, remotecontrol.TriggerMessageFeatureName).Errorf("error on request: %v", err)
+		} else if confirmation.Status == remotecontrol.TriggerMessageStatusAccepted {
+			logDefault(chargePointID, confirmation.GetFeatureName()).Infof("%v triggered successfully", diagnostics.LogStatusNotificationFeatureName)
+		} else if confirmation.Status == remotecontrol.TriggerMessageStatusRejected {
+			logDefault(chargePointID, confirmation.GetFeatureName()).Infof("%v trigger was rejected", diagnostics.LogStatusNotificationFeatureName)
+		}
+	}
+	e = csms.TriggerMessage(chargePointID, cb6, diagnostics.LogStatusNotificationFeatureName)
+	if e != nil {
+		logDefault(chargePointID, remotecontrol.TriggerMessageFeatureName).Errorf("couldn't send message: %v", e)
+		return
+	}
+
+	// Wait for some time
+	time.Sleep(5 * time.Second)
+	// Trigger a
+}
+
+// Start function
+func main() {
+	// Load config from ENV
+	var listenPort = defaultListenPort
+	port, _ := os.LookupEnv(envVarServerPort)
+	if p, err := strconv.Atoi(port); err == nil {
+		listenPort = p
+	} else {
+		log.Printf("no valid %v environment variable found, using default port", envVarServerPort)
+	}
+	// Check if TLS enabled
+	t, _ := os.LookupEnv(envVarTls)
+	tlsEnabled, _ := strconv.ParseBool(t)
+	// Prepare OCPP 1.6 central system
+	if tlsEnabled {
+		csms = setupTlsCentralSystem()
+	} else {
+		csms = setupCentralSystem()
+	}
+	// Support callbacks for all OCPP 2.0.1 profiles
+	handler := &CSMSHandler{chargingStations: map[string]*ChargingStationState{}}
+	csms.SetAuthorizationHandler(handler)
+	csms.SetAvailabilityHandler(handler)
+	csms.SetDiagnosticsHandler(handler)
+	csms.SetFirmwareHandler(handler)
+	csms.SetLocalAuthListHandler(handler)
+	csms.SetMeterHandler(handler)
+	csms.SetProvisioningHandler(handler)
+	csms.SetRemoteControlHandler(handler)
+	csms.SetReservationHandler(handler)
+	csms.SetTariffCostHandler(handler)
+	csms.SetTransactionsHandler(handler)
+	// Add handlers for dis/connection of charge points
+	csms.SetNewChargingStationHandler(func(chargePoint ocpp2.ChargingStationConnection) {
+		handler.chargingStations[chargePoint.ID()] = &ChargingStationState{connectors: map[int]*ConnectorInfo{}, transactions: map[int]*TransactionInfo{}}
+		log.WithField("client", chargePoint.ID()).Info("new charging station connected")
+		go exampleRoutine(chargePoint.ID(), handler)
+	})
+	csms.SetChargingStationDisconnectedHandler(func(chargePoint ocpp2.ChargingStationConnection) {
+		log.WithField("client", chargePoint.ID()).Info("charging station disconnected")
+		delete(handler.chargingStations, chargePoint.ID())
+	})
+	ocppj.SetLogger(log)
+	// Run CSMS
+	log.Infof("starting CSMS on port %v", listenPort)
+	csms.Start(listenPort, "/{ws}")
+	log.Info("stopped CSMS")
+}
+
+func init() {
+	log = logrus.New()
+	log.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+	log.SetLevel(logrus.InfoLevel)
+}

--- a/example/2.0.1/csms/data_handler.go
+++ b/example/2.0.1/csms/data_handler.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/data"
+)
+
+type DataSample struct {
+	SampleString string  `json:"sample_string"`
+	SampleValue  float64 `json:"sample_value"`
+}
+
+func (c *CSMSHandler) OnDataTransfer(chargingStationID string, request *data.DataTransferRequest) (response *data.DataTransferResponse, err error) {
+	var dataSample DataSample
+	err = json.Unmarshal(request.Data.([]byte), &dataSample)
+	if err != nil {
+		logDefault(chargingStationID, request.GetFeatureName()).
+			Errorf("invalid data received: %v", request.Data)
+		return nil, err
+	}
+	logDefault(chargingStationID, request.GetFeatureName()).
+		Infof("data received: %v, %v", dataSample.SampleString, dataSample.SampleString)
+	return data.NewDataTransferResponse(data.DataTransferStatusAccepted), nil
+}

--- a/example/2.0.1/csms/data_handler.go
+++ b/example/2.0.1/csms/data_handler.go
@@ -19,6 +19,6 @@ func (c *CSMSHandler) OnDataTransfer(chargingStationID string, request *data.Dat
 		return nil, err
 	}
 	logDefault(chargingStationID, request.GetFeatureName()).
-		Infof("data received: %v, %v", dataSample.SampleString, dataSample.SampleString)
+		Infof("data received: %v, %v", dataSample.SampleString, dataSample.SampleValue)
 	return data.NewDataTransferResponse(data.DataTransferStatusAccepted), nil
 }

--- a/example/2.0.1/csms/diagnostics_handler.go
+++ b/example/2.0.1/csms/diagnostics_handler.go
@@ -1,0 +1,33 @@
+package main
+
+import "github.com/lorenzodonini/ocpp-go/ocpp2.0.1/diagnostics"
+
+func (c *CSMSHandler) OnLogStatusNotification(chargingStationID string, request *diagnostics.LogStatusNotificationRequest) (response *diagnostics.LogStatusNotificationResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Infof("log upload status: %v", request.Status)
+	response = diagnostics.NewLogStatusNotificationResponse()
+	return
+}
+
+func (c *CSMSHandler) OnNotifyCustomerInformation(chargingStationID string, request *diagnostics.NotifyCustomerInformationRequest) (response *diagnostics.NotifyCustomerInformationResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Infof("data report for request %v: %v", request.RequestID, request.Data)
+	response = diagnostics.NewNotifyCustomerInformationResponse()
+	return
+}
+
+func (c *CSMSHandler) OnNotifyEvent(chargingStationID string, request *diagnostics.NotifyEventRequest) (response *diagnostics.NotifyEventResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Infof("report part %v for events:\n", request.SeqNo)
+	for _, ed := range request.EventData {
+		logDefault(chargingStationID, request.GetFeatureName()).Infof("%v", ed)
+	}
+	response = diagnostics.NewNotifyEventResponse()
+	return
+}
+
+func (c *CSMSHandler) OnNotifyMonitoringReport(chargingStationID string, request *diagnostics.NotifyMonitoringReportRequest) (response *diagnostics.NotifyMonitoringReportResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Infof("report part %v for monitored variables:\n", request.SeqNo)
+	for _, md := range request.Monitor {
+		logDefault(chargingStationID, request.GetFeatureName()).Infof("%v", md)
+	}
+	response = diagnostics.NewNotifyMonitoringReportResponse()
+	return
+}

--- a/example/2.0.1/csms/display_handler.go
+++ b/example/2.0.1/csms/display_handler.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/display"
+)
+
+func (c *CSMSHandler) OnNotifyDisplayMessages(chargingStationID string, request *display.NotifyDisplayMessagesRequest) (response *display.NotifyDisplayMessagesResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Infof("received display messages for request %v:\n", request.RequestID)
+	for _, msg := range request.MessageInfo {
+		logDefault(chargingStationID, request.GetFeatureName()).Printf("%v", msg)
+	}
+	response = display.NewNotifyDisplayMessagesResponse()
+	return
+}

--- a/example/2.0.1/csms/firmware_handler.go
+++ b/example/2.0.1/csms/firmware_handler.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/firmware"
+)
+
+func (c *CSMSHandler) OnFirmwareStatusNotification(chargingStationID string, request *firmware.FirmwareStatusNotificationRequest) (response *firmware.FirmwareStatusNotificationResponse, err error) {
+	info, ok := c.chargingStations[chargingStationID]
+	if !ok {
+		err = fmt.Errorf("unknown charging station %v", chargingStationID)
+		return
+	}
+	info.firmwareStatus = request.Status
+	logDefault(chargingStationID, request.GetFeatureName()).Infof("updated firmware status to %v", request.Status)
+	response = firmware.NewFirmwareStatusNotificationResponse()
+	return
+}
+
+func (c *CSMSHandler) OnPublishFirmwareStatusNotification(chargingStationID string, request *firmware.PublishFirmwareStatusNotificationRequest) (response *firmware.PublishFirmwareStatusNotificationResponse, err error) {
+	if len(request.Location) > 0 {
+		logDefault(chargingStationID, request.GetFeatureName()).Infof("firmware download status on local controller: %v, download locations: %v", request.Status, request.Location)
+	} else {
+		logDefault(chargingStationID, request.GetFeatureName()).Infof("firmware download status on local controller: %v", request.Status)
+	}
+	response = firmware.NewPublishFirmwareStatusNotificationResponse()
+	return
+}

--- a/example/2.0.1/csms/handler.go
+++ b/example/2.0.1/csms/handler.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/availability"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/firmware"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+)
+
+// TransactionInfo contains info about a transaction
+type TransactionInfo struct {
+	id          int
+	startTime   *types.DateTime
+	endTime     *types.DateTime
+	startMeter  int
+	endMeter    int
+	connectorID int
+	idTag       string
+}
+
+func (ti *TransactionInfo) hasTransactionEnded() bool {
+	return ti.endTime != nil && !ti.endTime.IsZero()
+}
+
+// ConnectorInfo contains status and ongoing transaction ID for a connector
+type ConnectorInfo struct {
+	status             availability.ConnectorStatus
+	currentTransaction int
+}
+
+func (ci *ConnectorInfo) hasTransactionInProgress() bool {
+	return ci.currentTransaction >= 0
+}
+
+// ChargingStationState contains some simple state for a connected charging station
+type ChargingStationState struct {
+	status         availability.ChangeAvailabilityStatus
+	firmwareStatus firmware.FirmwareStatus
+	connectors     map[int]*ConnectorInfo
+	transactions   map[int]*TransactionInfo
+}
+
+func (s *ChargingStationState) getConnector(id int) *ConnectorInfo {
+	ci, ok := s.connectors[id]
+	if !ok {
+		ci = &ConnectorInfo{currentTransaction: -1}
+		s.connectors[id] = ci
+	}
+	return ci
+}
+
+// CSMSHandler contains some simple state that a CSMS may want to keep.
+// In production this will typically be replaced by database/API calls.
+type CSMSHandler struct {
+	chargingStations map[string]*ChargingStationState
+}
+
+// Utility functions
+func logDefault(chargingStationID string, feature string) *logrus.Entry {
+	return log.WithFields(logrus.Fields{"client": chargingStationID, "message": feature})
+}

--- a/example/2.0.1/csms/iso15118_handler.go
+++ b/example/2.0.1/csms/iso15118_handler.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/lorenzodonini/ocpp-go/ocpp"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/iso15118"
+	"github.com/lorenzodonini/ocpp-go/ocppj"
+)
+
+func (c *CSMSHandler) OnGet15118EVCertificate(chargingStationID string, request *iso15118.Get15118EVCertificateRequest) (response *iso15118.Get15118EVCertificateResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (c *CSMSHandler) OnGetCertificateStatus(chargingStationID string, request *iso15118.GetCertificateStatusRequest) (response *iso15118.GetCertificateStatusResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}

--- a/example/2.0.1/csms/meter_handler.go
+++ b/example/2.0.1/csms/meter_handler.go
@@ -1,0 +1,12 @@
+package main
+
+import "github.com/lorenzodonini/ocpp-go/ocpp2.0.1/meter"
+
+func (c *CSMSHandler) OnMeterValues(chargingStationID string, request *meter.MeterValuesRequest) (response *meter.MeterValuesResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Infof("received meter values for EVSE %v. Meter values:\n", request.EvseID)
+	for _, mv := range request.MeterValue {
+		logDefault(chargingStationID, request.GetFeatureName()).Printf("%v", mv)
+	}
+	response = meter.NewMeterValuesResponse()
+	return
+}

--- a/example/2.0.1/csms/provisioning_handler.go
+++ b/example/2.0.1/csms/provisioning_handler.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/provisioning"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"time"
+)
+
+func (c *CSMSHandler) OnBootNotification(chargingStationID string, request *provisioning.BootNotificationRequest) (response *provisioning.BootNotificationResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Infof("boot confirmed for %v %v, serial: %v, firmare version: %v, reason: %v",
+		request.ChargingStation.VendorName, request.ChargingStation.Model, request.ChargingStation.SerialNumber, request.ChargingStation.FirmwareVersion, request.Reason)
+	response = provisioning.NewBootNotificationResponse(types.NewDateTime(time.Now()), defaultHeartbeatInterval, provisioning.RegistrationStatusAccepted)
+	return
+}
+
+func (c *CSMSHandler) OnNotifyReport(chargingStationID string, request *provisioning.NotifyReportRequest) (response *provisioning.NotifyReportResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Infof("data report %v, seq. %v:\n", request.RequestID, request.SeqNo)
+	for _, d := range request.ReportData {
+		logDefault(chargingStationID, request.GetFeatureName()).Printf("%v", d)
+	}
+	response = provisioning.NewNotifyReportResponse()
+	return
+}

--- a/example/2.0.1/csms/reservation_handler.go
+++ b/example/2.0.1/csms/reservation_handler.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/lorenzodonini/ocpp-go/ocpp2.0.1/reservation"
+
+func (c *CSMSHandler) OnReservationStatusUpdate(chargingStationID string, request *reservation.ReservationStatusUpdateRequest) (response *reservation.ReservationStatusUpdateResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Infof("updated status of reservation %v to: %v", request.ReservationID, request.Status)
+	response = reservation.NewReservationStatusUpdateResponse()
+	return
+}

--- a/example/2.0.1/csms/security_handler.go
+++ b/example/2.0.1/csms/security_handler.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/lorenzodonini/ocpp-go/ocpp"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/security"
+	"github.com/lorenzodonini/ocpp-go/ocppj"
+)
+
+func (c *CSMSHandler) OnSecurityEventNotification(chargingStationID string, request *security.SecurityEventNotificationRequest) (response *security.SecurityEventNotificationResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Infof("type: %s, info: %s", request.Type, request.TechInfo)
+	response = security.NewSecurityEventNotificationResponse()
+	return
+}
+
+func (c *CSMSHandler) OnSignCertificate(chargingStationID string, request *security.SignCertificateRequest) (response *security.SignCertificateResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}

--- a/example/2.0.1/csms/smartcharging_handler.go
+++ b/example/2.0.1/csms/smartcharging_handler.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"github.com/lorenzodonini/ocpp-go/ocpp"
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/smartcharging"
+	"github.com/lorenzodonini/ocpp-go/ocppj"
+)
+
+func (c *CSMSHandler) OnClearedChargingLimit(chargingStationID string, request *smartcharging.ClearedChargingLimitRequest) (response *smartcharging.ClearedChargingLimitResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (c *CSMSHandler) OnNotifyChargingLimit(chargingStationID string, request *smartcharging.NotifyChargingLimitRequest) (response *smartcharging.NotifyChargingLimitResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (c *CSMSHandler) OnNotifyEVChargingNeeds(chargingStationID string, request *smartcharging.NotifyEVChargingNeedsRequest) (response *smartcharging.NotifyEVChargingNeedsResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (c *CSMSHandler) OnNotifyEVChargingSchedule(chargingStationID string, request *smartcharging.NotifyEVChargingScheduleRequest) (response *smartcharging.NotifyEVChargingScheduleResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}
+
+func (c *CSMSHandler) OnReportChargingProfiles(chargingStationID string, request *smartcharging.ReportChargingProfilesRequest) (response *smartcharging.ReportChargingProfilesResponse, err error) {
+	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
+	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+}

--- a/example/2.0.1/csms/transactions_handler.go
+++ b/example/2.0.1/csms/transactions_handler.go
@@ -1,0 +1,22 @@
+package main
+
+import "github.com/lorenzodonini/ocpp-go/ocpp2.0.1/transactions"
+
+func (c *CSMSHandler) OnTransactionEvent(chargingStationID string, request *transactions.TransactionEventRequest) (response *transactions.TransactionEventResponse, err error) {
+	switch request.EventType {
+	case transactions.TransactionEventStarted:
+		logDefault(chargingStationID, request.GetFeatureName()).Infof("transaction %v started, reason: %v, state: %v", request.TransactionInfo.TransactionID, request.TriggerReason, request.TransactionInfo.ChargingState)
+		break
+	case transactions.TransactionEventUpdated:
+		logDefault(chargingStationID, request.GetFeatureName()).Infof("transaction %v updated, reason: %v, state: %v\n", request.TransactionInfo.TransactionID, request.TriggerReason, request.TransactionInfo.ChargingState)
+		for _, mv := range request.MeterValue {
+			logDefault(chargingStationID, request.GetFeatureName()).Printf("%v", mv)
+		}
+		break
+	case transactions.TransactionEventEnded:
+		logDefault(chargingStationID, request.GetFeatureName()).Infof("transaction %v stopped, reason: %v, state: %v\n", request.TransactionInfo.TransactionID, request.TriggerReason, request.TransactionInfo.ChargingState)
+		break
+	}
+	response = transactions.NewTransactionEventResponse()
+	return
+}

--- a/example/2.0.1/docker-compose.tls.yml
+++ b/example/2.0.1/docker-compose.tls.yml
@@ -1,0 +1,45 @@
+version: '3'
+services:
+  csms:
+    build:
+      context: ../..
+      dockerfile: csms/Dockerfile
+    image: ldonini/ocpp2.0.1-csms:latest
+    container_name: csms
+    volumes:
+      - ./certs/csms:/usr/local/share/certs
+      - ./certs/ca.crt:/usr/local/share/certs/ca.crt
+    environment:
+      - SERVER_LISTEN_PORT=443
+      - TLS_ENABLED=true
+      - CA_CERTIFICATE_PATH=/usr/local/share/certs/ca.crt
+      - SERVER_CERTIFICATE_PATH=/usr/local/share/certs/csms.crt
+      - SERVER_CERTIFICATE_KEY_PATH=/usr/local/share/certs/csms.key
+    ports:
+      - "443:443"
+    networks:
+      - sim
+    tty: true
+  charging-station:
+    build:
+      context: ../..
+      dockerfile: chargingstation/Dockerfile
+    image: ldonini/ocpp2.0.1-chargingstation:latest
+    container_name: charging-station
+    volumes:
+      - ./certs/chargingstation:/usr/local/share/certs
+      - ./certs/ca.crt:/usr/local/share/certs/ca.crt
+    environment:
+      - CLIENT_ID=chargingStationSim
+      - CSMS_URL=wss://csms:443
+      - TLS_ENABLED=true
+      - CA_CERTIFICATE_PATH=/usr/local/share/certs/ca.crt
+      - CLIENT_CERTIFICATE_PATH=/usr/local/share/certs/charging-station.crt
+      - CLIENT_CERTIFICATE_KEY_PATH=/usr/local/share/certs/charging-station.key
+    networks:
+      - sim
+    tty: true
+
+networks:
+  sim:
+    driver: bridge

--- a/example/2.0.1/docker-compose.yml
+++ b/example/2.0.1/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3'
+services:
+  csms:
+    build:
+      context: ../..
+      dockerfile: csms/Dockerfile
+    image: ldonini/ocpp2.0.1-csms:latest
+    container_name: csms
+    environment:
+      - SERVER_LISTEN_PORT=8887
+    ports:
+      - "8887:8887"
+    networks:
+      - sim
+    tty: true
+  charging-station:
+    build:
+      context: ../..
+      dockerfile: chargingstation/Dockerfile
+    image: ldonini/ocpp2.0.1-chargingstation:latest
+    container_name: charging-station
+    environment:
+      - CLIENT_ID=chargingStationSim
+      - CSMS_URL=ws://csms:8887
+    networks:
+      - sim
+    tty: true
+
+networks:
+  sim:
+    driver: bridge

--- a/example/2.0.1/openssl-chargingstation.conf
+++ b/example/2.0.1/openssl-chargingstation.conf
@@ -1,0 +1,14 @@
+[req]
+distinguished_name = req_dn
+req_extensions = req_ext
+prompt = no
+[req_dn]
+CN = charging-station
+[req_ext]
+basicConstraints        = CA:FALSE
+subjectKeyIdentifier    = hash
+keyUsage                = digitalSignature, keyEncipherment
+extendedKeyUsage        = clientAuth
+subjectAltName          = @alt_names
+[alt_names]
+DNS.1 = charging-station

--- a/example/2.0.1/openssl-csms.conf
+++ b/example/2.0.1/openssl-csms.conf
@@ -1,0 +1,14 @@
+[req]
+distinguished_name = req_dn
+req_extensions = req_ext
+prompt = no
+[req_dn]
+CN = csms
+[req_ext]
+basicConstraints        = CA:FALSE
+subjectKeyIdentifier    = hash
+keyUsage                = digitalSignature, keyEncipherment, dataEncipherment
+extendedKeyUsage        = serverAuth
+subjectAltName          = @alt_names
+[alt_names]
+DNS.1 = csms

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/sys v0.0.0-20220804214406-8e32c043e418 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.30.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -25,7 +24,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220804214406-8e32c043e418 h1:9vYwv7OjYaky/tlAeD7C4oC9EsPTlaFl1H2jS++V+ME=
+golang.org/x/sys v0.0.0-20220804214406-8e32c043e418/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -39,4 +41,5 @@ gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXa
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.30.0 h1:Wk0Z37oBmKj9/n+tPyBHZmeL19LaCoK3Qq48VwYENss=
 gopkg.in/go-playground/validator.v9 v9.30.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/ocpp2.0.1/diagnostics/clear_variable_monitoring.go
+++ b/ocpp2.0.1/diagnostics/clear_variable_monitoring.go
@@ -46,7 +46,7 @@ type ClearVariableMonitoringResponse struct {
 	ClearMonitoringResult []ClearMonitoringResult `json:"clearMonitoringResult" validate:"required,min=1,dive"` // List of result statuses per monitor.
 }
 
-// The CSMS asks the Charging Station to clear a display message that has been configured in the Charging Station to be cleared/removed.
+// The CSMS asks the Charging Station to clear/remove a display message that has been configured in the Charging Station.
 // The Charging station checks for a message with the requested ID and removes it.
 // The Charging station then responds with a ClearVariableMonitoringResponse. The response payload indicates whether the Charging Station was able to remove the message from display or not.
 type ClearVariableMonitoringFeature struct{}

--- a/ocpp2.0.1/display/notify_display_messages.go
+++ b/ocpp2.0.1/display/notify_display_messages.go
@@ -20,8 +20,8 @@ type NotifyDisplayMessagesRequest struct {
 type NotifyDisplayMessagesResponse struct {
 }
 
-// A CSO MAY request all the installed DisplayMessages configured via OCPP in a Charging Station. For this the CSO asks the CSMS to retrieve all messages (see NotifyDisplayMessages).
-// If the Charging Station responded with a NotifyDisplayMessagesResponse Accepted, it will then send these messages asynchronously to the CSMS.
+// A CSO MAY request all the installed DisplayMessages configured via OCPP in a Charging Station. For this the CSO asks the CSMS to retrieve all messages (see GetDisplayMessagesFeature).
+// If the Charging Station responded with a status Accepted, it will then send these messages asynchronously to the CSMS.
 //
 // The Charging Station sends one or more NotifyDisplayMessagesRequest message to the CSMS (depending on the amount of messages to be send).
 // The CSMS responds to every notification with a NotifyDisplayMessagesResponse message.

--- a/ocpp2.0.1/provisioning/provisioning.go
+++ b/ocpp2.0.1/provisioning/provisioning.go
@@ -7,9 +7,9 @@ import "github.com/lorenzodonini/ocpp-go/ocpp"
 // Needs to be implemented by a CSMS for handling messages part of the OCPP 2.0 Provisioning profile.
 type CSMSHandler interface {
 	// OnBootNotification is called on the CSMS whenever a BootNotificationRequest is received from a charging station.
-	OnBootNotification(chargingStationID string, request *BootNotificationRequest) (confirmation *BootNotificationResponse, err error)
+	OnBootNotification(chargingStationID string, request *BootNotificationRequest) (response *BootNotificationResponse, err error)
 	// OnNotifyReport is called on the CSMS whenever a NotifyReportRequest is received from a charging station.
-	OnNotifyReport(chargingStationID string, request *NotifyReportRequest) (confirmation *NotifyReportResponse, err error)
+	OnNotifyReport(chargingStationID string, request *NotifyReportRequest) (response *NotifyReportResponse, err error)
 }
 
 // Needs to be implemented by Charging stations for handling messages part of the OCPP 2.0 Provisioning profile.

--- a/ocpp2.0.1/transactions/transaction_event.go
+++ b/ocpp2.0.1/transactions/transaction_event.go
@@ -130,7 +130,7 @@ func isValidReason(fl validator.FieldLevel) bool {
 type Transaction struct {
 	TransactionID     string        `json:"transactionId" validate:"required,max=36"`
 	ChargingState     ChargingState `json:"chargingState,omitempty" validate:"omitempty,chargingState"`
-	TimeSpentCharging *int          `json:"timeSpentCharging,omitempty" validate:"omitempty"`
+	TimeSpentCharging *int          `json:"timeSpentCharging,omitempty" validate:"omitempty"` // Contains the total time that energy flowed from EVSE to EV during the transaction (in seconds).
 	StoppedReason     Reason        `json:"stoppedReason,omitempty" validate:"omitempty,stoppedReason"`
 	RemoteStartID     *int          `json:"remoteStartId,omitempty" validate:"omitempty"`
 }

--- a/ocpp2.0.1/types/datetime.go
+++ b/ocpp2.0.1/types/datetime.go
@@ -22,6 +22,11 @@ func NewDateTime(time time.Time) *DateTime {
 	return &DateTime{Time: time}
 }
 
+// Creates a new DateTime struct, embedding a struct generated using time.Now().
+func Now() *DateTime {
+	return &DateTime{Time: time.Now()}
+}
+
 func (dt *DateTime) UnmarshalJSON(input []byte) error {
 	strInput := string(input)
 	strInput = strings.Trim(strInput, `"`)


### PR DESCRIPTION
Adds experimental examples for OCPP 2.0.1, including respective docker images

Includes some additional improvements:
- Generate docker images for multiple architectures
- Forces sha256 digest for self-signed certificates (SHA1 gets rejected, see [official issue](https://github.com/golang/go/issues/41682))
- Updated readme