### PR TITLE
Move validation to its own package

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -30,7 +30,6 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220804214406-8e32c043e418 h1:9vYwv7OjYaky/tlAeD7C4oC9EsPTlaFl1H2jS++V+ME=
 golang.org/x/sys v0.0.0-20220804214406-8e32c043e418/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -41,5 +40,5 @@ gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXa
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.30.0 h1:Wk0Z37oBmKj9/n+tPyBHZmeL19LaCoK3Qq48VwYENss=
 gopkg.in/go-playground/validator.v9 v9.30.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/ocpp1.6/core/boot_notification.go
+++ b/ocpp1.6/core/boot_notification.go
@@ -1,9 +1,11 @@
 package core
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Boot Notification (CP -> CS) --------------------
@@ -91,5 +93,5 @@ func NewBootNotificationConfirmation(currentTime *types.DateTime, interval int, 
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("registrationStatus", isValidRegistrationStatus)
+	validate.MustRegisterValidation("registrationStatus", isValidRegistrationStatus)
 }

--- a/ocpp1.6/core/change_availability.go
+++ b/ocpp1.6/core/change_availability.go
@@ -1,9 +1,10 @@
 package core
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Change Availability (CS -> CP) --------------------
@@ -97,6 +98,6 @@ func NewChangeAvailabilityConfirmation(status AvailabilityStatus) *ChangeAvailab
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("availabilityType", isValidAvailabilityType)
-	_ = types.Validate.RegisterValidation("availabilityStatus", isValidAvailabilityStatus)
+	validate.MustRegisterValidation("availabilityType", isValidAvailabilityType)
+	validate.MustRegisterValidation("availabilityStatus", isValidAvailabilityStatus)
 }

--- a/ocpp1.6/core/change_configuration.go
+++ b/ocpp1.6/core/change_configuration.go
@@ -1,9 +1,10 @@
 package core
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Change Configuration (CS -> CP) --------------------
@@ -85,5 +86,5 @@ func NewChangeConfigurationConfirmation(status ConfigurationStatus) *ChangeConfi
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("configurationStatus", isValidConfigurationStatus)
+	validate.MustRegisterValidation("configurationStatus", isValidConfigurationStatus)
 }

--- a/ocpp1.6/core/clear_cache.go
+++ b/ocpp1.6/core/clear_cache.go
@@ -1,9 +1,10 @@
 package core
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Clear Cache (CS -> CP) --------------------
@@ -75,5 +76,5 @@ func NewClearCacheConfirmation(status ClearCacheStatus) *ClearCacheConfirmation 
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("cacheStatus", isValidClearCacheStatus)
+	validate.MustRegisterValidation("cacheStatus", isValidClearCacheStatus)
 }

--- a/ocpp1.6/core/data_transfer.go
+++ b/ocpp1.6/core/data_transfer.go
@@ -1,9 +1,10 @@
 package core
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Data Transfer (CP -> CS / CS -> CP) --------------------
@@ -79,5 +80,5 @@ func NewDataTransferConfirmation(status DataTransferStatus) *DataTransferConfirm
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("dataTransferStatus", isValidDataTransferStatus)
+	validate.MustRegisterValidation("dataTransferStatus", isValidDataTransferStatus)
 }

--- a/ocpp1.6/core/heartbeat.go
+++ b/ocpp1.6/core/heartbeat.go
@@ -1,9 +1,11 @@
 package core
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Heartbeat (CP -> CS) --------------------
@@ -67,5 +69,5 @@ func validateHeartbeatConfirmation(sl validator.StructLevel) {
 }
 
 func init() {
-	types.Validate.RegisterStructValidation(validateHeartbeatConfirmation, HeartbeatConfirmation{})
+	validate.MustRegisterStructValidation(validateHeartbeatConfirmation, HeartbeatConfirmation{})
 }

--- a/ocpp1.6/core/reset.go
+++ b/ocpp1.6/core/reset.go
@@ -1,9 +1,10 @@
 package core
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Reset (CS -> CP) --------------------
@@ -62,8 +63,8 @@ type ResetConfirmation struct {
 // At receipt of a soft reset, the Charge Point SHALL stop ongoing transactions gracefully and send StopTransactionRequest for every ongoing transaction.
 // It should then restart the application software (if possible, otherwise restart the processor/controller).
 // At receipt of a hard reset the Charge Point SHALL restart (all) the hardware, it is not required to gracefully stop ongoing transaction.
-//If possible the Charge Point sends a StopTransactionRequest for previously ongoing transactions after having restarted and having been accepted by the Central System via a BootNotificationConfirmation.
-//This is a last resort solution for a not correctly functioning Charge Points, by sending a "hard" reset, (queued) information might get lost.
+// If possible the Charge Point sends a StopTransactionRequest for previously ongoing transactions after having restarted and having been accepted by the Central System via a BootNotificationConfirmation.
+// This is a last resort solution for a not correctly functioning Charge Points, by sending a "hard" reset, (queued) information might get lost.
 type ResetFeature struct{}
 
 func (f ResetFeature) GetFeatureName() string {
@@ -97,6 +98,6 @@ func NewResetConfirmation(status ResetStatus) *ResetConfirmation {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("resetType", isValidResetType)
-	_ = types.Validate.RegisterValidation("resetStatus", isValidResetStatus)
+	validate.MustRegisterValidation("resetType", isValidResetType)
+	validate.MustRegisterValidation("resetStatus", isValidResetStatus)
 }

--- a/ocpp1.6/core/status_notification.go
+++ b/ocpp1.6/core/status_notification.go
@@ -1,9 +1,11 @@
 package core
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Status Notification (CP -> CS) --------------------
@@ -132,6 +134,6 @@ func NewStatusNotificationConfirmation() *StatusNotificationConfirmation {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("chargePointErrorCode", isValidChargePointErrorCode)
-	_ = types.Validate.RegisterValidation("chargePointStatus", isValidChargePointStatus)
+	validate.MustRegisterValidation("chargePointErrorCode", isValidChargePointErrorCode)
+	validate.MustRegisterValidation("chargePointStatus", isValidChargePointStatus)
 }

--- a/ocpp1.6/core/stop_transaction.go
+++ b/ocpp1.6/core/stop_transaction.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -107,7 +108,7 @@ func NewStopTransactionConfirmation() *StopTransactionConfirmation {
 	return &StopTransactionConfirmation{}
 }
 
-//TODO: advanced validation
+// TODO: advanced validation
 func init() {
-	_ = types.Validate.RegisterValidation("reason", isValidReason)
+	validate.MustRegisterValidation("reason", isValidReason)
 }

--- a/ocpp1.6/core/unlock_connector.go
+++ b/ocpp1.6/core/unlock_connector.go
@@ -1,9 +1,10 @@
 package core
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Unlock Connector (CS -> CP) --------------------
@@ -81,5 +82,5 @@ func NewUnlockConnectorConfirmation(status UnlockStatus) *UnlockConnectorConfirm
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("unlockStatus", isValidUnlockStatus)
+	validate.MustRegisterValidation("unlockStatus", isValidUnlockStatus)
 }

--- a/ocpp1.6/firmware/diagnostics_status_notification.go
+++ b/ocpp1.6/firmware/diagnostics_status_notification.go
@@ -1,9 +1,10 @@
 package firmware
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Diagnostics Status Notification (CP -> CS) --------------------
@@ -75,5 +76,5 @@ func NewDiagnosticsStatusNotificationConfirmation() *DiagnosticsStatusNotificati
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("diagnosticsStatus", isValidDiagnosticsStatus)
+	validate.MustRegisterValidation("diagnosticsStatus", isValidDiagnosticsStatus)
 }

