### PR TITLE
fix: prevent blocking the websocket

### DIFF
--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -484,8 +484,8 @@ func (cs *centralSystem) handleIncomingRequest(chargePoint ChargePointConnection
 			}
 		}
 	}
-	var confirmation ocpp.Response = nil
-	var err error = nil
+	var confirmation ocpp.Response
+	var err error
 	// Execute in separate goroutine, so the caller goroutine is available
 	go func() {
 		switch action {
@@ -519,7 +519,8 @@ func (cs *centralSystem) handleIncomingRequest(chargePoint ChargePointConnection
 
 func (cs *centralSystem) handleIncomingConfirmation(chargePoint ChargePointConnection, confirmation ocpp.Response, requestId string) {
 	if callback, ok := cs.callbackQueue.Dequeue(chargePoint.ID()); ok {
-		callback(confirmation, nil)
+		// Execute in separate goroutine, so the caller goroutine is available
+		go callback(confirmation, nil)
 	} else {
 		err := fmt.Errorf("no handler available for call of type %v from client %s for request %s", confirmation.GetFeatureName(), chargePoint.ID(), requestId)
 		cs.error(err)
@@ -528,7 +529,8 @@ func (cs *centralSystem) handleIncomingConfirmation(chargePoint ChargePointConne
 
 func (cs *centralSystem) handleIncomingError(chargePoint ChargePointConnection, err *ocpp.Error, details interface{}) {
 	if callback, ok := cs.callbackQueue.Dequeue(chargePoint.ID()); ok {
-		callback(nil, err)
+		// Execute in separate goroutine, so the caller goroutine is available
+		go callback(nil, err)
 	} else {
 		err := fmt.Errorf("no handler available for call error %w from client %s", err, chargePoint.ID())
 		cs.error(err)
@@ -537,7 +539,8 @@ func (cs *centralSystem) handleIncomingError(chargePoint ChargePointConnection, 
 
 func (cs *centralSystem) handleCanceledRequest(chargePointID string, request ocpp.Request, err *ocpp.Error) {
 	if callback, ok := cs.callbackQueue.Dequeue(chargePointID); ok {
-		callback(nil, err)
+		// Execute in separate goroutine, so the caller goroutine is available
+		go callback(nil, err)
 	} else {
 		err := fmt.Errorf("no handler available for canceled request %s for client %s: %w",
 			request.GetFeatureName(), chargePointID, err)

--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -925,8 +925,8 @@ func (cs *csms) handleIncomingRequest(chargingStation ChargingStationConnection,
 			return
 		}
 	}
-	var response ocpp.Response = nil
-	var err error = nil
+	var response ocpp.Response
+	var err error
 	// Execute in separate goroutine, so the caller goroutine is available
 	go func() {
 		switch action {
@@ -990,7 +990,8 @@ func (cs *csms) handleIncomingRequest(chargingStation ChargingStationConnection,
 
 func (cs *csms) handleIncomingResponse(chargingStation ChargingStationConnection, response ocpp.Response, requestId string) {
 	if callback, ok := cs.callbackQueue.Dequeue(chargingStation.ID()); ok {
-		callback(response, nil)
+		// Execute in separate goroutine, so the caller goroutine is available
+		go callback(response, nil)
 	} else {
 		err := fmt.Errorf("no handler available for call of type %v from client %s for request %s", response.GetFeatureName(), chargingStation.ID(), requestId)
 		cs.error(err)
@@ -999,7 +1000,8 @@ func (cs *csms) handleIncomingResponse(chargingStation ChargingStationConnection
 
 func (cs *csms) handleIncomingError(chargingStation ChargingStationConnection, err *ocpp.Error, details interface{}) {
 	if callback, ok := cs.callbackQueue.Dequeue(chargingStation.ID()); ok {
-		callback(nil, err)
+		// Execute in separate goroutine, so the caller goroutine is available
+		go callback(nil, err)
 	} else {
 		cs.error(fmt.Errorf("no handler available for call error %w from client %s", err, chargingStation.ID()))
 	}
@@ -1007,7 +1009,8 @@ func (cs *csms) handleIncomingError(chargingStation ChargingStationConnection, e
 
 func (cs *csms) handleCanceledRequest(chargePointID string, request ocpp.Request, err *ocpp.Error) {
 	if callback, ok := cs.callbackQueue.Dequeue(chargePointID); ok {
-		callback(nil, err)
+		// Execute in separate goroutine, so the caller goroutine is available
+		go callback(nil, err)
 	} else {
 		err := fmt.Errorf("no handler available for canceled request %s for client %s: %w",
 			request.GetFeatureName(), chargePointID, err)


### PR DESCRIPTION
We experienced an issue where our executed code in the callback function of `GetConfiguration` was blocking and we couldn't see any other OCPP messages incoming on the same websocket session. (Note: We are running as OCPP Server)
After digging deeper into the code base here, we figured out that the response messages are handled without any go-routine calls and thus they are directly called from the readPump() function of the websocket.

For `CALL_RESULT`s, the following queue of function calls holds:
`readPump()` -> `messageHandler()` -> `responseHandler()` -> `handleIncomingConfirmation()` -> (BLOCKING CODE also blocks the underyling websocket readPump)

Since the documentation about the callback function does not say that the callback should be called in a go-routine, I would suggest to call the callback functions always in a separate go-routine.
The return value of the callback is not used in any way, thus a synchronous behavior is not really necessary.