### PR TITLE
Add IsConnected method

### DIFF
--- a/ocpp1.6/charge_point.go
+++ b/ocpp1.6/charge_point.go
@@ -340,6 +340,10 @@ func (cp *chargePoint) Stop() {
 	}
 }
 
+func (cp *chargePoint) IsConnected() bool {
+	return cp.client.IsConnected()
+}
+
 func (cp *chargePoint) notImplementedError(requestId string, action string) {
 	err := cp.client.SendError(requestId, ocppj.NotImplemented, fmt.Sprintf("no handler for action %v implemented", action), nil)
 	if err != nil {

--- a/ocpp1.6/v16.go
+++ b/ocpp1.6/v16.go
@@ -101,6 +101,9 @@ type ChargePoint interface {
 	// Stops the charge point routine, disconnecting it from the central system.
 	// Any pending requests are discarded.
 	Stop()
+	// Returns true if the charge point is currently connected to the central system, false otherwise.
+	// While automatically reconnecting to the central system, the method returns false.
+	IsConnected() bool
 	// Errors returns a channel for error messages. If it doesn't exist it es created.
 	// The channel is closed by the charge point when stopped.
 	Errors() <-chan error

--- a/ocpp1.6_test/ocpp16_test.go
+++ b/ocpp1.6_test/ocpp16_test.go
@@ -143,6 +143,11 @@ func (websocketClient *MockWebsocketClient) Errors() <-chan error {
 	return websocketClient.errC
 }
 
+func (websocketClient *MockWebsocketClient) IsConnected() bool {
+	args := websocketClient.MethodCalled("IsConnected")
+	return args.Bool(0)
+}
+
 // Default queue capacity
 const queueCapacity = 10
 
@@ -682,6 +687,16 @@ func (suite *OcppV16TestSuite) SetupTest() {
 		return defaultMessageId
 	}}
 	ocppj.SetMessageIdGenerator(suite.messageIdGenerator.generateId)
+}
+
+func (suite *OcppV16TestSuite) TestIsConnected() {
+	t := suite.T()
+	// Simulate ws connected
+	mockCall := suite.mockWsClient.On("IsConnected").Return(true)
+	assert.True(t, suite.chargePoint.IsConnected())
+	// Simulate ws disconnected
+	mockCall.Return(false)
+	assert.False(t, suite.chargePoint.IsConnected())
 }
 
 //TODO: implement generic protocol tests

--- a/ocpp2.0.1/charging_station.go
+++ b/ocpp2.0.1/charging_station.go
@@ -591,6 +591,10 @@ func (cs *chargingStation) Stop() {
 	cs.client.Stop()
 }
 
+func (cs *chargingStation) IsConnected() bool {
+	return cs.client.IsConnected()
+}
+
 func (cs *chargingStation) notImplementedError(requestId string, action string) {
 	err := cs.client.SendError(requestId, ocppj.NotImplemented, fmt.Sprintf("no handler for action %v implemented", action), nil)
 	if err != nil {

--- a/ocpp2.0.1/v2.go
+++ b/ocpp2.0.1/v2.go
@@ -165,6 +165,9 @@ type ChargingStation interface {
 	// Stops the charging station routine, disconnecting it from the CSMS.
 	// Any pending requests are discarded.
 	Stop()
+	// Returns true if the charging station is currently connected to the CSMS, false otherwise.
+	// While automatically reconnecting to the CSMS, the method returns false.
+	IsConnected() bool
 	// Errors returns a channel for error messages. If it doesn't exist it es created.
 	// The channel is closed by the charging station when stopped.
 	Errors() <-chan error

--- a/ocpp2.0.1_test/ocpp2_test.go
+++ b/ocpp2.0.1_test/ocpp2_test.go
@@ -159,6 +159,11 @@ func (websocketClient *MockWebsocketClient) Errors() <-chan error {
 	return websocketClient.errC
 }
 
+func (websocketClient *MockWebsocketClient) IsConnected() bool {
+	args := websocketClient.MethodCalled("IsConnected")
+	return args.Bool(0)
+}
+
 // Default queue capacity
 const queueCapacity = 10
 
@@ -1116,6 +1121,16 @@ func (suite *OcppV2TestSuite) SetupTest() {
 		return defaultMessageId
 	}}
 	ocppj.SetMessageIdGenerator(suite.messageIdGenerator.generateId)
+}
+
+func (suite *OcppV2TestSuite) TestIsConnected() {
+	t := suite.T()
+	// Simulate ws connected
+	mockCall := suite.mockWsClient.On("IsConnected").Return(true)
+	assert.True(t, suite.chargingStation.IsConnected())
+	// Simulate ws disconnected
+	mockCall.Return(false)
+	assert.False(t, suite.chargingStation.IsConnected())
 }
 
 //TODO: implement generic protocol tests

--- a/ocppj/client.go
+++ b/ocppj/client.go
@@ -115,6 +115,10 @@ func (c *Client) Stop() {
 	<-cleanupC
 }
 
+func (c *Client) IsConnected() bool {
+	return c.client.IsConnected()
+}
+
 // Sends an OCPP Request to the server.
 // The protocol is based on request-response and cannot send multiple messages concurrently.
 // To guarantee this, outgoing messages are added to a queue and processed sequentially.

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -162,6 +162,11 @@ func (websocketClient *MockWebsocketClient) Errors() <-chan error {
 	return websocketClient.errC
 }
 
+func (websocketClient *MockWebsocketClient) IsConnected() bool {
+	args := websocketClient.MethodCalled("IsConnected")
+	return args.Bool(0)
+}
+
 // ---------------------- MOCK FEATURE ----------------------
 const (
 	MockFeatureName = "Mock"


### PR DESCRIPTION
Charge points in v1.6 and v2.0.1 now support a utility `IsConnected` method, that allows to verify whether the client is currently connected to the server.

While reconnecting, the method will return `false`.

Closes #154 