--- a/ocpp1.6/firmware/firmware_status_notification.go
+++ b/ocpp1.6/firmware/firmware_status_notification.go
@@ -1,9 +1,10 @@
 package firmware
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Firmware Status Notification (CP -> CS) --------------------
@@ -79,5 +80,5 @@ func NewFirmwareStatusNotificationConfirmation() *FirmwareStatusNotificationConf
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("firmwareStatus", isValidFirmwareStatus)
+	validate.MustRegisterValidation("firmwareStatus", isValidFirmwareStatus)
 }

--- a/ocpp1.6/localauth/send_local_list.go
+++ b/ocpp1.6/localauth/send_local_list.go
@@ -1,9 +1,11 @@
 package localauth
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Send Local List (CS -> CP) --------------------
@@ -105,7 +107,7 @@ func NewSendLocalListConfirmation(status UpdateStatus) *SendLocalListConfirmatio
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("updateStatus", isValidUpdateStatus)
-	_ = types.Validate.RegisterValidation("updateType", isValidUpdateType)
+	validate.MustRegisterValidation("updateStatus", isValidUpdateStatus)
+	validate.MustRegisterValidation("updateType", isValidUpdateType)
 	//TODO: validation for SendLocalListMaxLength
 }

--- a/ocpp1.6/remotetrigger/trigger_message.go
+++ b/ocpp1.6/remotetrigger/trigger_message.go
@@ -1,11 +1,12 @@
 package remotetrigger
 
 import (
+	"reflect"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
-	"reflect"
 )
 
 // -------------------- Trigger Message (CS -> CP) --------------------
@@ -110,6 +111,6 @@ func NewTriggerMessageConfirmation(status TriggerMessageStatus) *TriggerMessageC
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("triggerMessageStatus", isValidTriggerMessageStatus)
-	_ = types.Validate.RegisterValidation("messageTrigger", isValidMessageTrigger)
+	validate.MustRegisterValidation("triggerMessageStatus", isValidTriggerMessageStatus)
+	validate.MustRegisterValidation("messageTrigger", isValidMessageTrigger)
 }

--- a/ocpp1.6/reservation/cancel_reservation.go
+++ b/ocpp1.6/reservation/cancel_reservation.go
@@ -1,9 +1,10 @@
 package reservation
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Cancel Reservation (CS -> CP) --------------------
@@ -75,5 +76,5 @@ func NewCancelReservationConfirmation(status CancelReservationStatus) *CancelRes
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("cancelReservationStatus", isValidCancelReservationStatus)
+	validate.MustRegisterValidation("cancelReservationStatus", isValidCancelReservationStatus)
 }

--- a/ocpp1.6/reservation/reserve_now.go
+++ b/ocpp1.6/reservation/reserve_now.go
@@ -1,9 +1,11 @@
 package reservation
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Reserve Now (CS -> CP) --------------------
@@ -93,5 +95,5 @@ func NewReserveNowConfirmation(status ReservationStatus) *ReserveNowConfirmation
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("reservationStatus", isValidReservationStatus)
+	validate.MustRegisterValidation("reservationStatus", isValidReservationStatus)
 }

--- a/ocpp1.6/smartcharging/clear_charging_profile.go
+++ b/ocpp1.6/smartcharging/clear_charging_profile.go
@@ -1,9 +1,11 @@
 package smartcharging
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Clear Charging Profile (CS -> CP) --------------------
@@ -80,5 +82,5 @@ func NewClearChargingProfileConfirmation(status ClearChargingProfileStatus) *Cle
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("clearChargingProfileStatus", isValidClearChargingProfileStatus)
+	validate.MustRegisterValidation("clearChargingProfileStatus", isValidClearChargingProfileStatus)
 }

--- a/ocpp1.6/smartcharging/get_composite_schedule.go
+++ b/ocpp1.6/smartcharging/get_composite_schedule.go
@@ -1,9 +1,11 @@
 package smartcharging
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
-	"gopkg.in/go-playground/validator.v9"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // -------------------- Get Composite Schedule (CS -> CP) --------------------
@@ -82,5 +84,5 @@ func NewGetCompositeScheduleConfirmation(status GetCompositeScheduleStatus) *Get
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("compositeScheduleStatus", isValidGetCompositeScheduleStatus)
+	validate.MustRegisterValidation("compositeScheduleStatus", isValidGetCompositeScheduleStatus)
 }

--- a/ocpp1.6/smartcharging/set_charging_profile.go
+++ b/ocpp1.6/smartcharging/set_charging_profile.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -79,5 +80,5 @@ func NewSetChargingProfileConfirmation(status ChargingProfileStatus) *SetChargin
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("chargingProfileStatus", isValidChargingProfileStatus)
+	validate.MustRegisterValidation("chargingProfileStatus", isValidChargingProfileStatus)
 }

--- a/ocpp1.6/types/types.go
+++ b/ocpp1.6/types/types.go
@@ -2,7 +2,7 @@
 package types
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocppj"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -313,20 +313,17 @@ type MeterValue struct {
 	SampledValue []SampledValue `json:"sampledValue" validate:"required,min=1,dive"`
 }
 
-// Initialize validator
-var Validate = ocppj.Validate
-
 func init() {
-	_ = Validate.RegisterValidation("authorizationStatus", isValidAuthorizationStatus)
-	_ = Validate.RegisterValidation("chargingProfilePurpose", isValidChargingProfilePurpose)
-	_ = Validate.RegisterValidation("chargingProfileKind", isValidChargingProfileKind)
-	_ = Validate.RegisterValidation("recurrencyKind", isValidRecurrencyKind)
-	_ = Validate.RegisterValidation("chargingRateUnit", isValidChargingRateUnit)
-	_ = Validate.RegisterValidation("remoteStartStopStatus", isValidRemoteStartStopStatus)
-	_ = Validate.RegisterValidation("readingContext", isValidReadingContext)
-	_ = Validate.RegisterValidation("valueFormat", isValidValueFormat)
-	_ = Validate.RegisterValidation("measurand", isValidMeasurand)
-	_ = Validate.RegisterValidation("phase", isValidPhase)
-	_ = Validate.RegisterValidation("location", isValidLocation)
-	_ = Validate.RegisterValidation("unitOfMeasure", isValidUnitOfMeasure)
+	validate.MustRegisterValidation("authorizationStatus", isValidAuthorizationStatus)
+	validate.MustRegisterValidation("chargingProfilePurpose", isValidChargingProfilePurpose)
+	validate.MustRegisterValidation("chargingProfileKind", isValidChargingProfileKind)
+	validate.MustRegisterValidation("recurrencyKind", isValidRecurrencyKind)
+	validate.MustRegisterValidation("chargingRateUnit", isValidChargingRateUnit)
+	validate.MustRegisterValidation("remoteStartStopStatus", isValidRemoteStartStopStatus)
+	validate.MustRegisterValidation("readingContext", isValidReadingContext)
+	validate.MustRegisterValidation("valueFormat", isValidValueFormat)
+	validate.MustRegisterValidation("measurand", isValidMeasurand)
+	validate.MustRegisterValidation("phase", isValidPhase)
+	validate.MustRegisterValidation("location", isValidLocation)
+	validate.MustRegisterValidation("unitOfMeasure", isValidUnitOfMeasure)
 }

