### PR TITLE
Explicitly use context.CancelFunc type for cancel

### DIFF
--- a/ocppj/dispatcher.go
+++ b/ocppj/dispatcher.go
@@ -365,7 +365,7 @@ type CanceledRequestHandler func(clientID string, requestID string, request ocpp
 // Utility struct for passing a client context around and cancel pending requests.
 type clientTimeoutContext struct {
 	ctx    context.Context
-	cancel func()
+	cancel context.CancelFunc
 }
 
 func (c clientTimeoutContext) isActive() bool {


### PR DESCRIPTION
Explicitly use context.CancelFunc type for cancel

Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

Although `context.CancelFunc` has the type defined as `func()` I believe we should use `context.CancelFunc` for consistency IMHO