### PR TITLE
Fix validation errors on SampledValue

### DIFF
--- a/ocpp2.0.1/types/types.go
+++ b/ocpp2.0.1/types/types.go
@@ -681,7 +681,7 @@ type SignedMeterValue struct {
 }
 
 type SampledValue struct {
-	Value            float64           `json:"value" validate:"required"`                             // Indicates the measured value.
+	Value            float64           `json:"value"`                                                 // Indicates the measured value. This value is required.
 	Context          ReadingContext    `json:"context,omitempty" validate:"omitempty,readingContext"` // Type of detail value: start, end or sample. Default = "Sample.Periodic"
 	Measurand        Measurand         `json:"measurand,omitempty" validate:"omitempty,measurand"`    // Type of measurement. Default = "Energy.Active.Import.Register"
 	Phase            Phase             `json:"phase,omitempty" validate:"omitempty,phase"`            // Indicates how the measured value is to be interpreted. For instance between L1 and neutral (L1-N) Please note that not all values of phase are applicable to all Measurands. When phase is absent, the measured value is interpreted as an overall value.

--- a/ocpp2.0.1_test/common_test.go
+++ b/ocpp2.0.1_test/common_test.go
@@ -237,6 +237,7 @@ func (suite *OcppV2TestSuite) TestSampledValueValidation() {
 		{types.SampledValue{Value: 3.14, Context: types.ReadingContextTransactionEnd}, true},
 		{types.SampledValue{Value: 3.14}, true},
 		{types.SampledValue{Value: -3.14}, true},
+		{types.SampledValue{}, true},
 		{types.SampledValue{Value: 3.14, Context: "invalidContext"}, false},
 		{types.SampledValue{Value: 3.14, Measurand: "invalidMeasurand"}, false},
 		{types.SampledValue{Value: 3.14, Phase: "invalidPhase"}, false},


### PR DESCRIPTION
Validation for `SampledValue.Value` in OCPP 2.0.1 was leading to errors for `0` values. This is not intended, since zero values are allowed. 

Since go doesn't distinguish between zero and empty when parsing JSON into base types, this was fixed by removing the `required` validation tag from the field.

Closes #151, #157 