--- a/ocpp1.6/v16.go
+++ b/ocpp1.6/v16.go
@@ -5,8 +5,6 @@ import (
 	"crypto/tls"
 	"net"
 
-	"github.com/gorilla/websocket"
-
 	"github.com/lorenzodonini/ocpp-go/internal/callbackqueue"
 	"github.com/lorenzodonini/ocpp-go/ocpp"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
@@ -34,12 +32,15 @@ type ChargePointConnectionHandler func(chargePoint ChargePointConnection)
 // You can instantiate a default Charge Point struct by calling NewClient.
 //
 // The logic for incoming messages needs to be implemented, and the message handlers need to be registered with the charge point:
-// 	handler := &ChargePointHandler{}
+//
+//	handler := &ChargePointHandler{}
 //	client.SetCoreHandler(handler)
+//
 // Refer to the ChargePointHandler interfaces in the respective core, firmware, localauth, remotetrigger, reservation and smartcharging profiles for the implementation requirements.
 //
 // A charge point can be started and stopped using the Start and Stop functions.
 // While running, messages can be sent to the Central system by calling the Charge point's functions, e.g.
+//
 //	bootConf, err := client.BootNotification("model1", "vendor1")
 //
 // All messages are synchronous blocking, and return either the response from the Central system or an error.
@@ -109,10 +110,12 @@ type ChargePoint interface {
 // The id parameter is required to uniquely identify the charge point.
 //
 // The endpoint and client parameters may be omitted, in order to use a default configuration:
-//   client := NewClient("someUniqueId", nil, nil)
+//
+//	client := NewClient("someUniqueId", nil, nil)
 //
 // Additional networking parameters (e.g. TLS or proxy configuration) may be passed, by creating a custom client.
 // Here is an example for a client using TLS configuration with a self-signed certificate:
+//
 //	certPool := x509.NewCertPool()
 //	data, err := ioutil.ReadFile("serverSelfSignedCertFilename")
 //	if err != nil {
@@ -132,19 +135,6 @@ func NewChargePoint(id string, endpoint *ocppj.Client, client ws.WsClient) Charg
 	if client == nil {
 		client = ws.NewClient()
 	}
-	client.AddOption(func(dialer *websocket.Dialer) {
-		// Look for v1.6 subprotocol and add it, if not found
-		alreadyExists := false
-		for _, proto := range dialer.Subprotocols {
-			if proto == types.V16Subprotocol {
-				alreadyExists = true
-				break
-			}
-		}
-		if !alreadyExists {
-			dialer.Subprotocols = append(dialer.Subprotocols, types.V16Subprotocol)
-		}
-	})
 	cp := chargePoint{confirmationHandler: make(chan ocpp.Response, 1), errorHandler: make(chan error, 1), callbacks: callbackqueue.New()}
 
 	if endpoint == nil {
@@ -171,18 +161,22 @@ func NewChargePoint(id string, endpoint *ocppj.Client, client ws.WsClient) Charg
 // You can instantiate a default Central System struct by calling the NewServer function.
 //
 // The logic for handling incoming messages needs to be implemented, and the message handlers need to be registered with the central system:
+//
 //	handler := &CentralSystemHandler{}
 //	server.SetCoreHandler(handler)
+//
 // Refer to the CentralSystemHandler interfaces in the respective core, firmware, localauth, remotetrigger, reservation and smartcharging profiles for the implementation requirements.
 //
 // A Central system can be started by using the Start function.
 // To be notified of incoming (dis)connections from charge points refer to the SetNewClientHandler and SetChargePointDisconnectedHandler functions.
 //
 // While running, messages can be sent to a charge point by calling the Central system's functions, e.g.:
+//
 //	callback := func(conf *ChangeAvailabilityConfirmation, err error) {
 //		// handle the response...
 //	}
 //	changeAvailabilityConf, err := server.ChangeAvailability("cs0001", callback, 1, AvailabilityTypeOperative)
+//
 // All messages are sent asynchronously and do not block the caller.
 type CentralSystem interface {
 	// Instructs a charge point to change its availability. The target availability can be set for a single connector of for the whole charge point.
@@ -259,12 +253,14 @@ type CentralSystem interface {
 // Creates a new OCPP 1.6 central system.
 //
 // The endpoint and server parameters may be omitted, in order to use a default configuration:
-//   client := NewServer(nil, nil)
+//
+//	client := NewServer(nil, nil)
 //
 // It is recommended to use the default configuration, unless a custom networking / ocppj layer is required.
 // The default ocppj endpoint supports all OCPP 1.6 profiles out-of-the-box.
 //
 // If you need a TLS server, you may use the following:
+//
 //	cs := NewServer(nil, ws.NewTLSServer("certificatePath", "privateKeyPath"))
 func NewCentralSystem(endpoint *ocppj.Server, server ws.WsServer) CentralSystem {
 	if server == nil {

--- a/ocpp1.6_test/ocpp16_test.go
+++ b/ocpp1.6_test/ocpp16_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/smartcharging"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/lorenzodonini/ocpp-go/ocppj"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"github.com/lorenzodonini/ocpp-go/ws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -625,7 +626,7 @@ type ConfirmationTestEntry struct {
 // TODO: pass expected error value for improved validation and error message
 func ExecuteGenericTestTable(t *testing.T, testTable []GenericTestEntry) {
 	for _, testCase := range testTable {
-		err := types.Validate.Struct(testCase.Element)
+		err := validate.Validator.Struct(testCase.Element)
 		if err != nil {
 			assert.Equal(t, testCase.ExpectedValid, false, err.Error())
 		} else {

--- a/ocpp2.0.1/authorization/authorize.go
+++ b/ocpp2.0.1/authorization/authorize.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Authorize (CS -> CSMS) --------------------
@@ -90,5 +91,5 @@ func NewAuthorizationResponse(idTokenInfo types.IdTokenInfo) *AuthorizeResponse 
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("authorizeCertificateStatus", isValidAuthorizeCertificateStatus)
+	validate.MustRegisterValidation("authorizeCertificateStatus", isValidAuthorizeCertificateStatus)
 }

--- a/ocpp2.0.1/authorization/clear_cache.go
+++ b/ocpp2.0.1/authorization/clear_cache.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Clear Cache (CSMS -> CS) --------------------
@@ -78,5 +79,5 @@ func NewClearCacheResponse(status ClearCacheStatus) *ClearCacheResponse {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("cacheStatus", isValidClearCacheStatus)
+	validate.MustRegisterValidation("cacheStatus", isValidClearCacheStatus)
 }

--- a/ocpp2.0.1/availability/change_availability.go
+++ b/ocpp2.0.1/availability/change_availability.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Change Availability (CSMS -> CS) --------------------
@@ -100,6 +101,6 @@ func NewChangeAvailabilityResponse(status ChangeAvailabilityStatus) *ChangeAvail
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("operationalStatus", isValidOperationalStatus)
-	_ = types.Validate.RegisterValidation("changeAvailabilityStatus", isValidChangeAvailabilityStatus)
+	validate.MustRegisterValidation("operationalStatus", isValidOperationalStatus)
+	validate.MustRegisterValidation("changeAvailabilityStatus", isValidChangeAvailabilityStatus)
 }

--- a/ocpp2.0.1/availability/heartbeat.go
+++ b/ocpp2.0.1/availability/heartbeat.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -65,5 +66,5 @@ func validateHeartbeatResponse(sl validator.StructLevel) {
 }
 
 func init() {
-	types.Validate.RegisterStructValidation(validateHeartbeatResponse, HeartbeatResponse{})
+	validate.MustRegisterStructValidation(validateHeartbeatResponse, HeartbeatResponse{})
 }

--- a/ocpp2.0.1/availability/status_notification.go
+++ b/ocpp2.0.1/availability/status_notification.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -46,12 +47,12 @@ type StatusNotificationResponse struct {
 
 // The Charging Station notifies the CSMS about a connector status change.
 // This may typically be after on of the following events:
-//  - (re)boot
-//  - reset
-//  - any transaction event (start/stop/authorization)
-//  - reservation events
-//  - change availability operations
-//  - remote triggers
+//   - (re)boot
+//   - reset
+//   - any transaction event (start/stop/authorization)
+//   - reservation events
+//   - change availability operations
+//   - remote triggers
 //
 // The charging station sends a StatusNotificationRequest to the CSMS with information about the new status.
 // The CSMS responds with a StatusNotificationResponse.
@@ -88,5 +89,5 @@ func NewStatusNotificationResponse() *StatusNotificationResponse {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("connectorStatus", isValidConnectorStatus)
+	validate.MustRegisterValidation("connectorStatus", isValidConnectorStatus)
 }

--- a/ocpp2.0.1/data/data_transfer.go
+++ b/ocpp2.0.1/data/data_transfer.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Data Transfer (CS -> CSMS / CSMS -> CS) --------------------
@@ -82,5 +83,5 @@ func NewDataTransferResponse(status DataTransferStatus) *DataTransferResponse {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("dataTransferStatus", isValidDataTransferStatus)
+	validate.MustRegisterValidation("dataTransferStatus", isValidDataTransferStatus)
 }

--- a/ocpp2.0.1/diagnostics/clear_variable_monitoring.go
+++ b/ocpp2.0.1/diagnostics/clear_variable_monitoring.go
@@ -3,7 +3,7 @@ package diagnostics
 import (
 	"reflect"
 
-	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -82,5 +82,5 @@ func NewClearVariableMonitoringResponse(result []ClearMonitoringResult) *ClearVa
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("clearMonitoringStatus", isValidClearMonitoringStatus)
+	validate.MustRegisterValidation("clearMonitoringStatus", isValidClearMonitoringStatus)
 }

--- a/ocpp2.0.1/diagnostics/customer_information.go
+++ b/ocpp2.0.1/diagnostics/customer_information.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Customer Information (CSMS -> CS) --------------------
@@ -85,5 +86,5 @@ func NewCustomerInformationResponse(status CustomerInformationStatus) *CustomerI
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("customerInformationStatus", isValidCustomerInformationStatus)
+	validate.MustRegisterValidation("customerInformationStatus", isValidCustomerInformationStatus)
 }

--- a/ocpp2.0.1/diagnostics/get_log.go
+++ b/ocpp2.0.1/diagnostics/get_log.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -105,6 +106,6 @@ func NewGetLogResponse(status LogStatus) *GetLogResponse {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("logType", isValidLogType)
-	_ = types.Validate.RegisterValidation("logStatus", isValidLogStatus)
+	validate.MustRegisterValidation("logType", isValidLogType)
+	validate.MustRegisterValidation("logStatus", isValidLogStatus)
 }

--- a/ocpp2.0.1/diagnostics/get_monitoring_report.go
+++ b/ocpp2.0.1/diagnostics/get_monitoring_report.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -81,5 +82,5 @@ func NewGetMonitoringReportResponse(status types.GenericDeviceModelStatus) *GetM
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("monitoringCriteria", isValidMonitoringCriteriaType)
+	validate.MustRegisterValidation("monitoringCriteria", isValidMonitoringCriteriaType)
 }

--- a/ocpp2.0.1/diagnostics/log_status_notification.go
+++ b/ocpp2.0.1/diagnostics/log_status_notification.go
@@ -3,7 +3,7 @@ package diagnostics
 import (
 	"reflect"
 
-	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -82,5 +82,5 @@ func NewLogStatusNotificationResponse() *LogStatusNotificationResponse {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("uploadLogStatus", isValidUploadLogStatus)
+	validate.MustRegisterValidation("uploadLogStatus", isValidUploadLogStatus)
 }

--- a/ocpp2.0.1/diagnostics/notify_event.go
+++ b/ocpp2.0.1/diagnostics/notify_event.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -121,6 +122,6 @@ func NewNotifyEventResponse() *NotifyEventResponse {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("eventTrigger", isValidEventTrigger)
-	_ = types.Validate.RegisterValidation("eventNotification", isValidEventNotification)
+	validate.MustRegisterValidation("eventTrigger", isValidEventTrigger)
+	validate.MustRegisterValidation("eventNotification", isValidEventNotification)
 }

--- a/ocpp2.0.1/diagnostics/set_monitoring_base.go
+++ b/ocpp2.0.1/diagnostics/set_monitoring_base.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -82,5 +83,5 @@ func NewSetMonitoringBaseResponse(status types.GenericDeviceModelStatus) *SetMon
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("monitoringBase", isValidMonitoringBase)
+	validate.MustRegisterValidation("monitoringBase", isValidMonitoringBase)
 }

--- a/ocpp2.0.1/diagnostics/set_monitoring_level.go
+++ b/ocpp2.0.1/diagnostics/set_monitoring_level.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Set Monitoring Level (CSMS -> CS) --------------------
@@ -87,5 +88,5 @@ func NewSetMonitoringLevelResponse(status types.GenericDeviceModelStatus) *SetMo
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("monitoringBase", isValidMonitoringBase)
+	validate.MustRegisterValidation("monitoringBase", isValidMonitoringBase)
 }

--- a/ocpp2.0.1/diagnostics/set_variable_monitoring.go
+++ b/ocpp2.0.1/diagnostics/set_variable_monitoring.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -104,5 +105,5 @@ func NewSetVariableMonitoringResponse(result []SetMonitoringResult) *SetVariable
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("setMonitoringStatus", isValidSetMonitoringStatus)
+	validate.MustRegisterValidation("setMonitoringStatus", isValidSetMonitoringStatus)
 }

--- a/ocpp2.0.1/diagnostics/types.go
+++ b/ocpp2.0.1/diagnostics/types.go
@@ -1,7 +1,7 @@
 package diagnostics
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -27,5 +27,5 @@ func isValidMonitorType(fl validator.FieldLevel) bool {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("monitorType", isValidMonitorType)
+	validate.MustRegisterValidation("monitorType", isValidMonitorType)
 }

--- a/ocpp2.0.1/display/clear_display_message.go
+++ b/ocpp2.0.1/display/clear_display_message.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Clear Display Message (CSMS -> CS) --------------------
@@ -78,5 +79,5 @@ func NewClearDisplayResponse(status ClearMessageStatus) *ClearDisplayResponse {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("clearMessageStatus", isValidClearMessageStatus)
+	validate.MustRegisterValidation("clearMessageStatus", isValidClearMessageStatus)
 }

--- a/ocpp2.0.1/display/set_display_message.go
+++ b/ocpp2.0.1/display/set_display_message.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -88,5 +89,5 @@ func NewSetDisplayMessageResponse(status DisplayMessageStatus) *SetDisplayMessag
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("displayMessageStatus", isValidDisplayMessageStatus)
+	validate.MustRegisterValidation("displayMessageStatus", isValidDisplayMessageStatus)
 }

--- a/ocpp2.0.1/display/types.go
+++ b/ocpp2.0.1/display/types.go
@@ -2,6 +2,7 @@ package display
 
 import (
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -71,7 +72,7 @@ type MessageInfo struct {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("messagePriority", isValidMessagePriority)
-	_ = types.Validate.RegisterValidation("messageState", isValidMessageState)
-	_ = types.Validate.RegisterValidation("messageStatus", isValidMessageStatus)
+	validate.MustRegisterValidation("messagePriority", isValidMessagePriority)
+	validate.MustRegisterValidation("messageState", isValidMessageState)
+	validate.MustRegisterValidation("messageStatus", isValidMessageStatus)
 }

--- a/ocpp2.0.1/firmware/firmware_status_notification.go
+++ b/ocpp2.0.1/firmware/firmware_status_notification.go
@@ -3,9 +3,8 @@ package firmware
 import (
 	"reflect"
 
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
-
-	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
 )
 
 // -------------------- Firmware Status Notification (CS -> CSMS) --------------------
@@ -82,5 +81,5 @@ func NewFirmwareStatusNotificationResponse() *FirmwareStatusNotificationResponse
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("firmwareStatus", isValidFirmwareStatus)
+	validate.MustRegisterValidation("firmwareStatus", isValidFirmwareStatus)
 }

--- a/ocpp2.0.1/firmware/publish_firmware_status_notification.go
+++ b/ocpp2.0.1/firmware/publish_firmware_status_notification.go
@@ -3,7 +3,7 @@ package firmware
 import (
 	"reflect"
 
-	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -87,5 +87,5 @@ func NewPublishFirmwareStatusNotificationResponse() *PublishFirmwareStatusNotifi
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("publishFirmwareStatus", isValidPublishFirmwareStatus)
+	validate.MustRegisterValidation("publishFirmwareStatus", isValidPublishFirmwareStatus)
 }

--- a/ocpp2.0.1/firmware/unpublish_firmware.go
+++ b/ocpp2.0.1/firmware/unpublish_firmware.go
@@ -3,9 +3,8 @@ package firmware
 import (
 	"reflect"
 
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
-
-	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
 )
 
 // -------------------- Publish Firmware (CSMS -> CS) --------------------
@@ -78,5 +77,5 @@ func NewUnpublishFirmwareResponse(status UnpublishFirmwareStatus) *UnpublishFirm
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("unpublishFirmwareStatus", isValidUnpublishFirmwareStatus)
+	validate.MustRegisterValidation("unpublishFirmwareStatus", isValidUnpublishFirmwareStatus)
 }

--- a/ocpp2.0.1/firmware/update_firmware.go
+++ b/ocpp2.0.1/firmware/update_firmware.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Publish Firmware (CSMS -> CS) --------------------
@@ -102,5 +103,5 @@ func NewUpdateFirmwareResponse(status UpdateFirmwareStatus) *UpdateFirmwareRespo
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("updateFirmwareStatus", isValidUpdateFirmwareStatus)
+	validate.MustRegisterValidation("updateFirmwareStatus", isValidUpdateFirmwareStatus)
 }

--- a/ocpp2.0.1/iso15118/delete_certificate.go
+++ b/ocpp2.0.1/iso15118/delete_certificate.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Delete Certificate (CSMS -> CS) --------------------
@@ -78,5 +79,5 @@ func NewDeleteCertificateResponse(status DeleteCertificateStatus) *DeleteCertifi
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("deleteCertificateStatus", isValidDeleteCertificateStatus)
+	validate.MustRegisterValidation("deleteCertificateStatus", isValidDeleteCertificateStatus)
 }

--- a/ocpp2.0.1/iso15118/get_15118ev_certificate.go
+++ b/ocpp2.0.1/iso15118/get_15118ev_certificate.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Get 15118EV Certificate (CS -> CSMS) --------------------
@@ -81,5 +82,5 @@ func NewGet15118EVCertificateResponse(status types.Certificate15118EVStatus, exi
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("certificateAction", isValidCertificateAction)
+	validate.MustRegisterValidation("certificateAction", isValidCertificateAction)
 }

--- a/ocpp2.0.1/iso15118/get_installed_certificate_ids.go
+++ b/ocpp2.0.1/iso15118/get_installed_certificate_ids.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -76,5 +77,5 @@ func NewGetInstalledCertificateIdsResponse(status GetInstalledCertificateStatus)
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("getInstalledCertificateStatus", isValidGetInstalledCertificateStatus)
+	validate.MustRegisterValidation("getInstalledCertificateStatus", isValidGetInstalledCertificateStatus)
 }

