### PR TITLE
Require Go 1.18 and fix golangci-linter warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.15.x
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.18
+          cache: true
       - name: Setup toxiproxy
         run: |
           wget -O toxiproxy-2.1.4.deb https://github.com/Shopify/toxiproxy/releases/download/v2.1.4/toxiproxy_2.1.4_amd64.deb

--- a/example/1.6/cp/charge_point_sim.go
+++ b/example/1.6/cp/charge_point_sim.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -42,7 +41,7 @@ func setupTlsChargePoint(chargePointID string) ocpp16.ChargePoint {
 	// Load CA cert
 	caPath, ok := os.LookupEnv(envVarCACertificate)
 	if ok {
-		caCert, err := ioutil.ReadFile(caPath)
+		caCert, err := os.ReadFile(caPath)
 		if err != nil {
 			log.Warn(err)
 		} else if !certPool.AppendCertsFromPEM(caCert) {

--- a/example/1.6/cs/central_system_sim.go
+++ b/example/1.6/cs/central_system_sim.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -51,7 +50,7 @@ func setupTlsCentralSystem() ocpp16.CentralSystem {
 		certPool = systemPool
 	} else {
 		certPool = x509.NewCertPool()
-		data, err := ioutil.ReadFile(caCertificate)
+		data, err := os.ReadFile(caCertificate)
 		if err != nil {
 			log.Fatalf("couldn't read CA certificate from %v: %v", caCertificate, err)
 		}

--- a/example/2.0.1/chargingstation/charging_station_sim.go
+++ b/example/2.0.1/chargingstation/charging_station_sim.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -45,7 +44,7 @@ func setupTlsChargingStation(chargingStationID string) ocpp2.ChargingStation {
 	// Load CA cert
 	caPath, ok := os.LookupEnv(envVarCACertificate)
 	if ok {
-		caCert, err := ioutil.ReadFile(caPath)
+		caCert, err := os.ReadFile(caPath)
 		if err != nil {
 			log.Warn(err)
 		} else if !certPool.AppendCertsFromPEM(caCert) {

--- a/example/2.0.1/chargingstation/remotecontrol_handler.go
+++ b/example/2.0.1/chargingstation/remotecontrol_handler.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -29,7 +28,7 @@ func (handler *ChargingStationHandler) OnRequestStartTransaction(request *remote
 		evse.currentTransaction = nextTransactionID()
 		logDefault(request.GetFeatureName()).Infof("started transaction %v on evse %v, connector %v", evse.currentTransaction, *request.EvseID, connectorID)
 		response = remotecontrol.NewRequestStartTransactionResponse(remotecontrol.RequestStartStopStatusAccepted)
-		response.TransactionID = fmt.Sprintf("%s", evse.currentTransaction)
+		response.TransactionID = evse.currentTransaction
 		return response, nil
 	}
 	logDefault(request.GetFeatureName()).Errorf("couldn't start a transaction for token %v without an evseID", request.IDToken)

--- a/example/2.0.1/csms/csms_sim.go
+++ b/example/2.0.1/csms/csms_sim.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -54,7 +53,7 @@ func setupTlsCentralSystem() ocpp2.CSMS {
 		certPool = systemPool
 	} else {
 		certPool = x509.NewCertPool()
-		data, err := ioutil.ReadFile(caCertificate)
+		data, err := os.ReadFile(caCertificate)
 		if err != nil {
 			log.Fatalf("couldn't read CA certificate from %v: %v", caCertificate, err)
 		}

--- a/example/2.0.1/csms/transactions_handler.go
+++ b/example/2.0.1/csms/transactions_handler.go
@@ -6,16 +6,13 @@ func (c *CSMSHandler) OnTransactionEvent(chargingStationID string, request *tran
 	switch request.EventType {
 	case transactions.TransactionEventStarted:
 		logDefault(chargingStationID, request.GetFeatureName()).Infof("transaction %v started, reason: %v, state: %v", request.TransactionInfo.TransactionID, request.TriggerReason, request.TransactionInfo.ChargingState)
-		break
 	case transactions.TransactionEventUpdated:
 		logDefault(chargingStationID, request.GetFeatureName()).Infof("transaction %v updated, reason: %v, state: %v\n", request.TransactionInfo.TransactionID, request.TriggerReason, request.TransactionInfo.ChargingState)
 		for _, mv := range request.MeterValue {
 			logDefault(chargingStationID, request.GetFeatureName()).Printf("%v", mv)
 		}
-		break
 	case transactions.TransactionEventEnded:
 		logDefault(chargingStationID, request.GetFeatureName()).Infof("transaction %v stopped, reason: %v, state: %v\n", request.TransactionInfo.TransactionID, request.TriggerReason, request.TransactionInfo.ChargingState)
-		break
 	}
 	response = transactions.NewTransactionEventResponse()
 	return

--- a/go.mod
+++ b/go.mod
@@ -1,27 +1,19 @@
 module github.com/lorenzodonini/ocpp-go
 
-go 1.18
+go 1.16
 
 require (
 	github.com/Shopify/toxiproxy v2.1.4+incompatible
-	github.com/gorilla/mux v1.7.3
-	github.com/gorilla/websocket v1.4.1
-	github.com/sirupsen/logrus v1.4.2
-	github.com/stretchr/testify v1.4.0
-	gopkg.in/go-playground/validator.v9 v9.30.0
-)
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-playground/locales v0.12.1 // indirect
 	github.com/go-playground/universal-translator v0.16.0 // indirect
-	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/gorilla/mux v1.7.3
+	github.com/gorilla/websocket v1.4.1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/leodido/go-urn v1.1.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/objx v0.1.1 // indirect
+	github.com/sirupsen/logrus v1.4.2
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/sys v0.0.0-20220804214406-8e32c043e418 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
-	gopkg.in/yaml.v2 v2.2.2 // indirect
+	gopkg.in/go-playground/validator.v9 v9.30.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,19 +1,27 @@
 module github.com/lorenzodonini/ocpp-go
 
-go 1.12
+go 1.18
 
 require (
 	github.com/Shopify/toxiproxy v2.1.4+incompatible
-	github.com/go-playground/locales v0.12.1 // indirect
-	github.com/go-playground/universal-translator v0.16.0 // indirect
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.1
-	github.com/kr/pretty v0.1.0 // indirect
-	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
+	gopkg.in/go-playground/validator.v9 v9.30.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-playground/locales v0.12.1 // indirect
+	github.com/go-playground/universal-translator v0.16.0 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/leodido/go-urn v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.1 // indirect
 	golang.org/x/sys v0.0.0-20220804214406-8e32c043e418 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
-	gopkg.in/go-playground/validator.v9 v9.30.0
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -30,7 +30,6 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220804214406-8e32c043e418 h1:9vYwv7OjYaky/tlAeD7C4oC9EsPTlaFl1H2jS++V+ME=
 golang.org/x/sys v0.0.0-20220804214406-8e32c043e418/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -41,5 +40,5 @@ gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXa
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.30.0 h1:Wk0Z37oBmKj9/n+tPyBHZmeL19LaCoK3Qq48VwYENss=
 gopkg.in/go-playground/validator.v9 v9.30.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -484,8 +484,8 @@ func (cs *centralSystem) handleIncomingRequest(chargePoint ChargePointConnection
 			}
 		}
 	}
-	var confirmation ocpp.Response = nil
-	var err error = nil
+	var confirmation ocpp.Response
+	var err error
 	// Execute in separate goroutine, so the caller goroutine is available
 	go func() {
 		switch action {

--- a/ocpp1.6/charge_point.go
+++ b/ocpp1.6/charge_point.go
@@ -276,7 +276,7 @@ func (cp *chargePoint) asyncCallbackHandler() {
 				err := fmt.Errorf("no handler available for error %v", protoError.Error())
 				cp.error(err)
 			}
-		case _, _ = <-cp.stopC:
+		case <-cp.stopC:
 			// Handler stopped, cleanup callbacks.
 			// No callback invocation, since the user manually stopped the client.
 			cp.clearCallbacks(false)
@@ -397,9 +397,9 @@ func (cp *chargePoint) handleIncomingRequest(request ocpp.Request, requestId str
 		}
 	}
 	// Process request
-	var confirmation ocpp.Response = nil
+	var confirmation ocpp.Response
 	cp.client.GetProfileForFeature(action)
-	var err error = nil
+	var err error
 	switch action {
 	case core.ChangeAvailabilityFeatureName:
 		confirmation, err = cp.coreHandler.OnChangeAvailability(request.(*core.ChangeAvailabilityRequest))

--- a/ocpp1.6/types/datetime.go
+++ b/ocpp1.6/types/datetime.go
@@ -29,8 +29,8 @@ func (dt *DateTime) UnmarshalJSON(input []byte) error {
 	strInput := string(input)
 	strInput = strings.Trim(strInput, `"`)
 	if DateTimeFormat == "" {
-		defaultTime := time.Time{}
-		err := json.Unmarshal(input, defaultTime)
+		var defaultTime time.Time
+		err := json.Unmarshal(input, &defaultTime)
 		if err != nil {
 			return err
 		}
@@ -67,17 +67,4 @@ func FormatTimestamp(t time.Time) string {
 
 func DateTimeIsNull(dateTime *DateTime) bool {
 	return dateTime != nil && dateTime.IsZero()
-}
-
-func validateDateTimeGt(dateTime *DateTime, than time.Time) bool {
-	return dateTime != nil && dateTime.After(than)
-}
-
-func validateDateTimeNow(dateTime DateTime) bool {
-	dur := time.Now().Sub(dateTime.Time).Minutes()
-	return dur < 1
-}
-
-func validateDateTimeLt(dateTime DateTime, than time.Time) bool {
-	return dateTime.Before(than)
 }

--- a/ocpp1.6/v16.go
+++ b/ocpp1.6/v16.go
@@ -34,12 +34,15 @@ type ChargePointConnectionHandler func(chargePoint ChargePointConnection)
 // You can instantiate a default Charge Point struct by calling NewClient.
 //
 // The logic for incoming messages needs to be implemented, and the message handlers need to be registered with the charge point:
-// 	handler := &ChargePointHandler{}
+//
+//	handler := &ChargePointHandler{}
 //	client.SetCoreHandler(handler)
+//
 // Refer to the ChargePointHandler interfaces in the respective core, firmware, localauth, remotetrigger, reservation and smartcharging profiles for the implementation requirements.
 //
 // A charge point can be started and stopped using the Start and Stop functions.
 // While running, messages can be sent to the Central system by calling the Charge point's functions, e.g.
+//
 //	bootConf, err := client.BootNotification("model1", "vendor1")
 //
 // All messages are synchronous blocking, and return either the response from the Central system or an error.
@@ -109,12 +112,14 @@ type ChargePoint interface {
 // The id parameter is required to uniquely identify the charge point.
 //
 // The endpoint and client parameters may be omitted, in order to use a default configuration:
-//   client := NewClient("someUniqueId", nil, nil)
+//
+//	client := NewClient("someUniqueId", nil, nil)
 //
 // Additional networking parameters (e.g. TLS or proxy configuration) may be passed, by creating a custom client.
 // Here is an example for a client using TLS configuration with a self-signed certificate:
+//
 //	certPool := x509.NewCertPool()
-//	data, err := ioutil.ReadFile("serverSelfSignedCertFilename")
+//	data, err := os.ReadFile("serverSelfSignedCertFilename")
 //	if err != nil {
 //		log.Fatal(err)
 //	}
@@ -171,18 +176,22 @@ func NewChargePoint(id string, endpoint *ocppj.Client, client ws.WsClient) Charg
 // You can instantiate a default Central System struct by calling the NewServer function.
 //
 // The logic for handling incoming messages needs to be implemented, and the message handlers need to be registered with the central system:
+//
 //	handler := &CentralSystemHandler{}
 //	server.SetCoreHandler(handler)
+//
 // Refer to the CentralSystemHandler interfaces in the respective core, firmware, localauth, remotetrigger, reservation and smartcharging profiles for the implementation requirements.
 //
 // A Central system can be started by using the Start function.
 // To be notified of incoming (dis)connections from charge points refer to the SetNewClientHandler and SetChargePointDisconnectedHandler functions.
 //
 // While running, messages can be sent to a charge point by calling the Central system's functions, e.g.:
+//
 //	callback := func(conf *ChangeAvailabilityConfirmation, err error) {
 //		// handle the response...
 //	}
 //	changeAvailabilityConf, err := server.ChangeAvailability("cs0001", callback, 1, AvailabilityTypeOperative)
+//
 // All messages are sent asynchronously and do not block the caller.
 type CentralSystem interface {
 	// Instructs a charge point to change its availability. The target availability can be set for a single connector of for the whole charge point.
@@ -259,12 +268,14 @@ type CentralSystem interface {
 // Creates a new OCPP 1.6 central system.
 //
 // The endpoint and server parameters may be omitted, in order to use a default configuration:
-//   client := NewServer(nil, nil)
+//
+//	client := NewServer(nil, nil)
 //
 // It is recommended to use the default configuration, unless a custom networking / ocppj layer is required.
 // The default ocppj endpoint supports all OCPP 1.6 profiles out-of-the-box.
 //
 // If you need a TLS server, you may use the following:
+//
 //	cs := NewServer(nil, ws.NewTLSServer("certificatePath", "privateKeyPath"))
 func NewCentralSystem(endpoint *ocppj.Server, server ws.WsServer) CentralSystem {
 	if server == nil {

--- a/ocpp2.0.1/charging_station.go
+++ b/ocpp2.0.1/charging_station.go
@@ -548,7 +548,7 @@ func (cs *chargingStation) asyncCallbackHandler() {
 			} else {
 				cs.error(fmt.Errorf("no callback available for incoming error %w", protoError))
 			}
-		case _, _ = <-cs.stopC:
+		case <-cs.stopC:
 			return
 		}
 	}
@@ -685,8 +685,8 @@ func (cs *chargingStation) handleIncomingRequest(request ocpp.Request, requestId
 		}
 	}
 	// Process request
-	var response ocpp.Response = nil
-	var err error = nil
+	var response ocpp.Response
+	var err error
 	switch action {
 	case reservation.CancelReservationFeatureName:
 		response, err = cs.reservationHandler.OnCancelReservation(request.(*reservation.CancelReservationRequest))

--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -925,8 +925,8 @@ func (cs *csms) handleIncomingRequest(chargingStation ChargingStationConnection,
 			return
 		}
 	}
-	var response ocpp.Response = nil
-	var err error = nil
+	var response ocpp.Response
+	var err error
 	// Execute in separate goroutine, so the caller goroutine is available
 	go func() {
 		switch action {

--- a/ocpp2.0.1/types/datetime.go
+++ b/ocpp2.0.1/types/datetime.go
@@ -31,8 +31,8 @@ func (dt *DateTime) UnmarshalJSON(input []byte) error {
 	strInput := string(input)
 	strInput = strings.Trim(strInput, `"`)
 	if DateTimeFormat == "" {
-		defaultTime := time.Time{}
-		err := json.Unmarshal(input, defaultTime)
+		var defaultTime time.Time
+		err := json.Unmarshal(input, &defaultTime)
 		if err != nil {
 			return err
 		}
@@ -69,17 +69,4 @@ func FormatTimestamp(t time.Time) string {
 
 func DateTimeIsNull(dateTime *DateTime) bool {
 	return dateTime != nil && dateTime.IsZero()
-}
-
-func validateDateTimeGt(dateTime *DateTime, than time.Time) bool {
-	return dateTime != nil && dateTime.After(than)
-}
-
-func validateDateTimeNow(dateTime DateTime) bool {
-	dur := time.Now().Sub(dateTime.Time).Minutes()
-	return dur < 1
-}
-
-func validateDateTimeLt(dateTime DateTime, than time.Time) bool {
-	return dateTime.Before(than)
 }

--- a/ocpp2.0.1/v2.go
+++ b/ocpp2.0.1/v2.go
@@ -44,16 +44,19 @@ type ChargingStationConnectionHandler func(chargePoint ChargingStationConnection
 // You can instantiate a default Charging Station struct by calling NewChargingStation.
 //
 // The logic for incoming messages needs to be implemented, and message handlers need to be registered with the charging station:
-//	handler := &ChargingStationHandler{} 				// Custom struct
-//  chargingStation.SetAuthorizationHandler(handler)
-//  chargingStation.SetProvisioningHandler(handler)
-//  // set more handlers...
+//
+//		handler := &ChargingStationHandler{} 				// Custom struct
+//	 chargingStation.SetAuthorizationHandler(handler)
+//	 chargingStation.SetProvisioningHandler(handler)
+//	 // set more handlers...
+//
 // Refer to the ChargingStationHandler interface of each profile for the implementation requirements.
 //
 // If a handler for a profile is not set, the OCPP library will reply to incoming messages for that profile with a NotImplemented error.
 //
 // A charging station can be started and stopped using the Start and Stop functions.
 // While running, messages can be sent to the CSMS by calling the Charging Station's functions, e.g.
+//
 //	bootConf, err := chargingStation.BootNotification(BootReasonPowerUp, "model1", "vendor1")
 //
 // All messages are synchronous blocking, and return either the response from the CSMS or an error.
@@ -173,12 +176,14 @@ type ChargingStation interface {
 // The id parameter is required to uniquely identify the charge point.
 //
 // The endpoint and client parameters may be omitted, in order to use a default configuration:
-//   chargingStation := NewChargingStation("someUniqueId", nil, nil)
+//
+//	chargingStation := NewChargingStation("someUniqueId", nil, nil)
 //
 // Additional networking parameters (e.g. TLS or proxy configuration) may be passed, by creating a custom client.
 // Here is an example for a client using TLS configuration with a self-signed certificate:
+//
 //	certPool := x509.NewCertPool()
-//	data, err := ioutil.ReadFile("serverSelfSignedCertFilename")
+//	data, err := os.ReadFile("serverSelfSignedCertFilename")
 //	if err != nil {
 //		log.Fatal(err)
 //	}
@@ -236,10 +241,12 @@ func NewChargingStation(id string, endpoint *ocppj.Client, client ws.WsClient) C
 // You can instantiate a default CSMS struct by calling the NewCSMS function.
 //
 // The logic for handling incoming messages needs to be implemented, and message handlers need to be registered with the CSMS:
-//	handler := &CSMSHandler{} 				// Custom struct
-//  csms.SetAuthorizationHandler(handler)
-//  csms.SetProvisioningHandler(handler)
-//  // set more handlers...
+//
+//		handler := &CSMSHandler{} 				// Custom struct
+//	 csms.SetAuthorizationHandler(handler)
+//	 csms.SetProvisioningHandler(handler)
+//	 // set more handlers...
+//
 // Refer to the CSMSHandler interface of each profile for the implementation requirements.
 //
 // If a handler for a profile is not set, the OCPP library will reply to incoming messages for that profile with a NotImplemented error.
@@ -248,10 +255,12 @@ func NewChargingStation(id string, endpoint *ocppj.Client, client ws.WsClient) C
 // To be notified of incoming (dis)connections from charging stations refer to the SetNewChargingStationHandler and SetChargingStationDisconnectedHandler functions.
 //
 // While running, messages can be sent to a Charging Station by calling the CSMS's functions, e.g.:
+//
 //	callback := func(conf *ClearDisplayResponse, err error) {
 //		// handle the response...
 //	}
 //	clearDisplayConf, err := csms.ClearDisplay("cs0001", callback, 10)
+//
 // All messages are sent asynchronously and do not block the caller.
 type CSMS interface {
 	// Cancel a pending reservation, provided the reservationId, on a charging station.
@@ -388,12 +397,14 @@ type CSMS interface {
 // Creates a new OCPP 2.0 CSMS.
 //
 // The endpoint and client parameters may be omitted, in order to use a default configuration:
-//   csms := NewCSMS(nil, nil)
+//
+//	csms := NewCSMS(nil, nil)
 //
 // It is recommended to use the default configuration, unless a custom networking / ocppj layer is required.
 // The default dispatcher supports all implemented OCPP 2.0 features out-of-the-box.
 //
 // If you need a TLS server, you may use the following:
+//
 //	csms := NewCSMS(nil, ws.NewTLSServer("certificatePath", "privateKeyPath"))
 func NewCSMS(endpoint *ocppj.Server, server ws.WsServer) CSMS {
 	if server == nil {

--- a/ocpp2.0.1_test/ocpp2_test.go
+++ b/ocpp2.0.1_test/ocpp2_test.go
@@ -847,39 +847,39 @@ type expectedChargingStationOptions struct {
 func setupDefaultCSMSHandlers(suite *OcppV2TestSuite, options expectedCSMSOptions, handlers ...interface{}) {
 	t := suite.T()
 	for _, h := range handlers {
-		switch h.(type) {
+		switch h := h.(type) {
 		case *MockCSMSAuthorizationHandler:
-			suite.csms.SetAuthorizationHandler(h.(*MockCSMSAuthorizationHandler))
+			suite.csms.SetAuthorizationHandler(h)
 		case *MockCSMSAvailabilityHandler:
-			suite.csms.SetAvailabilityHandler(h.(*MockCSMSAvailabilityHandler))
+			suite.csms.SetAvailabilityHandler(h)
 		case *MockCSMSDataHandler:
-			suite.csms.SetDataHandler(h.(*MockCSMSDataHandler))
+			suite.csms.SetDataHandler(h)
 		case *MockCSMSDiagnosticsHandler:
-			suite.csms.SetDiagnosticsHandler(h.(*MockCSMSDiagnosticsHandler))
+			suite.csms.SetDiagnosticsHandler(h)
 		case *MockCSMSDisplayHandler:
-			suite.csms.SetDisplayHandler(h.(*MockCSMSDisplayHandler))
+			suite.csms.SetDisplayHandler(h)
 		case *MockCSMSFirmwareHandler:
-			suite.csms.SetFirmwareHandler(h.(*MockCSMSFirmwareHandler))
+			suite.csms.SetFirmwareHandler(h)
 		case *MockCSMSIso15118Handler:
-			suite.csms.SetISO15118Handler(h.(*MockCSMSIso15118Handler))
+			suite.csms.SetISO15118Handler(h)
 		case *MockCSMSLocalAuthHandler:
-			suite.csms.SetLocalAuthListHandler(h.(*MockCSMSLocalAuthHandler))
+			suite.csms.SetLocalAuthListHandler(h)
 		case *MockCSMSMeterHandler:
-			suite.csms.SetMeterHandler(h.(*MockCSMSMeterHandler))
+			suite.csms.SetMeterHandler(h)
 		case *MockCSMSProvisioningHandler:
-			suite.csms.SetProvisioningHandler(h.(*MockCSMSProvisioningHandler))
+			suite.csms.SetProvisioningHandler(h)
 		case *MockCSMSRemoteControlHandler:
-			suite.csms.SetRemoteControlHandler(h.(*MockCSMSRemoteControlHandler))
+			suite.csms.SetRemoteControlHandler(h)
 		case *MockCSMSReservationHandler:
-			suite.csms.SetReservationHandler(h.(*MockCSMSReservationHandler))
+			suite.csms.SetReservationHandler(h)
 		case *MockCSMSSecurityHandler:
-			suite.csms.SetSecurityHandler(h.(*MockCSMSSecurityHandler))
+			suite.csms.SetSecurityHandler(h)
 		case *MockCSMSSmartChargingHandler:
-			suite.csms.SetSmartChargingHandler(h.(*MockCSMSSmartChargingHandler))
+			suite.csms.SetSmartChargingHandler(h)
 		case *MockCSMSTariffCostHandler:
-			suite.csms.SetTariffCostHandler(h.(*MockCSMSTariffCostHandler))
+			suite.csms.SetTariffCostHandler(h)
 		case *MockCSMSTransactionsHandler:
-			suite.csms.SetTransactionsHandler(h.(*MockCSMSTransactionsHandler))
+			suite.csms.SetTransactionsHandler(h)
 		}
 	}
 	suite.csms.SetNewChargingStationHandler(func(chargingStation ocpp2.ChargingStationConnection) {
@@ -906,39 +906,39 @@ func setupDefaultCSMSHandlers(suite *OcppV2TestSuite, options expectedCSMSOption
 func setupDefaultChargingStationHandlers(suite *OcppV2TestSuite, options expectedChargingStationOptions, handlers ...interface{}) {
 	t := suite.T()
 	for _, h := range handlers {
-		switch h.(type) {
+		switch h := h.(type) {
 		case *MockChargingStationAuthorizationHandler:
-			suite.chargingStation.SetAuthorizationHandler(h.(*MockChargingStationAuthorizationHandler))
+			suite.chargingStation.SetAuthorizationHandler(h)
 		case *MockChargingStationAvailabilityHandler:
-			suite.chargingStation.SetAvailabilityHandler(h.(*MockChargingStationAvailabilityHandler))
+			suite.chargingStation.SetAvailabilityHandler(h)
 		case *MockChargingStationDataHandler:
-			suite.chargingStation.SetDataHandler(h.(*MockChargingStationDataHandler))
+			suite.chargingStation.SetDataHandler(h)
 		case *MockChargingStationDiagnosticsHandler:
-			suite.chargingStation.SetDiagnosticsHandler(h.(*MockChargingStationDiagnosticsHandler))
+			suite.chargingStation.SetDiagnosticsHandler(h)
 		case *MockChargingStationDisplayHandler:
-			suite.chargingStation.SetDisplayHandler(h.(*MockChargingStationDisplayHandler))
+			suite.chargingStation.SetDisplayHandler(h)
 		case *MockChargingStationFirmwareHandler:
-			suite.chargingStation.SetFirmwareHandler(h.(*MockChargingStationFirmwareHandler))
+			suite.chargingStation.SetFirmwareHandler(h)
 		case *MockChargingStationIso15118Handler:
-			suite.chargingStation.SetISO15118Handler(h.(*MockChargingStationIso15118Handler))
+			suite.chargingStation.SetISO15118Handler(h)
 		case *MockChargingStationLocalAuthHandler:
-			suite.chargingStation.SetLocalAuthListHandler(h.(*MockChargingStationLocalAuthHandler))
+			suite.chargingStation.SetLocalAuthListHandler(h)
 		case *MockChargingStationMeterHandler:
-			suite.chargingStation.SetMeterHandler(h.(*MockChargingStationMeterHandler))
+			suite.chargingStation.SetMeterHandler(h)
 		case *MockChargingStationProvisioningHandler:
-			suite.chargingStation.SetProvisioningHandler(h.(*MockChargingStationProvisioningHandler))
+			suite.chargingStation.SetProvisioningHandler(h)
 		case *MockChargingStationRemoteControlHandler:
-			suite.chargingStation.SetRemoteControlHandler(h.(*MockChargingStationRemoteControlHandler))
+			suite.chargingStation.SetRemoteControlHandler(h)
 		case *MockChargingStationReservationHandler:
-			suite.chargingStation.SetReservationHandler(h.(*MockChargingStationReservationHandler))
+			suite.chargingStation.SetReservationHandler(h)
 		case *MockChargingStationSecurityHandler:
-			suite.chargingStation.SetSecurityHandler(h.(*MockChargingStationSecurityHandler))
+			suite.chargingStation.SetSecurityHandler(h)
 		case *MockChargingStationSmartChargingHandler:
-			suite.chargingStation.SetSmartChargingHandler(h.(*MockChargingStationSmartChargingHandler))
+			suite.chargingStation.SetSmartChargingHandler(h)
 		case *MockChargingStationTariffCostHandler:
-			suite.chargingStation.SetTariffCostHandler(h.(*MockChargingStationTariffCostHandler))
+			suite.chargingStation.SetTariffCostHandler(h)
 		case *MockChargingStationTransactionHandler:
-			suite.chargingStation.SetTransactionsHandler(h.(*MockChargingStationTransactionHandler))
+			suite.chargingStation.SetTransactionsHandler(h)
 		}
 	}
 	suite.mockWsClient.On("Start", mock.AnythingOfType("string")).Return(options.startReturnArgument).Run(func(args mock.Arguments) {

--- a/ocppj/central_system_test.go
+++ b/ocppj/central_system_test.go
@@ -262,7 +262,7 @@ func (suite *OcppJTestSuite) TestCentralSystemNewClientHandler() {
 	// Simulate client connection
 	channel := NewMockWebSocket(mockClientID)
 	suite.mockServer.NewClientHandler(channel)
-	ok, _ := <-connectedC
+	ok := <-connectedC
 	assert.True(t, ok)
 	// Client state was created
 	_, ok = suite.serverRequestMap.Get(mockClientID)
@@ -288,7 +288,7 @@ func (suite *OcppJTestSuite) TestCentralSystemDisconnectedHandler() {
 	// Simulate client connection
 	channel := NewMockWebSocket(mockClientID)
 	suite.mockServer.NewClientHandler(channel)
-	ok, _ := <-connectedC
+	ok := <-connectedC
 	assert.True(t, ok)
 	// Simulate client disconnection
 	suite.mockServer.DisconnectedClientHandler(channel)

--- a/ocppj/central_system_test.go
+++ b/ocppj/central_system_test.go
@@ -292,7 +292,7 @@ func (suite *OcppJTestSuite) TestCentralSystemDisconnectedHandler() {
 	assert.True(t, ok)
 	// Simulate client disconnection
 	suite.mockServer.DisconnectedClientHandler(channel)
-	ok, _ = <-disconnectedC
+	ok = <-disconnectedC
 	assert.True(t, ok)
 }
 
@@ -490,7 +490,7 @@ func (suite *OcppJTestSuite) TestParallelRequests() {
 	suite.serverDispatcher.CreateClient(mockChargePointId)
 	for i := 0; i < messagesToQueue; i++ {
 		go func() {
-			req := newMockRequest(fmt.Sprintf("someReq"))
+			req := newMockRequest("someReq")
 			err := suite.centralSystem.SendRequest(mockChargePointId, req)
 			require.Nil(t, err)
 		}()

--- a/ocppj/charge_point_test.go
+++ b/ocppj/charge_point_test.go
@@ -388,7 +388,7 @@ func (suite *OcppJTestSuite) TestClientParallelRequests() {
 	require.Nil(t, err)
 	for i := 0; i < messagesToQueue; i++ {
 		go func() {
-			req := newMockRequest(fmt.Sprintf("someReq"))
+			req := newMockRequest("someReq")
 			err = suite.chargePoint.SendRequest(req)
 			require.Nil(t, err)
 		}()
@@ -526,7 +526,7 @@ func (suite *OcppJTestSuite) TestClientDisconnected() {
 		require.NoError(t, err)
 	}
 	// Wait for trigger disconnect after a few responses were returned
-	_ = <-triggerC
+	<-triggerC
 	assert.False(t, suite.clientDispatcher.IsPaused())
 	suite.mockClient.DisconnectedHandler(disconnectError)
 	time.Sleep(200 * time.Millisecond)
@@ -592,7 +592,7 @@ func (suite *OcppJTestSuite) TestClientReconnected() {
 		require.NoError(t, err)
 	}
 	// Wait for trigger disconnect after a few responses were returned
-	_ = <-triggerC
+	<-triggerC
 	suite.mockClient.DisconnectedHandler(disconnectError)
 	// One message was sent, but all others are still in queue
 	time.Sleep(200 * time.Millisecond)
@@ -604,7 +604,7 @@ func (suite *OcppJTestSuite) TestClientReconnected() {
 	assert.True(t, suite.clientDispatcher.IsRunning())
 	assert.False(t, suite.clientRequestQueue.IsEmpty())
 	// Wait until remaining messages are sent
-	_ = <-triggerC
+	<-triggerC
 	assert.False(t, suite.clientDispatcher.IsPaused())
 	assert.True(t, suite.clientDispatcher.IsRunning())
 	assert.Equal(t, messagesToQueue, sentMessages)
@@ -614,8 +614,8 @@ func (suite *OcppJTestSuite) TestClientReconnected() {
 
 // TestClientResponseTimeout ensures that upon a response timeout, the client dispatcher:
 //
-//  - cancels the current pending request
-//	- fires an error, which is returned to the caller
+//   - cancels the current pending request
+//   - fires an error, which is returned to the caller
 func (suite *OcppJTestSuite) TestClientResponseTimeout() {
 	t := suite.T()
 	requestID := ""
@@ -650,7 +650,7 @@ func (suite *OcppJTestSuite) TestClientResponseTimeout() {
 	assert.Equal(t, 1, suite.clientRequestQueue.Size())
 	assert.True(t, state.HasPendingRequest())
 	// Wait for timeout error to be thrown
-	_ = <-timeoutC
+	<-timeoutC
 	assert.True(t, suite.clientRequestQueue.IsEmpty())
 	assert.True(t, suite.clientDispatcher.IsRunning())
 	assert.False(t, state.HasPendingRequest())

--- a/ocppj/dispatcher.go
+++ b/ocppj/dispatcher.go
@@ -462,18 +462,18 @@ func (d *DefaultServerDispatcher) messagePump() {
 	// Dispatcher Loop
 	for {
 		select {
-		case _ = <-d.stoppedC:
+		case <-d.stoppedC:
 			// Server was stopped
 			d.queueMap.Init()
 			log.Info("stopped processing requests")
 			return
-		case clientID, _ = <-d.requestChannel:
+		case clientID = <-d.requestChannel:
 			// Check whether there is a request queue for the specified client
 			clientQueue, ok = d.queueMap.Get(clientID)
 			if !ok {
 				// No client queue found (client was removed)
 				// Deleting and canceling the context
-				clientCtx, _ = clientContextMap[clientID]
+				clientCtx = clientContextMap[clientID]
 				delete(clientContextMap, clientID)
 				if clientCtx.ctx != nil {
 					clientCtx.cancel()
@@ -496,7 +496,7 @@ func (d *DefaultServerDispatcher) messagePump() {
 			}
 			// Canceling timeout context
 			log.Debugf("timeout for client %v, canceling message", clientID)
-			clientCtx, _ = clientContextMap[clientID]
+			clientCtx = clientContextMap[clientID]
 			if clientCtx.isActive() {
 				clientCtx.cancel()
 				clientContextMap[clientID] = clientTimeoutContext{}
@@ -589,7 +589,7 @@ func (d *DefaultServerDispatcher) waitForTimeout(clientID string, clientCtx clie
 		} else {
 			log.Debugf("timeout canceled for %s", clientID)
 		}
-	case _ = <-d.stoppedC:
+	case <-d.stoppedC:
 		// Server was stopped, every pending timeout gets canceled
 	}
 }

--- a/ocppj/dispatcher.go
+++ b/ocppj/dispatcher.go
@@ -577,7 +577,7 @@ func (d *DefaultServerDispatcher) waitForTimeout(clientID string, clientCtx clie
 	defer clientCtx.cancel()
 	log.Debugf("started timeout timer for %s", clientID)
 	select {
-	case _, _ = <-clientCtx.ctx.Done():
+	case <-clientCtx.ctx.Done():
 		err := clientCtx.ctx.Err()
 		if err == context.DeadlineExceeded {
 			// Timeout triggered, notifying messagePump

--- a/ocppj/dispatcher.go
+++ b/ocppj/dispatcher.go
@@ -78,8 +78,7 @@ type ClientDispatcher interface {
 
 // pendingRequest is used internally for associating metadata to a pending Request.
 type pendingRequest struct {
-	request   ocpp.Request
-	startTime time.Time
+	request ocpp.Request
 }
 
 // DefaultClientDispatcher is a default implementation of the ClientDispatcher interface.
@@ -515,7 +514,7 @@ func (d *DefaultServerDispatcher) messagePump() {
 		case clientID = <-d.readyForDispatch:
 			// Cancel previous timeout (if any)
 			clientCtx, ok = clientContextMap[clientID]
-			if clientCtx.isActive() {
+			if ok && clientCtx.isActive() {
 				clientCtx.cancel()
 				clientContextMap[clientID] = clientTimeoutContext{}
 			}

--- a/ocppj/dispatcher_test.go
+++ b/ocppj/dispatcher_test.go
@@ -94,7 +94,7 @@ func (s *ServerDispatcherTestSuite) TestServerRequestCanceled() {
 	s.websocketServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
 		id, _ := args.Get(0).(string)
 		assert.Equal(t, clientID, id)
-		_, _ = <-writeC
+		<-writeC
 	}).Return(fmt.Errorf(errMsg))
 	// Create mock request
 	req := newMockRequest("somevalue")
@@ -293,7 +293,7 @@ func (c *ClientDispatcherTestSuite) TestClientRequestCanceled() {
 	writeC := make(chan bool, 1)
 	errMsg := "mockError"
 	c.websocketClient.On("Write", mock.Anything).Run(func(args mock.Arguments) {
-		_, _ = <-writeC
+		<-writeC
 	}).Return(fmt.Errorf(errMsg))
 	// Create mock request
 	req := newMockRequest("somevalue")
@@ -362,7 +362,7 @@ func (c *ClientDispatcherTestSuite) TestClientDispatcherTimeout() {
 	err = c.dispatcher.SendRequest(bundle)
 	require.NoError(t, err)
 	// Check status after sending request
-	_, _ = <-writeC
+	<-writeC
 	assert.True(t, c.state.HasPendingRequest())
 	// Wait for timeout
 	_, ok := <-timeout

--- a/ocppj/dispatcher_test.go
+++ b/ocppj/dispatcher_test.go
@@ -233,7 +233,6 @@ func (s *ServerDispatcherTestSuite) TestServerDispatcherTimeout() {
 
 type ClientDispatcherTestSuite struct {
 	suite.Suite
-	mutex           sync.Mutex
 	state           ocppj.ClientState
 	queue           ocppj.RequestQueue
 	dispatcher      ocppj.ClientDispatcher

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -78,6 +78,7 @@ var messageIdGenerator = func() string {
 // The function is invoked automatically when creating a new Call.
 //
 // Settings this overrides the default behavior, which is:
+//
 //	fmt.Sprintf("%v", rand.Uint32())
 func SetMessageIdGenerator(generator func() string) {
 	if generator != nil {
@@ -223,11 +224,11 @@ func ocppMessageToJson(message interface{}) ([]byte, error) {
 }
 
 func getValueLength(value interface{}) int {
-	switch value.(type) {
+	switch value := value.(type) {
 	case int:
-		return value.(int)
+		return value
 	case string:
-		return len(value.(string))
+		return len(value)
 	default:
 		return 0
 	}

--- a/ocppj/server.go
+++ b/ocppj/server.go
@@ -31,6 +31,7 @@ type ErrorHandler func(client ws.Channel, err *ocpp.Error, details interface{})
 // a custom state handler and a list of profiles may be passed.
 //
 // You may create a simple new server by using these default values:
+//
 //	s := ocppj.NewServer(ws.NewServer(), nil, nil)
 //
 // The dispatcher's associated ClientState will be set during initialization.
@@ -129,7 +130,7 @@ func (s *Server) SendRequest(clientID string, request ocpp.Request) error {
 	if !s.dispatcher.IsRunning() {
 		return fmt.Errorf("ocppj server is not started, couldn't send request")
 	}
-	call, err := s.CreateCall(request.(ocpp.Request))
+	call, err := s.CreateCall(request)
 	if err != nil {
 		return err
 	}

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -32,8 +32,6 @@ const (
 	defaultPingWait = defaultPongWait
 	// Send pings to peer with this period. Must be less than pongWait.
 	defaultPingPeriod = (defaultPongWait * 9) / 10
-	// Maximum message size allowed from peer.
-	maxMessageSize = 512
 	// Time allowed for the initial handshake to complete.
 	defaultHandshakeTimeout = 30 * time.Second
 	// Default sub-protocol to send to peer upon connection.
@@ -461,7 +459,9 @@ out:
 	// Handle client authentication
 	if server.basicAuthHandler != nil {
 		username, password, ok := r.BasicAuth()
-		ok = server.basicAuthHandler(username, password)
+		if ok {
+			ok = server.basicAuthHandler(username, password)
+		}
 		if !ok {
 			server.error(fmt.Errorf("basic auth failed: credentials invalid"))
 			w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)

--- a/ws/websocket_test.go
+++ b/ws/websocket_test.go
@@ -145,7 +145,7 @@ func TestWebsocketEcho(t *testing.T) {
 		assert.True(t, sig)
 		err := wsServer.Write(path.Base(testPath), message)
 		require.Nil(t, err)
-		sig, _ = <-triggerC
+		sig = <-triggerC
 		assert.True(t, sig)
 		wsClient.Stop()
 	}()
@@ -223,7 +223,7 @@ func TestTLSWebsocketEcho(t *testing.T) {
 		assert.True(t, sig)
 		err := wsServer.Write(path.Base(testPath), message)
 		require.NoError(t, err)
-		sig, _ = <-triggerC
+		sig = <-triggerC
 		assert.True(t, sig)
 		wsClient.Stop()
 	}()
@@ -954,12 +954,12 @@ func TestServerErrors(t *testing.T) {
 	err := wsClient.Start(u.String())
 	require.NoError(t, err)
 	// Wait for new client callback
-	r, _ = <-triggerC
+	r = <-triggerC
 	require.True(t, r)
 	// Send a dummy message and expect error on server side
 	err = wsClient.Write([]byte("dummy message"))
 	require.NoError(t, err)
-	r, _ = <-triggerC
+	r = <-triggerC
 	assert.True(t, r)
 	// Send message to non-existing client
 	err = wsServer.Write("fakeId", []byte("dummy response"))
@@ -967,10 +967,10 @@ func TestServerErrors(t *testing.T) {
 	// Send unexpected close message and wait for error to be thrown
 	err = wsClient.webSocket.connection.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseUnsupportedData, ""))
 	assert.NoError(t, err)
-	r, _ = <-triggerC
+	r = <-triggerC
 	// Stop and wait for errors channel cleanup
 	wsServer.Stop()
-	r, _ = <-triggerC
+	r = <-triggerC
 	assert.True(t, r)
 	close(finishC)
 }
@@ -1017,19 +1017,19 @@ func TestClientErrors(t *testing.T) {
 	// Send a dummy message and expect error on client side
 	err = wsServer.Write(path.Base(testPath), []byte("dummy message"))
 	require.NotNil(t, t, err)
-	r, _ = <-triggerC
+	r = <-triggerC
 	assert.True(t, r)
 	// Send unexpected close message and wait for error to be thrown
 	conn := wsServer.connections[path.Base(testPath)]
 	require.NotNil(t, conn)
 	err = conn.connection.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseUnsupportedData, ""))
 	assert.NoError(t, err)
-	r, _ = <-triggerC
+	r = <-triggerC
 	require.True(t, r)
 	// Stop server and client and wait for errors channel cleanup
 	wsServer.Stop()
 	wsClient.Stop()
-	r, _ = <-triggerC
+	r = <-triggerC
 	require.True(t, r)
 	close(finishC)
 }

--- a/ws/websocket_test.go
+++ b/ws/websocket_test.go
@@ -967,7 +967,7 @@ func TestServerErrors(t *testing.T) {
 	// Send unexpected close message and wait for error to be thrown
 	err = wsClient.webSocket.connection.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseUnsupportedData, ""))
 	assert.NoError(t, err)
-	r = <-triggerC
+	<-triggerC
 	// Stop and wait for errors channel cleanup
 	wsServer.Stop()
 	r = <-triggerC

--- a/ws/websocket_test.go
+++ b/ws/websocket_test.go
@@ -10,7 +10,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/http"
@@ -142,7 +141,7 @@ func TestWebsocketEcho(t *testing.T) {
 	// Start flow routine
 	go func() {
 		// Wait for messages to be exchanged, then close connection
-		sig, _ := <-triggerC
+		sig := <-triggerC
 		assert.True(t, sig)
 		err := wsServer.Write(path.Base(testPath), message)
 		require.Nil(t, err)
@@ -206,7 +205,7 @@ func TestTLSWebsocketEcho(t *testing.T) {
 	})
 	wsClient.AddOption(func(dialer *websocket.Dialer) {
 		certPool := x509.NewCertPool()
-		data, err := ioutil.ReadFile(certFilename)
+		data, err := os.ReadFile(certFilename)
 		assert.Nil(t, err)
 		ok := certPool.AppendCertsFromPEM(data)
 		assert.True(t, ok)
@@ -220,7 +219,7 @@ func TestTLSWebsocketEcho(t *testing.T) {
 	// Start flow routine
 	go func() {
 		// Wait for messages to be exchanged, then close connection
-		sig, _ := <-triggerC
+		sig := <-triggerC
 		assert.True(t, sig)
 		err := wsServer.Write(path.Base(testPath), message)
 		require.NoError(t, err)
@@ -265,7 +264,7 @@ func TestServerStartErrors(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	// Starting server again throws error
 	wsServer.Start(serverPort, serverPath)
-	r, _ := <-triggerC
+	r := <-triggerC
 	require.True(t, r)
 	wsServer.Stop()
 }
@@ -507,7 +506,7 @@ func TestValidBasicAuth(t *testing.T) {
 
 	// Create TLS client
 	certPool := x509.NewCertPool()
-	data, err := ioutil.ReadFile(certFilename)
+	data, err := os.ReadFile(certFilename)
 	require.Nil(t, err)
 	ok := certPool.AppendCertsFromPEM(data)
 	require.True(t, ok)
@@ -560,7 +559,7 @@ func TestInvalidBasicAuth(t *testing.T) {
 
 	// Create TLS client
 	certPool := x509.NewCertPool()
-	data, err := ioutil.ReadFile(certFilename)
+	data, err := os.ReadFile(certFilename)
 	require.Nil(t, err)
 	ok := certPool.AppendCertsFromPEM(data)
 	require.True(t, ok)
@@ -685,7 +684,7 @@ func TestValidClientTLSCertificate(t *testing.T) {
 
 	// Create TLS server with self-signed certificate
 	certPool := x509.NewCertPool()
-	data, err := ioutil.ReadFile(clientCertFilename)
+	data, err := os.ReadFile(clientCertFilename)
 	require.Nil(t, err)
 	ok := certPool.AppendCertsFromPEM(data)
 	require.True(t, ok)
@@ -704,7 +703,7 @@ func TestValidClientTLSCertificate(t *testing.T) {
 
 	// Create TLS client
 	certPool = x509.NewCertPool()
-	data, err = ioutil.ReadFile(serverCertFilename)
+	data, err = os.ReadFile(serverCertFilename)
 	require.Nil(t, err)
 	ok = certPool.AppendCertsFromPEM(data)
 	require.True(t, ok)
@@ -745,7 +744,7 @@ func TestInvalidClientTLSCertificate(t *testing.T) {
 
 	// Create TLS server with self-signed certificate
 	certPool := x509.NewCertPool()
-	data, err := ioutil.ReadFile(serverCertFilename)
+	data, err := os.ReadFile(serverCertFilename)
 	require.Nil(t, err)
 	ok := certPool.AppendCertsFromPEM(data)
 	require.True(t, ok)
@@ -764,7 +763,7 @@ func TestInvalidClientTLSCertificate(t *testing.T) {
 
 	// Create TLS client
 	certPool = x509.NewCertPool()
-	data, err = ioutil.ReadFile(serverCertFilename)
+	data, err = os.ReadFile(serverCertFilename)
 	require.Nil(t, err)
 	ok = certPool.AppendCertsFromPEM(data)
 	require.True(t, ok)
@@ -931,7 +930,7 @@ func TestServerErrors(t *testing.T) {
 				if ok {
 					assert.Error(t, err)
 				}
-			case _, _ = <-finishC:
+			case <-finishC:
 				return
 			}
 		}
@@ -942,7 +941,7 @@ func TestServerErrors(t *testing.T) {
 	// Will trigger an out-of-bound error
 	time.Sleep(50 * time.Millisecond)
 	wsServer.Stop()
-	r, _ := <-triggerC
+	r := <-triggerC
 	assert.True(t, r)
 	// Start server for real
 	wsServer.httpServer = &http.Server{}
@@ -997,7 +996,7 @@ func TestClientErrors(t *testing.T) {
 				if ok {
 					assert.Error(t, err)
 				}
-			case _, _ = <-finishC:
+			case <-finishC:
 				return
 			}
 		}
@@ -1013,7 +1012,7 @@ func TestClientErrors(t *testing.T) {
 	err = wsClient.Start(u.String())
 	require.NoError(t, err)
 	// Wait for new client callback
-	r, _ := <-triggerC
+	r := <-triggerC
 	require.True(t, r)
 	// Send a dummy message and expect error on client side
 	err = wsServer.Write(path.Base(testPath), []byte("dummy message"))


### PR DESCRIPTION
Go 1.12 is very old. This PR upgrades to Go 1.18 released in 2022. 
This PR fixes all linter warnings outside test and examples.