### PR TITLE
Register defaultSubProtocol

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -30,7 +30,6 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220804214406-8e32c043e418 h1:9vYwv7OjYaky/tlAeD7C4oC9EsPTlaFl1H2jS++V+ME=
 golang.org/x/sys v0.0.0-20220804214406-8e32c043e418/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -41,5 +40,5 @@ gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXa
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.30.0 h1:Wk0Z37oBmKj9/n+tPyBHZmeL19LaCoK3Qq48VwYENss=
 gopkg.in/go-playground/validator.v9 v9.30.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/ocpp1.6/v16.go
+++ b/ocpp1.6/v16.go
@@ -5,8 +5,6 @@ import (
 	"crypto/tls"
 	"net"
 
-	"github.com/gorilla/websocket"
-
 	"github.com/lorenzodonini/ocpp-go/internal/callbackqueue"
 	"github.com/lorenzodonini/ocpp-go/ocpp"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
@@ -34,12 +32,15 @@ type ChargePointConnectionHandler func(chargePoint ChargePointConnection)
 // You can instantiate a default Charge Point struct by calling NewClient.
 //
 // The logic for incoming messages needs to be implemented, and the message handlers need to be registered with the charge point:
-// 	handler := &ChargePointHandler{}
+//
+//	handler := &ChargePointHandler{}
 //	client.SetCoreHandler(handler)
+//
 // Refer to the ChargePointHandler interfaces in the respective core, firmware, localauth, remotetrigger, reservation and smartcharging profiles for the implementation requirements.
 //
 // A charge point can be started and stopped using the Start and Stop functions.
 // While running, messages can be sent to the Central system by calling the Charge point's functions, e.g.
+//
 //	bootConf, err := client.BootNotification("model1", "vendor1")
 //
 // All messages are synchronous blocking, and return either the response from the Central system or an error.
@@ -109,10 +110,12 @@ type ChargePoint interface {
 // The id parameter is required to uniquely identify the charge point.
 //
 // The endpoint and client parameters may be omitted, in order to use a default configuration:
-//   client := NewClient("someUniqueId", nil, nil)
+//
+//	client := NewClient("someUniqueId", nil, nil)
 //
 // Additional networking parameters (e.g. TLS or proxy configuration) may be passed, by creating a custom client.
 // Here is an example for a client using TLS configuration with a self-signed certificate:
+//
 //	certPool := x509.NewCertPool()
 //	data, err := ioutil.ReadFile("serverSelfSignedCertFilename")
 //	if err != nil {
@@ -132,19 +135,7 @@ func NewChargePoint(id string, endpoint *ocppj.Client, client ws.WsClient) Charg
 	if client == nil {
 		client = ws.NewClient()
 	}
-	client.AddOption(func(dialer *websocket.Dialer) {
-		// Look for v1.6 subprotocol and add it, if not found
-		alreadyExists := false
-		for _, proto := range dialer.Subprotocols {
-			if proto == types.V16Subprotocol {
-				alreadyExists = true
-				break
-			}
-		}
-		if !alreadyExists {
-			dialer.Subprotocols = append(dialer.Subprotocols, types.V16Subprotocol)
-		}
-	})
+	client.AddOption(ws.DefaultSubProtocol())
 	cp := chargePoint{confirmationHandler: make(chan ocpp.Response, 1), errorHandler: make(chan error, 1), callbacks: callbackqueue.New()}
 
 	if endpoint == nil {
@@ -171,18 +162,22 @@ func NewChargePoint(id string, endpoint *ocppj.Client, client ws.WsClient) Charg
 // You can instantiate a default Central System struct by calling the NewServer function.
 //
 // The logic for handling incoming messages needs to be implemented, and the message handlers need to be registered with the central system:
+//
 //	handler := &CentralSystemHandler{}
 //	server.SetCoreHandler(handler)
+//
 // Refer to the CentralSystemHandler interfaces in the respective core, firmware, localauth, remotetrigger, reservation and smartcharging profiles for the implementation requirements.
 //
 // A Central system can be started by using the Start function.
 // To be notified of incoming (dis)connections from charge points refer to the SetNewClientHandler and SetChargePointDisconnectedHandler functions.
 //
 // While running, messages can be sent to a charge point by calling the Central system's functions, e.g.:
+//
 //	callback := func(conf *ChangeAvailabilityConfirmation, err error) {
 //		// handle the response...
 //	}
 //	changeAvailabilityConf, err := server.ChangeAvailability("cs0001", callback, 1, AvailabilityTypeOperative)
+//
 // All messages are sent asynchronously and do not block the caller.
 type CentralSystem interface {
 	// Instructs a charge point to change its availability. The target availability can be set for a single connector of for the whole charge point.
@@ -259,12 +254,14 @@ type CentralSystem interface {
 // Creates a new OCPP 1.6 central system.
 //
 // The endpoint and server parameters may be omitted, in order to use a default configuration:
-//   client := NewServer(nil, nil)
+//
+//	client := NewServer(nil, nil)
 //
 // It is recommended to use the default configuration, unless a custom networking / ocppj layer is required.
 // The default ocppj endpoint supports all OCPP 1.6 profiles out-of-the-box.
 //
 // If you need a TLS server, you may use the following:
+//
 //	cs := NewServer(nil, ws.NewTLSServer("certificatePath", "privateKeyPath"))
 func NewCentralSystem(endpoint *ocppj.Server, server ws.WsServer) CentralSystem {
 	if server == nil {

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -750,6 +750,7 @@ func NewClient() *Client {
 	}
 }
 
+// DefaultSubProtocol creates a dialer option that adds the ocpp1.6 subprotocol
 func DefaultSubProtocol() func(dialer *websocket.Dialer) {
 	return func(dialer *websocket.Dialer) {
 		// Look for v1.6 subprotocol and add it, if not found

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -743,23 +743,27 @@ type Client struct {
 // Additional options may be added using the AddOption function.
 // Basic authentication can be set using the SetBasicAuth function.
 func NewClient() *Client {
-	dialOptions := []func(*websocket.Dialer){
-		func(dialer *websocket.Dialer) {
-			// Look for v1.6 subprotocol and add it, if not found
-			alreadyExists := false
-			for _, proto := range dialer.Subprotocols {
-				if proto == defaultSubProtocol {
-					alreadyExists = true
-					break
-				}
-			}
-			if !alreadyExists {
-				dialer.Subprotocols = append(dialer.Subprotocols, defaultSubProtocol)
-			}
-		},
+	return &Client{
+		dialOptions:   []func(*websocket.Dialer){DefaultSubProtocol()},
+		timeoutConfig: NewClientTimeoutConfig(),
+		header:        http.Header{},
 	}
+}
 
-	return &Client{dialOptions: dialOptions, timeoutConfig: NewClientTimeoutConfig(), header: http.Header{}}
+func DefaultSubProtocol() func(dialer *websocket.Dialer) {
+	return func(dialer *websocket.Dialer) {
+		// Look for v1.6 subprotocol and add it, if not found
+		alreadyExists := false
+		for _, proto := range dialer.Subprotocols {
+			if proto == defaultSubProtocol {
+				alreadyExists = true
+				break
+			}
+		}
+		if !alreadyExists {
+			dialer.Subprotocols = append(dialer.Subprotocols, defaultSubProtocol)
+		}
+	}
 }
 
 // NewTLSClient creates a new secure websocket client. If supported by the server, the websocket channel will use TLS.


### PR DESCRIPTION
This PR moves registration of the `ocpp1.6` subprotocol to the  websocket client for sake of https://github.com/lorenzodonini/ocpp-go/issues/141#issuecomment-1256938448 without importing types (which, in turn, created the import cycle). 

Formatting changes are due to the `go fmt` updates of Go 1.19.