--- a/ocpp2.0.1/iso15118/install_certificate.go
+++ b/ocpp2.0.1/iso15118/install_certificate.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Clear Display (CSMS -> CS) --------------------
@@ -81,5 +82,5 @@ func NewInstallCertificateResponse(status InstallCertificateStatus) *InstallCert
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("installCertificateStatus", isValidInstallCertificateStatus)
+	validate.MustRegisterValidation("installCertificateStatus", isValidInstallCertificateStatus)
 }

--- a/ocpp2.0.1/localauth/send_local_list.go
+++ b/ocpp2.0.1/localauth/send_local_list.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -110,6 +111,6 @@ func NewSendLocalListResponse(status SendLocalListStatus) *SendLocalListResponse
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("updateType", isValidUpdateType)
-	_ = types.Validate.RegisterValidation("sendLocalListStatus", isValidSendLocalListStatus)
+	validate.MustRegisterValidation("updateType", isValidUpdateType)
+	validate.MustRegisterValidation("sendLocalListStatus", isValidSendLocalListStatus)
 }

--- a/ocpp2.0.1/provisioning/boot_notification.go
+++ b/ocpp2.0.1/provisioning/boot_notification.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Boot Notification (CS -> CSMS) --------------------
@@ -127,6 +128,6 @@ func NewBootNotificationResponse(currentTime *types.DateTime, interval int, stat
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("registrationStatus", isValidRegistrationStatus)
-	_ = types.Validate.RegisterValidation("bootReason", isValidBootReason)
+	validate.MustRegisterValidation("registrationStatus", isValidRegistrationStatus)
+	validate.MustRegisterValidation("bootReason", isValidBootReason)
 }

