### PR TITLE
Fix ChargingProfileStatus NotSupported value

### DIFF
--- a/example/1.6/cp/handler.go
+++ b/example/1.6/cp/handler.go
@@ -293,7 +293,7 @@ func (handler *ChargePointHandler) OnCancelReservation(request *reservation.Canc
 func (handler *ChargePointHandler) OnSetChargingProfile(request *smartcharging.SetChargingProfileRequest) (confirmation *smartcharging.SetChargingProfileConfirmation, err error) {
 	//TODO: handle logic
 	logDefault(request.GetFeatureName()).Warn("no set charging profile logic implemented yet")
-	return smartcharging.NewSetChargingProfileConfirmation(smartcharging.ChargingProfileStatusNotImplemented), nil
+	return smartcharging.NewSetChargingProfileConfirmation(smartcharging.ChargingProfileStatusNotSupported), nil
 }
 
 func (handler *ChargePointHandler) OnClearChargingProfile(request *smartcharging.ClearChargingProfileRequest) (confirmation *smartcharging.ClearChargingProfileConfirmation, err error) {

--- a/ocpp1.6/smartcharging/set_charging_profile.go
+++ b/ocpp1.6/smartcharging/set_charging_profile.go
@@ -15,15 +15,15 @@ const SetChargingProfileFeatureName = "SetChargingProfile"
 type ChargingProfileStatus string
 
 const (
-	ChargingProfileStatusAccepted       ChargingProfileStatus = "Accepted"
-	ChargingProfileStatusRejected       ChargingProfileStatus = "Rejected"
-	ChargingProfileStatusNotImplemented ChargingProfileStatus = "NotImplemented"
+	ChargingProfileStatusAccepted     ChargingProfileStatus = "Accepted"
+	ChargingProfileStatusRejected     ChargingProfileStatus = "Rejected"
+	ChargingProfileStatusNotSupported ChargingProfileStatus = "NotSupported"
 )
 
 func isValidChargingProfileStatus(fl validator.FieldLevel) bool {
 	status := ChargingProfileStatus(fl.Field().String())
 	switch status {
-	case ChargingProfileStatusAccepted, ChargingProfileStatusRejected, ChargingProfileStatusNotImplemented:
+	case ChargingProfileStatusAccepted, ChargingProfileStatusRejected, ChargingProfileStatusNotSupported:
 		return true
 	default:
 		return false


### PR DESCRIPTION
Changes the incorrect `NotImplemented` enum value for the `ChargingProfileStatus` (smartcharging profile) to the correct value `NotSupported`, as per official specification.

Closes #161 