--- a/ocpp2.0.1/provisioning/get_base_report.go
+++ b/ocpp2.0.1/provisioning/get_base_report.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Get Base Report (CSMS -> CS) --------------------
@@ -81,5 +82,5 @@ func NewGetBaseReportResponse(status types.GenericDeviceModelStatus) *GetBaseRep
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("reportBaseType", isValidReportBaseType)
+	validate.MustRegisterValidation("reportBaseType", isValidReportBaseType)
 }

--- a/ocpp2.0.1/provisioning/get_report.go
+++ b/ocpp2.0.1/provisioning/get_report.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -81,5 +82,5 @@ func NewGetReportResponse(status types.GenericDeviceModelStatus) *GetReportRespo
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("componentCriterion", isValidComponentCriterion)
+	validate.MustRegisterValidation("componentCriterion", isValidComponentCriterion)
 }

--- a/ocpp2.0.1/provisioning/get_variables.go
+++ b/ocpp2.0.1/provisioning/get_variables.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -95,5 +96,5 @@ func NewGetVariablesResponse(result []GetVariableResult) *GetVariablesResponse {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("getVariableStatus", isValidGetVariableStatus)
+	validate.MustRegisterValidation("getVariableStatus", isValidGetVariableStatus)
 }

--- a/ocpp2.0.1/provisioning/notify_report.go
+++ b/ocpp2.0.1/provisioning/notify_report.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -146,6 +147,6 @@ func NewNotifyReportResponse() *NotifyReportResponse {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("mutability", isValidMutability)
-	_ = types.Validate.RegisterValidation("dataTypeEnum", isValidDataType)
+	validate.MustRegisterValidation("mutability", isValidMutability)
+	validate.MustRegisterValidation("dataTypeEnum", isValidDataType)
 }

--- a/ocpp2.0.1/provisioning/reset.go
+++ b/ocpp2.0.1/provisioning/reset.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -103,6 +104,6 @@ func NewResetResponse(status ResetStatus) *ResetResponse {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("resetType", isValidResetType)
-	_ = types.Validate.RegisterValidation("resetStatus", isValidResetStatus)
+	validate.MustRegisterValidation("resetType", isValidResetType)
+	validate.MustRegisterValidation("resetStatus", isValidResetStatus)
 }

--- a/ocpp2.0.1/provisioning/set_network_profile.go
+++ b/ocpp2.0.1/provisioning/set_network_profile.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -212,10 +213,10 @@ func NewSetNetworkProfileResponse(status SetNetworkProfileStatus) *SetNetworkPro
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("ocppVersion", isValidOCPPVersion)
-	_ = types.Validate.RegisterValidation("ocppTransport", isValidOCPPTransport)
-	_ = types.Validate.RegisterValidation("ocppInterface", isValidOCPPInterface)
-	_ = types.Validate.RegisterValidation("vpnType", isValidVPNType)
-	_ = types.Validate.RegisterValidation("apnAuthentication", isValidAPNAuthentication)
-	_ = types.Validate.RegisterValidation("setNetworkProfileStatus", isValidSetNetworkProfileStatus)
+	validate.MustRegisterValidation("ocppVersion", isValidOCPPVersion)
+	validate.MustRegisterValidation("ocppTransport", isValidOCPPTransport)
+	validate.MustRegisterValidation("ocppInterface", isValidOCPPInterface)
+	validate.MustRegisterValidation("vpnType", isValidVPNType)
+	validate.MustRegisterValidation("apnAuthentication", isValidAPNAuthentication)
+	validate.MustRegisterValidation("setNetworkProfileStatus", isValidSetNetworkProfileStatus)
 }

--- a/ocpp2.0.1/provisioning/set_variables.go
+++ b/ocpp2.0.1/provisioning/set_variables.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -97,5 +98,5 @@ func NewSetVariablesResponse(result []SetVariableResult) *SetVariablesResponse {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("setVariableStatus", isValidSetVariableStatus)
+	validate.MustRegisterValidation("setVariableStatus", isValidSetVariableStatus)
 }

--- a/ocpp2.0.1/remotecontrol/request_start_transaction.go
+++ b/ocpp2.0.1/remotecontrol/request_start_transaction.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -48,9 +49,9 @@ type RequestStartTransactionResponse struct {
 
 // The CSMS may remotely start a transaction for a user.
 // This functionality may be triggered by:
-//	- a CSO, to help out a user, that is having trouble starting a transaction
-//	- a third-party event (e.g. mobile app)
-//  - a previously set ChargingProfile
+//   - a CSO, to help out a user, that is having trouble starting a transaction
+//   - a third-party event (e.g. mobile app)
+//   - a previously set ChargingProfile
 //
 // The CSMS sends a RequestStartTransactionRequest to the Charging Station.
 // The Charging Stations will reply with a RequestStartTransactionResponse.
@@ -87,5 +88,5 @@ func NewRequestStartTransactionResponse(status RequestStartStopStatus) *RequestS
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("requestStartStopStatus", isValidRequestStartStopStatus)
+	validate.MustRegisterValidation("requestStartStopStatus", isValidRequestStartStopStatus)
 }

--- a/ocpp2.0.1/remotecontrol/trigger_message.go
+++ b/ocpp2.0.1/remotecontrol/trigger_message.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -107,6 +108,6 @@ func NewTriggerMessageResponse(status TriggerMessageStatus) *TriggerMessageRespo
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("messageTrigger", isValidMessageTrigger)
-	_ = types.Validate.RegisterValidation("triggerMessageStatus", isValidTriggerMessageStatus)
+	validate.MustRegisterValidation("messageTrigger", isValidMessageTrigger)
+	validate.MustRegisterValidation("triggerMessageStatus", isValidTriggerMessageStatus)
 }

--- a/ocpp2.0.1/remotecontrol/unlock_connector.go
+++ b/ocpp2.0.1/remotecontrol/unlock_connector.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Trigger Message (CSMS -> CS) --------------------
@@ -52,7 +53,7 @@ type UnlockConnectorResponse struct {
 // This happens most of the time when there is tension on the charging cable.
 // This means the driver cannot unplug his charging cable from the Charging Station.
 // To help a driver, the CSO can send a UnlockConnectorRequest to the Charging Station.
-//The Charging Station will then try to unlock the connector again and respond with an UnlockConnectorResponse.
+// The Charging Station will then try to unlock the connector again and respond with an UnlockConnectorResponse.
 type UnlockConnectorFeature struct{}
 
 func (f UnlockConnectorFeature) GetFeatureName() string {
@@ -86,5 +87,5 @@ func NewUnlockConnectorResponse(status UnlockStatus) *UnlockConnectorResponse {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("unlockStatus", isValidUnlockStatus)
+	validate.MustRegisterValidation("unlockStatus", isValidUnlockStatus)
 }

--- a/ocpp2.0.1/reservation/cancel_reservation.go
+++ b/ocpp2.0.1/reservation/cancel_reservation.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Cancel Reservation (CSMS -> CS) --------------------
@@ -78,5 +79,5 @@ func NewCancelReservationResponse(status CancelReservationStatus) *CancelReserva
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("cancelReservationStatus", isValidCancelReservationStatus)
+	validate.MustRegisterValidation("cancelReservationStatus", isValidCancelReservationStatus)
 }

--- a/ocpp2.0.1/reservation/reservation_status_update.go
+++ b/ocpp2.0.1/reservation/reservation_status_update.go
@@ -3,7 +3,7 @@ package reservation
 import (
 	"reflect"
 
-	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -41,8 +41,9 @@ type ReservationStatusUpdateResponse struct {
 }
 
 // A Charging Station shall cancel an existing reservation when:
-//  - the status of a targeted EVSE changes to either Faulted or Unavailable
-//  - the reservation has expired, before the EV driver started using the Charging Station
+//   - the status of a targeted EVSE changes to either Faulted or Unavailable
+//   - the reservation has expired, before the EV driver started using the Charging Station
+//
 // This message is not triggered, if a reservation is explicitly canceled by the user or the CSMS.
 //
 // The Charging Station sends a ReservationStatusUpdateRequest to the CSMS, with the according status set.
@@ -80,5 +81,5 @@ func NewReservationStatusUpdateResponse() *ReservationStatusUpdateResponse {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("reservationUpdateStatus", isValidReservationUpdateStatus)
+	validate.MustRegisterValidation("reservationUpdateStatus", isValidReservationUpdateStatus)
 }

--- a/ocpp2.0.1/reservation/reserve_now.go
+++ b/ocpp2.0.1/reservation/reserve_now.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -135,6 +136,6 @@ func NewReserveNowResponse(status ReserveNowStatus) *ReserveNowResponse {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("reserveNowStatus", isValidReserveNowStatus)
-	_ = types.Validate.RegisterValidation("connectorType", isValidConnectorType)
+	validate.MustRegisterValidation("reserveNowStatus", isValidReserveNowStatus)
+	validate.MustRegisterValidation("connectorType", isValidConnectorType)
 }

--- a/ocpp2.0.1/security/certificate_signed.go
+++ b/ocpp2.0.1/security/certificate_signed.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Certificate Signed (CSMS -> CS) --------------------
@@ -79,5 +80,5 @@ func NewCertificateSignedResponse(status CertificateSignedStatus) *CertificateSi
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("certificateSignedStatus", isValidCertificateSignedStatus)
+	validate.MustRegisterValidation("certificateSignedStatus", isValidCertificateSignedStatus)
 }

--- a/ocpp2.0.1/smartcharging/clear_charging_profile.go
+++ b/ocpp2.0.1/smartcharging/clear_charging_profile.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Clear Charging Profile (CSMS -> CS) --------------------
@@ -87,5 +88,5 @@ func NewClearChargingProfileResponse(status ClearChargingProfileStatus) *ClearCh
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("clearChargingProfileStatus", isValidClearChargingProfileStatus)
+	validate.MustRegisterValidation("clearChargingProfileStatus", isValidClearChargingProfileStatus)
 }

--- a/ocpp2.0.1/smartcharging/get_charging_profiles.go
+++ b/ocpp2.0.1/smartcharging/get_charging_profiles.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 )
 
 // -------------------- Get Charging Profiles (CSMS -> Charging Station) --------------------
@@ -89,5 +90,5 @@ func NewGetChargingProfilesResponse(status GetChargingProfileStatus) *GetChargin
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("getChargingProfileStatus", isValidGetChargingProfileStatus)
+	validate.MustRegisterValidation("getChargingProfileStatus", isValidGetChargingProfileStatus)
 }

--- a/ocpp2.0.1/smartcharging/get_composite_schedule.go
+++ b/ocpp2.0.1/smartcharging/get_composite_schedule.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -87,5 +88,5 @@ func NewGetCompositeScheduleResponse(status GetCompositeScheduleStatus, evseId i
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("getCompositeScheduleStatus", isValidGetCompositeScheduleStatus)
+	validate.MustRegisterValidation("getCompositeScheduleStatus", isValidGetCompositeScheduleStatus)
 }

--- a/ocpp2.0.1/smartcharging/notify_ev_charging_needs.go
+++ b/ocpp2.0.1/smartcharging/notify_ev_charging_needs.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -132,6 +133,6 @@ func NewNotifyEVChargingNeedsResponse(status EVChargingNeedsStatus) *NotifyEVCha
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("energyTransferMode", isValidEnergyTransferMode)
-	_ = types.Validate.RegisterValidation("evChargingNeedsStatus", isValidEVChargingNeedsStatus)
+	validate.MustRegisterValidation("energyTransferMode", isValidEnergyTransferMode)
+	validate.MustRegisterValidation("evChargingNeedsStatus", isValidEVChargingNeedsStatus)
 }

--- a/ocpp2.0.1/smartcharging/set_charging_profile.go
+++ b/ocpp2.0.1/smartcharging/set_charging_profile.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -87,5 +88,5 @@ func NewSetChargingProfileResponse(status ChargingProfileStatus) *SetChargingPro
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("chargingProfileStatus", isValidChargingProfileStatus)
+	validate.MustRegisterValidation("chargingProfileStatus", isValidChargingProfileStatus)
 }

--- a/ocpp2.0.1/transactions/transaction_event.go
+++ b/ocpp2.0.1/transactions/transaction_event.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -199,8 +200,8 @@ func NewTransactionEventResponse() *TransactionEventResponse {
 }
 
 func init() {
-	_ = types.Validate.RegisterValidation("transactionEvent", isValidTransactionEvent)
-	_ = types.Validate.RegisterValidation("triggerReason", isValidTriggerReason)
-	_ = types.Validate.RegisterValidation("chargingState", isValidChargingState)
-	_ = types.Validate.RegisterValidation("stoppedReason", isValidReason)
+	validate.MustRegisterValidation("transactionEvent", isValidTransactionEvent)
+	validate.MustRegisterValidation("triggerReason", isValidTriggerReason)
+	validate.MustRegisterValidation("chargingState", isValidChargingState)
+	validate.MustRegisterValidation("stoppedReason", isValidReason)
 }

--- a/ocpp2.0.1/types/types.go
+++ b/ocpp2.0.1/types/types.go
@@ -2,9 +2,8 @@
 package types
 
 import (
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"gopkg.in/go-playground/validator.v9"
-
-	"github.com/lorenzodonini/ocpp-go/ocppj"
 )
 
 const (
@@ -697,30 +696,28 @@ type MeterValue struct {
 
 // Validator used for validating all OCPP 2.0 messages.
 // Any additional custom validations must be added to this object for automatic validation.
-var Validate = ocppj.Validate
-
 func init() {
-	_ = Validate.RegisterValidation("idTokenType", isValidIdTokenType)
-	_ = Validate.RegisterValidation("genericDeviceModelStatus", isValidGenericDeviceModelStatus)
-	_ = Validate.RegisterValidation("genericStatus", isValidGenericStatus)
-	_ = Validate.RegisterValidation("hashAlgorithm", isValidHashAlgorithmType)
-	_ = Validate.RegisterValidation("messageFormat", isValidMessageFormatType)
-	_ = Validate.RegisterValidation("authorizationStatus", isValidAuthorizationStatus)
-	_ = Validate.RegisterValidation("attribute", isValidAttribute)
-	_ = Validate.RegisterValidation("chargingProfilePurpose", isValidChargingProfilePurpose)
-	_ = Validate.RegisterValidation("chargingProfileKind", isValidChargingProfileKind)
-	_ = Validate.RegisterValidation("recurrencyKind", isValidRecurrencyKind)
-	_ = Validate.RegisterValidation("chargingRateUnit", isValidChargingRateUnit)
-	_ = Validate.RegisterValidation("chargingLimitSource", isValidChargingLimitSource)
-	_ = Validate.RegisterValidation("remoteStartStopStatus", isValidRemoteStartStopStatus)
-	_ = Validate.RegisterValidation("readingContext", isValidReadingContext)
-	_ = Validate.RegisterValidation("measurand", isValidMeasurand)
-	_ = Validate.RegisterValidation("phase", isValidPhase)
-	_ = Validate.RegisterValidation("location", isValidLocation)
-	_ = Validate.RegisterValidation("signatureMethod", isValidSignatureMethod)
-	_ = Validate.RegisterValidation("encodingMethod", isValidEncodingMethod)
-	_ = Validate.RegisterValidation("certificateSigningUse", isValidCertificateSigningUse)
-	_ = Validate.RegisterValidation("certificateUse", isValidCertificateUse)
-	_ = Validate.RegisterValidation("15118EVCertificate", isValidCertificate15118EVStatus)
-	_ = Validate.RegisterValidation("costKind", isValidCostKind)
+	validate.MustRegisterValidation("idTokenType", isValidIdTokenType)
+	validate.MustRegisterValidation("genericDeviceModelStatus", isValidGenericDeviceModelStatus)
+	validate.MustRegisterValidation("genericStatus", isValidGenericStatus)
+	validate.MustRegisterValidation("hashAlgorithm", isValidHashAlgorithmType)
+	validate.MustRegisterValidation("messageFormat", isValidMessageFormatType)
+	validate.MustRegisterValidation("authorizationStatus", isValidAuthorizationStatus)
+	validate.MustRegisterValidation("attribute", isValidAttribute)
+	validate.MustRegisterValidation("chargingProfilePurpose", isValidChargingProfilePurpose)
+	validate.MustRegisterValidation("chargingProfileKind", isValidChargingProfileKind)
+	validate.MustRegisterValidation("recurrencyKind", isValidRecurrencyKind)
+	validate.MustRegisterValidation("chargingRateUnit", isValidChargingRateUnit)
+	validate.MustRegisterValidation("chargingLimitSource", isValidChargingLimitSource)
+	validate.MustRegisterValidation("remoteStartStopStatus", isValidRemoteStartStopStatus)
+	validate.MustRegisterValidation("readingContext", isValidReadingContext)
+	validate.MustRegisterValidation("measurand", isValidMeasurand)
+	validate.MustRegisterValidation("phase", isValidPhase)
+	validate.MustRegisterValidation("location", isValidLocation)
+	validate.MustRegisterValidation("signatureMethod", isValidSignatureMethod)
+	validate.MustRegisterValidation("encodingMethod", isValidEncodingMethod)
+	validate.MustRegisterValidation("certificateSigningUse", isValidCertificateSigningUse)
+	validate.MustRegisterValidation("certificateUse", isValidCertificateUse)
+	validate.MustRegisterValidation("15118EVCertificate", isValidCertificate15118EVStatus)
+	validate.MustRegisterValidation("costKind", isValidCostKind)
 }

--- a/ocpp2.0.1_test/ocpp2_test.go
+++ b/ocpp2.0.1_test/ocpp2_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/transactions"
 	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
 	"github.com/lorenzodonini/ocpp-go/ocppj"
+	"github.com/lorenzodonini/ocpp-go/validate"
 	"github.com/lorenzodonini/ocpp-go/ws"
 )
 
@@ -1048,7 +1049,7 @@ type GenericTestEntry struct {
 // TODO: pass expected error value for improved validation and error message
 func ExecuteGenericTestTable(t *testing.T, testTable []GenericTestEntry) {
 	for _, testCase := range testTable {
-		err := types.Validate.Struct(testCase.Element)
+		err := validate.Validator.Struct(testCase.Element)
 		if err != nil {
 			assert.Equal(t, testCase.ExpectedValid, false, err.Error())
 		} else {

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -8,14 +8,10 @@ import (
 	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/logging"
-
-	"gopkg.in/go-playground/validator.v9"
-
 	"github.com/lorenzodonini/ocpp-go/ocpp"
+	"github.com/lorenzodonini/ocpp-go/validate"
+	"gopkg.in/go-playground/validator.v9"
 )
-
-// The validator, used for validating incoming/outgoing OCPP messages.
-var Validate = validator.New()
 
 // The internal validation settings. Enabled by default.
 var validationEnabled bool
@@ -24,7 +20,7 @@ var validationEnabled bool
 var log logging.Logger
 
 func init() {
-	_ = Validate.RegisterValidation("errorCode", IsErrorCodeValid)
+	validate.MustRegisterValidation("errorCode", IsErrorCodeValid)
 	log = &logging.VoidLogger{}
 	validationEnabled = true
 }
@@ -78,6 +74,7 @@ var messageIdGenerator = func() string {
 // The function is invoked automatically when creating a new Call.
 //
 // Settings this overrides the default behavior, which is:
+//
 //	fmt.Sprintf("%v", rand.Uint32())
 func SetMessageIdGenerator(generator func() string) {
 	if generator != nil {
@@ -381,7 +378,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 			Action:        action,
 			Payload:       request,
 		}
-		err = Validate.Struct(call)
+		err = validate.Validator.Struct(call)
 		if err != nil {
 			return nil, errorFromValidation(err.(validator.ValidationErrors), uniqueId, action)
 		}
@@ -402,7 +399,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 			UniqueId:      uniqueId,
 			Payload:       confirmation,
 		}
-		err = Validate.Struct(callResult)
+		err = validate.Validator.Struct(callResult)
 		if err != nil {
 			return nil, errorFromValidation(err.(validator.ValidationErrors), uniqueId, request.GetFeatureName())
 		}
@@ -433,7 +430,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 			ErrorDescription: errorDescription,
 			ErrorDetails:     details,
 		}
-		err := Validate.Struct(callError)
+		err := validate.Validator.Struct(callError)
 		if err != nil {
 			return nil, errorFromValidation(err.(validator.ValidationErrors), uniqueId, "")
 		}
@@ -462,7 +459,7 @@ func (endpoint *Endpoint) CreateCall(request ocpp.Request) (*Call, error) {
 		Payload:       request,
 	}
 	if validationEnabled {
-		err := Validate.Struct(call)
+		err := validate.Validator.Struct(call)
 		if err != nil {
 			return nil, err
 		}
@@ -485,7 +482,7 @@ func (endpoint *Endpoint) CreateCallResult(confirmation ocpp.Response, uniqueId 
 		Payload:       confirmation,
 	}
 	if validationEnabled {
-		err := Validate.Struct(callResult)
+		err := validate.Validator.Struct(callResult)
 		if err != nil {
 			return nil, err
 		}
@@ -503,7 +500,7 @@ func (endpoint *Endpoint) CreateCallError(uniqueId string, code ocpp.ErrorCode, 
 		ErrorDetails:     details,
 	}
 	if validationEnabled {
-		err := Validate.Struct(callError)
+		err := validate.Validator.Struct(callError)
 		if err != nil {
 			return nil, err
 		}

--- a/validate/validator.go
+++ b/validate/validator.go
@@ -1,0 +1,16 @@
+package validate
+
+import "gopkg.in/go-playground/validator.v9"
+
+// The validator, used for validating incoming/outgoing OCPP messages.
+var Validator = validator.New()
+
+func MustRegisterValidation(tag string, fn validator.Func, callValidationEvenIfNull ...bool) {
+	if err := Validator.RegisterValidation(tag, fn, callValidationEvenIfNull...); err != nil {
+		panic(err)
+	}
+}
+
+func MustRegisterStructValidation(fn validator.StructLevelFunc, types ...interface{}) {
+	Validator.RegisterStructValidation(fn, types...)
+}

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -157,18 +157,22 @@ func (e HttpConnectionError) Error() string {
 // The offered API are of asynchronous nature, and each incoming connection/message is handled using callbacks.
 //
 // To create a new ws server, use:
+//
 //	server := NewServer()
 //
 // If you need a TLS ws server instead, use:
+//
 //	server := NewTLSServer("cert.pem", "privateKey.pem")
 //
 // To support client basic authentication, use:
+//
 //	server.SetBasicAuthHandler(func (user, pass) bool {
 //		ok := authenticate(user, pass) // ... check for user and pass correctness
 //		return ok
 //	})
 //
 // To specify supported sub-protocols, use:
+//
 //	server.AddSupportedSubprotocol("ocpp1.6")
 //
 // If you need to set a specific timeout configuration, refer to the SetTimeoutConfig method.
@@ -273,6 +277,7 @@ func NewServer() *Server {
 //
 // It is recommended to pass a valid TLSConfig for the server to use.
 // For example to require client certificate verification:
+//
 //	tlsConfig := &tls.Config{
 //		ClientAuth: tls.RequireAndVerifyClientCert,
 //		ClientCAs: clientCAs,
@@ -634,9 +639,11 @@ func (server *Server) cleanupConnection(ws *WebSocket) {
 // The offered API are of asynchronous nature, and each incoming message is handled using callbacks.
 //
 // To create a new ws client, use:
+//
 //	client := NewClient()
 //
 // If you need a TLS ws client instead, use:
+//
 //	certPool, err := x509.SystemCertPool()
 //	if err != nil {
 //		log.Fatal(err)
@@ -647,11 +654,13 @@ func (server *Server) cleanupConnection(ws *WebSocket) {
 //	})
 //
 // To add additional dial options, use:
+//
 //	client.AddOption(func(*websocket.Dialer) {
 //		// Your option ...
 //	)}
 //
 // To add basic HTTP authentication, use:
+//
 //	client.SetBasicAuth("username","password")
 //
 // If you need to set a specific timeout configuration, refer to the SetTimeoutConfig method.
@@ -743,6 +752,7 @@ func NewClient() *Client {
 // Basic authentication can be set using the SetBasicAuth function.
 //
 // To set a client certificate, you may do:
+//
 //	certificate, _ := tls.LoadX509KeyPair(clientCertPath, clientKeyPath)
 //	clientCertificates := []tls.Certificate{certificate}
 //	client := ws.NewTLSClient(&tls.Config{
@@ -753,6 +763,7 @@ func NewClient() *Client {
 // You can set any other TLS option within the same constructor as well.
 // For example, if you wish to test connecting to a server having a
 // self-signed certificate (do not use in production!), pass:
+//
 //	InsecureSkipVerify: true
 func NewTLSClient(tlsConfig *tls.Config) *Client {
 	client := &Client{dialOptions: []func(*websocket.Dialer){}, timeoutConfig: NewClientTimeoutConfig(), header: http.Header{}}


### PR DESCRIPTION
Purpose of this PR is to allow importing of `types` without creating import cycles between `types` and `ocppj`. Root cause is the shared validator which originally lives in `ocppj`. 
An alternative approach would be to move the validator to `types`. However, that would lead to packages importing `types` that otherwise wouldn't need to do so.

The original motivation for doing so was https://github.com/lorenzodonini/ocpp-go/pull/145. I've implemented that without resorting to using `types`, so strictly speaking this PR is no longer necessary. Please feel free to close if this introduces too many changes.

I've also added handling of registration errors, i.e. `panic`.

Formatting changes are due to the `go fmt` updates of Go 1.19.