### PR TITLE
Fix incorrect IdTokenType

### DIFF
--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -431,7 +431,7 @@ func (cs *csms) PublishFirmware(clientId string, callback func(*firmware.Publish
 	return cs.SendRequestAsync(clientId, request, genericCallback)
 }
 
-func (cs *csms) RequestStartTransaction(clientId string, callback func(*remotecontrol.RequestStartTransactionResponse, error), remoteStartID int, IdToken types.IdTokenType, props ...func(request *remotecontrol.RequestStartTransactionRequest)) error {
+func (cs *csms) RequestStartTransaction(clientId string, callback func(*remotecontrol.RequestStartTransactionResponse, error), remoteStartID int, IdToken types.IdToken, props ...func(request *remotecontrol.RequestStartTransactionRequest)) error {
 	request := remotecontrol.NewRequestStartTransactionRequest(remoteStartID, IdToken)
 	for _, fn := range props {
 		fn(request)
@@ -461,7 +461,7 @@ func (cs *csms) RequestStopTransaction(clientId string, callback func(*remotecon
 	return cs.SendRequestAsync(clientId, request, genericCallback)
 }
 
-func (cs *csms) ReserveNow(clientId string, callback func(*reservation.ReserveNowResponse, error), id int, expiryDateTime *types.DateTime, idToken types.IdTokenType, props ...func(request *reservation.ReserveNowRequest)) error {
+func (cs *csms) ReserveNow(clientId string, callback func(*reservation.ReserveNowResponse, error), id int, expiryDateTime *types.DateTime, idToken types.IdToken, props ...func(request *reservation.ReserveNowRequest)) error {
 	request := reservation.NewReserveNowRequest(id, expiryDateTime, idToken)
 	for _, fn := range props {
 		fn(request)

--- a/ocpp2.0.1/remotecontrol/request_start_transaction.go
+++ b/ocpp2.0.1/remotecontrol/request_start_transaction.go
@@ -33,9 +33,9 @@ func isValidRequestStartStopStatus(fl validator.FieldLevel) bool {
 type RequestStartTransactionRequest struct {
 	EvseID          *int                   `json:"evseId,omitempty" validate:"omitempty,gt=0"`
 	RemoteStartID   int                    `json:"remoteStartId" validate:"gte=0"`
-	IDToken         types.IdTokenType      `json:"idToken" validate:"idTokenType"`
+	IDToken         types.IdToken          `json:"idToken" validate:"idTokenType"`
 	ChargingProfile *types.ChargingProfile `json:"chargingProfile,omitempty"`
-	GroupIdToken    types.IdTokenType      `json:"groupIdToken,omitempty" validate:"omitempty,idTokenType"`
+	GroupIdToken    *types.IdToken         `json:"groupIdToken,omitempty" validate:"omitempty,dive"`
 }
 
 // This field definition of the RequestStartTransaction response payload, sent by the Charging Station to the CSMS in response to a RequestStartTransactionRequest.
@@ -77,7 +77,7 @@ func (c RequestStartTransactionResponse) GetFeatureName() string {
 }
 
 // Creates a new RequestStartTransactionRequest, containing all required fields. Optional fields may be set afterwards.
-func NewRequestStartTransactionRequest(remoteStartID int, IdToken types.IdTokenType) *RequestStartTransactionRequest {
+func NewRequestStartTransactionRequest(remoteStartID int, IdToken types.IdToken) *RequestStartTransactionRequest {
 	return &RequestStartTransactionRequest{RemoteStartID: remoteStartID, IDToken: IdToken}
 }
 

--- a/ocpp2.0.1/reservation/reserve_now.go
+++ b/ocpp2.0.1/reservation/reserve_now.go
@@ -78,12 +78,12 @@ func isValidConnectorType(fl validator.FieldLevel) bool {
 
 // The field definition of the ReserveNow request payload sent by the CSMS to the Charging Station.
 type ReserveNowRequest struct {
-	ID             int               `json:"id" validate:"gte=0"` // ID of reservation
-	ExpiryDateTime *types.DateTime   `json:"expiryDateTime" validate:"required"`
-	ConnectorType  ConnectorType     `json:"connectorType,omitempty" validate:"omitempty,connectorType"`
-	EvseID         *int              `json:"evseId,omitempty" validate:"omitempty,gte=0"`
-	IdToken        types.IdTokenType `json:"idToken" validate:"required,idTokenType"`
-	GroupIdToken   types.IdTokenType `json:"groupIdToken,omitempty" validate:"omitempty,idTokenType"`
+	ID             int             `json:"id" validate:"gte=0"` // ID of reservation
+	ExpiryDateTime *types.DateTime `json:"expiryDateTime" validate:"required"`
+	ConnectorType  ConnectorType   `json:"connectorType,omitempty" validate:"omitempty,connectorType"`
+	EvseID         *int            `json:"evseId,omitempty" validate:"omitempty,gte=0"`
+	IdToken        types.IdToken   `json:"idToken" validate:"required,dive"`
+	GroupIdToken   *types.IdToken  `json:"groupIdToken,omitempty" validate:"omitempty,dive"`
 }
 
 // This field definition of the ReserveNow response payload, sent by the Charging Station to the CSMS in response to a ReserveNowRequest.
@@ -125,7 +125,7 @@ func (c ReserveNowResponse) GetFeatureName() string {
 }
 
 // Creates a new ReserveNowRequest, containing all required fields. Optional fields may be set afterwards.
-func NewReserveNowRequest(id int, expiryDateTime *types.DateTime, idToken types.IdTokenType) *ReserveNowRequest {
+func NewReserveNowRequest(id int, expiryDateTime *types.DateTime, idToken types.IdToken) *ReserveNowRequest {
 	return &ReserveNowRequest{ID: id, ExpiryDateTime: expiryDateTime, IdToken: idToken}
 }
 

--- a/ocpp2.0.1/transactions/transaction_event.go
+++ b/ocpp2.0.1/transactions/transaction_event.go
@@ -144,9 +144,9 @@ type TransactionEventRequest struct {
 	Offline            bool               `json:"offline,omitempty"`
 	NumberOfPhasesUsed *int               `json:"numberOfPhasesUsed,omitempty" validate:"omitempty,gte=0"`
 	CableMaxCurrent    *int               `json:"cableMaxCurrent,omitempty"`           // The maximum current of the connected cable in Ampere (A).
-	ReservationID      *int               `json:"reservationId,omitempty"`             // The Id of the reservation that terminates as a result of this transaction.
+	ReservationID      *int               `json:"reservationId,omitempty"`             // The ID of the reservation that terminates as a result of this transaction.
 	TransactionInfo    Transaction        `json:"transactionInfo" validate:"required"` // Contains transaction specific information.
-	IDToken            *types.IdToken     `json:"idToken,omitempty" validate:"omitempty"`
+	IDToken            *types.IdToken     `json:"idToken,omitempty" validate:"omitempty,dive"`
 	Evse               *types.EVSE        `json:"evse,omitempty" validate:"omitempty"`            // Identifies which evse (and connector) of the Charging Station is used.
 	MeterValue         []types.MeterValue `json:"meterValue,omitempty" validate:"omitempty,dive"` // Contains the relevant meter values.
 }

--- a/ocpp2.0.1/v2.go
+++ b/ocpp2.0.1/v2.go
@@ -301,11 +301,11 @@ type CSMS interface {
 	// Publishes a firmware to a local controller, allowing charging stations to download the same firmware from the local controller directly.
 	PublishFirmware(clientId string, callback func(*firmware.PublishFirmwareResponse, error), location string, checksum string, requestID int, props ...func(request *firmware.PublishFirmwareRequest)) error
 	// Remotely triggers a transaction to be started on a charging station.
-	RequestStartTransaction(clientId string, callback func(*remotecontrol.RequestStartTransactionResponse, error), remoteStartID int, IdToken types.IdTokenType, props ...func(request *remotecontrol.RequestStartTransactionRequest)) error
+	RequestStartTransaction(clientId string, callback func(*remotecontrol.RequestStartTransactionResponse, error), remoteStartID int, IdToken types.IdToken, props ...func(request *remotecontrol.RequestStartTransactionRequest)) error
 	// Remotely triggers an ongoing transaction to be stopped on a charging station.
 	RequestStopTransaction(clientId string, callback func(*remotecontrol.RequestStopTransactionResponse, error), transactionID string, props ...func(request *remotecontrol.RequestStopTransactionRequest)) error
 	// Attempts to reserve a connector for an EV, on a specific charging station.
-	ReserveNow(clientId string, callback func(*reservation.ReserveNowResponse, error), id int, expiryDateTime *types.DateTime, idToken types.IdTokenType, props ...func(request *reservation.ReserveNowRequest)) error
+	ReserveNow(clientId string, callback func(*reservation.ReserveNowResponse, error), id int, expiryDateTime *types.DateTime, idToken types.IdToken, props ...func(request *reservation.ReserveNowRequest)) error
 	// Instructs the Charging Station to reset itself.
 	Reset(clientId string, callback func(*provisioning.ResetResponse, error), t provisioning.ResetType, props ...func(request *provisioning.ResetRequest)) error
 	// Sends a local authorization list to a charging station, which can be used for the authorization of idTokens.

--- a/ocpp2.0.1_test/request_start_transaction_test.go
+++ b/ocpp2.0.1_test/request_start_transaction_test.go
@@ -32,17 +32,17 @@ func (suite *OcppV2TestSuite) TestRequestStartTransactionRequestValidation() {
 		},
 	}
 	var requestTable = []GenericTestEntry{
-		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(1), RemoteStartID: 42, IDToken: types.IdTokenTypeKeyCode, ChargingProfile: &chargingProfile, GroupIdToken: types.IdTokenTypeISO15693}, true},
-		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(1), RemoteStartID: 42, IDToken: types.IdTokenTypeKeyCode, ChargingProfile: &chargingProfile}, true},
-		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(1), RemoteStartID: 42, IDToken: types.IdTokenTypeKeyCode}, true},
-		{remotecontrol.RequestStartTransactionRequest{RemoteStartID: 42, IDToken: types.IdTokenTypeKeyCode}, true},
-		{remotecontrol.RequestStartTransactionRequest{IDToken: types.IdTokenTypeKeyCode}, true},
+		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(1), RemoteStartID: 42, IDToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}, ChargingProfile: &chargingProfile, GroupIdToken: &types.IdToken{IdToken: "1234", Type: types.IdTokenTypeISO15693}}, true},
+		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(1), RemoteStartID: 42, IDToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}, ChargingProfile: &chargingProfile}, true},
+		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(1), RemoteStartID: 42, IDToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}}, true},
+		{remotecontrol.RequestStartTransactionRequest{RemoteStartID: 42, IDToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}}, true},
+		{remotecontrol.RequestStartTransactionRequest{IDToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}}, true},
 		{remotecontrol.RequestStartTransactionRequest{}, false},
-		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(0), RemoteStartID: 42, IDToken: types.IdTokenTypeKeyCode, ChargingProfile: &chargingProfile, GroupIdToken: types.IdTokenTypeISO15693}, false},
-		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(1), RemoteStartID: -1, IDToken: types.IdTokenTypeKeyCode, ChargingProfile: &chargingProfile, GroupIdToken: types.IdTokenTypeISO15693}, false},
-		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(1), RemoteStartID: 42, IDToken: "invalidIdToken", ChargingProfile: &chargingProfile, GroupIdToken: types.IdTokenTypeISO15693}, false},
-		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(1), RemoteStartID: 42, IDToken: types.IdTokenTypeKeyCode, ChargingProfile: &types.ChargingProfile{}, GroupIdToken: types.IdTokenTypeISO15693}, false},
-		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(1), RemoteStartID: 42, IDToken: types.IdTokenTypeKeyCode, ChargingProfile: &chargingProfile, GroupIdToken: "invalidGroupIdToken"}, false},
+		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(0), RemoteStartID: 42, IDToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}, ChargingProfile: &chargingProfile, GroupIdToken: &types.IdToken{IdToken: "1234", Type: types.IdTokenTypeISO15693}}, false},
+		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(1), RemoteStartID: -1, IDToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}, ChargingProfile: &chargingProfile, GroupIdToken: &types.IdToken{IdToken: "1234", Type: types.IdTokenTypeISO15693}}, false},
+		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(1), RemoteStartID: 42, IDToken: types.IdToken{IdToken: "1234", Type: "invalidIdToken"}, ChargingProfile: &chargingProfile, GroupIdToken: &types.IdToken{IdToken: "1234", Type: types.IdTokenTypeISO15693}}, false},
+		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(1), RemoteStartID: 42, IDToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}, ChargingProfile: &types.ChargingProfile{}, GroupIdToken: &types.IdToken{IdToken: "1234", Type: types.IdTokenTypeISO15693}}, false},
+		{remotecontrol.RequestStartTransactionRequest{EvseID: newInt(1), RemoteStartID: 42, IDToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}, ChargingProfile: &chargingProfile, GroupIdToken: &types.IdToken{IdToken: "1234", Type: "invalidGroupIdToken"}}, false},
 	}
 	ExecuteGenericTestTable(t, requestTable)
 }
@@ -69,7 +69,7 @@ func (suite *OcppV2TestSuite) TestRequestStartTransactionE2EMocked() {
 	wsUrl := "someUrl"
 	evseId := newInt(1)
 	remoteStartID := 42
-	idToken := types.IdTokenTypeKeyCode
+	idToken := types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}
 	schedule := []types.ChargingSchedule{
 		{
 			ID:               1,
@@ -89,12 +89,12 @@ func (suite *OcppV2TestSuite) TestRequestStartTransactionE2EMocked() {
 		ChargingProfileKind:    types.ChargingProfileKindAbsolute,
 		ChargingSchedule:       schedule,
 	}
-	groupIdToken := types.IdTokenTypeISO15693
+	groupIdToken := types.IdToken{IdToken: "1234", Type: types.IdTokenTypeISO15693}
 	status := remotecontrol.RequestStartStopStatusAccepted
 	transactionId := "12345"
 	statusInfo := types.StatusInfo{ReasonCode: "200"}
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"evseId":%v,"remoteStartId":%v,"idToken":"%v","chargingProfile":{"id":%v,"stackLevel":%v,"chargingProfilePurpose":"%v","chargingProfileKind":"%v","chargingSchedule":[{"id":%v,"chargingRateUnit":"%v","chargingSchedulePeriod":[{"startPeriod":%v,"limit":%v}]}]},"groupIdToken":"%v"}]`,
-		messageId, remotecontrol.RequestStartTransactionFeatureName, *evseId, remoteStartID, idToken, chargingProfile.ID, chargingProfile.StackLevel, chargingProfile.ChargingProfilePurpose, chargingProfile.ChargingProfileKind, schedule[0].ID, schedule[0].ChargingRateUnit, schedule[0].ChargingSchedulePeriod[0].StartPeriod, schedule[0].ChargingSchedulePeriod[0].Limit, groupIdToken)
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"evseId":%v,"remoteStartId":%v,"idToken":{"idToken":"%s","type":"%s"},"chargingProfile":{"id":%v,"stackLevel":%v,"chargingProfilePurpose":"%v","chargingProfileKind":"%v","chargingSchedule":[{"id":%v,"chargingRateUnit":"%v","chargingSchedulePeriod":[{"startPeriod":%v,"limit":%v}]}]},"groupIdToken":{"idToken":"%s","type":"%s"}}]`,
+		messageId, remotecontrol.RequestStartTransactionFeatureName, *evseId, remoteStartID, idToken.IdToken, idToken.Type, chargingProfile.ID, chargingProfile.StackLevel, chargingProfile.ChargingProfilePurpose, chargingProfile.ChargingProfileKind, schedule[0].ID, schedule[0].ChargingRateUnit, schedule[0].ChargingSchedulePeriod[0].StartPeriod, schedule[0].ChargingSchedulePeriod[0].Limit, groupIdToken.IdToken, groupIdToken.Type)
 	responseJson := fmt.Sprintf(`[3,"%v",{"status":"%v","transactionId":"%v","statusInfo":{"reasonCode":"%v"}}]`,
 		messageId, status, transactionId, statusInfo.ReasonCode)
 	requestStartTransactionResponse := remotecontrol.NewRequestStartTransactionResponse(status)
@@ -108,7 +108,8 @@ func (suite *OcppV2TestSuite) TestRequestStartTransactionE2EMocked() {
 		require.True(t, ok)
 		assert.Equal(t, *evseId, *request.EvseID)
 		assert.Equal(t, remoteStartID, request.RemoteStartID)
-		assert.Equal(t, idToken, request.IDToken)
+		assert.Equal(t, idToken.IdToken, request.IDToken.IdToken)
+		assert.Equal(t, idToken.Type, request.IDToken.Type)
 		assert.Equal(t, chargingProfile.ID, request.ChargingProfile.ID)
 		assert.Equal(t, chargingProfile.ChargingProfilePurpose, request.ChargingProfile.ChargingProfilePurpose)
 		assert.Equal(t, chargingProfile.ChargingProfileKind, request.ChargingProfile.ChargingProfileKind)
@@ -119,6 +120,9 @@ func (suite *OcppV2TestSuite) TestRequestStartTransactionE2EMocked() {
 		require.Len(t, s.ChargingSchedulePeriod, len(chargingProfile.ChargingSchedule[0].ChargingSchedulePeriod))
 		assert.Equal(t, chargingProfile.ChargingSchedule[0].ChargingSchedulePeriod[0].Limit, s.ChargingSchedulePeriod[0].Limit)
 		assert.Equal(t, chargingProfile.ChargingSchedule[0].ChargingSchedulePeriod[0].StartPeriod, s.ChargingSchedulePeriod[0].StartPeriod)
+		require.NotNil(t, request.GroupIdToken)
+		assert.Equal(t, groupIdToken.IdToken, request.GroupIdToken.IdToken)
+		assert.Equal(t, groupIdToken.Type, request.GroupIdToken.Type)
 	})
 	setupDefaultCSMSHandlers(suite, expectedCSMSOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargingStationHandlers(suite, expectedChargingStationOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true}, handler)
@@ -137,7 +141,7 @@ func (suite *OcppV2TestSuite) TestRequestStartTransactionE2EMocked() {
 	}, remoteStartID, idToken, func(request *remotecontrol.RequestStartTransactionRequest) {
 		request.EvseID = evseId
 		request.ChargingProfile = &chargingProfile
-		request.GroupIdToken = groupIdToken
+		request.GroupIdToken = &groupIdToken
 	})
 	require.Nil(t, err)
 	result := <-resultChannel
@@ -148,7 +152,7 @@ func (suite *OcppV2TestSuite) TestRequestStartTransactionInvalidEndpoint() {
 	messageId := defaultMessageId
 	evseId := newInt(1)
 	remoteStartID := 42
-	idToken := types.IdTokenTypeKeyCode
+	idToken := types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}
 	schedule := []types.ChargingSchedule{
 		{
 			ChargingRateUnit: types.ChargingRateUnitAmperes,
@@ -167,15 +171,15 @@ func (suite *OcppV2TestSuite) TestRequestStartTransactionInvalidEndpoint() {
 		ChargingProfileKind:    types.ChargingProfileKindAbsolute,
 		ChargingSchedule:       schedule,
 	}
-	groupIdToken := types.IdTokenTypeISO15693
+	groupIdToken := types.IdToken{IdToken: "1234", Type: types.IdTokenTypeISO15693}
 	request := remotecontrol.RequestStartTransactionRequest{
 		EvseID:          evseId,
 		RemoteStartID:   remoteStartID,
 		IDToken:         idToken,
 		ChargingProfile: &chargingProfile,
-		GroupIdToken:    groupIdToken,
+		GroupIdToken:    &groupIdToken,
 	}
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"evseId":%v,"remoteStartId":%v,"idToken":"%v","chargingProfile":{"id":%v,"stackLevel":%v,"chargingProfilePurpose":"%v","chargingProfileKind":"%v","chargingSchedule":[{"chargingRateUnit":"%v","chargingSchedulePeriod":[{"startPeriod":%v,"limit":%v}]}]},"groupIdToken":"%v"}]`,
-		messageId, remotecontrol.RequestStartTransactionFeatureName, *evseId, remoteStartID, idToken, chargingProfile.ID, chargingProfile.StackLevel, chargingProfile.ChargingProfilePurpose, chargingProfile.ChargingProfileKind, schedule[0].ChargingRateUnit, schedule[0].ChargingSchedulePeriod[0].StartPeriod, schedule[0].ChargingSchedulePeriod[0].Limit, groupIdToken)
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"evseId":%v,"remoteStartId":%v,"idToken":{"idToken":"%s","type":"%s"},"chargingProfile":{"id":%v,"stackLevel":%v,"chargingProfilePurpose":"%v","chargingProfileKind":"%v","chargingSchedule":[{"id":%v,"chargingRateUnit":"%v","chargingSchedulePeriod":[{"startPeriod":%v,"limit":%v}]}]},"groupIdToken":{"idToken":"%s","type":"%s"}}]`,
+		messageId, remotecontrol.RequestStartTransactionFeatureName, *evseId, remoteStartID, idToken.IdToken, idToken.Type, chargingProfile.ID, chargingProfile.StackLevel, chargingProfile.ChargingProfilePurpose, chargingProfile.ChargingProfileKind, schedule[0].ID, schedule[0].ChargingRateUnit, schedule[0].ChargingSchedulePeriod[0].StartPeriod, schedule[0].ChargingSchedulePeriod[0].Limit, groupIdToken.IdToken, groupIdToken.Type)
 	testUnsupportedRequestFromChargingStation(suite, request, requestJson, messageId)
 }

--- a/ocpp2.0.1_test/reserve_now_test.go
+++ b/ocpp2.0.1_test/reserve_now_test.go
@@ -16,19 +16,19 @@ import (
 func (suite *OcppV2TestSuite) TestReserveNowRequestValidation() {
 	t := suite.T()
 	var requestTable = []GenericTestEntry{
-		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: reservation.ConnectorTypeCCS1, EvseID: newInt(1), IdToken: types.IdTokenTypeKeyCode, GroupIdToken: types.IdTokenTypeISO15693}, true},
-		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: reservation.ConnectorTypeCCS1, EvseID: newInt(1), IdToken: types.IdTokenTypeKeyCode}, true},
-		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: reservation.ConnectorTypeCCS1, IdToken: types.IdTokenTypeKeyCode}, true},
-		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), IdToken: types.IdTokenTypeKeyCode}, true},
-		{reservation.ReserveNowRequest{ExpiryDateTime: types.NewDateTime(time.Now()), IdToken: types.IdTokenTypeKeyCode}, true},
+		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: reservation.ConnectorTypeCCS1, EvseID: newInt(1), IdToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}, GroupIdToken: &types.IdToken{IdToken: "1234", Type: types.IdTokenTypeISO15693}}, true},
+		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: reservation.ConnectorTypeCCS1, EvseID: newInt(1), IdToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}}, true},
+		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: reservation.ConnectorTypeCCS1, IdToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}}, true},
+		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), IdToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}}, true},
+		{reservation.ReserveNowRequest{ExpiryDateTime: types.NewDateTime(time.Now()), IdToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}}, true},
 		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now())}, false},
-		{reservation.ReserveNowRequest{ID: 42, IdToken: types.IdTokenTypeKeyCode}, false},
+		{reservation.ReserveNowRequest{ID: 42, IdToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}}, false},
 		{reservation.ReserveNowRequest{}, false},
-		{reservation.ReserveNowRequest{ID: -1, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: reservation.ConnectorTypeCCS1, EvseID: newInt(1), IdToken: types.IdTokenTypeKeyCode, GroupIdToken: types.IdTokenTypeISO15693}, false},
-		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: "invalidConnectorType", EvseID: newInt(1), IdToken: types.IdTokenTypeKeyCode, GroupIdToken: types.IdTokenTypeISO15693}, false},
-		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: reservation.ConnectorTypeCCS1, EvseID: newInt(-1), IdToken: types.IdTokenTypeKeyCode, GroupIdToken: types.IdTokenTypeISO15693}, false},
-		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: reservation.ConnectorTypeCCS1, EvseID: newInt(1), IdToken: "invalidIdToken", GroupIdToken: types.IdTokenTypeISO15693}, false},
-		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: reservation.ConnectorTypeCCS1, EvseID: newInt(1), IdToken: types.IdTokenTypeKeyCode, GroupIdToken: "invalidIdToken"}, false},
+		{reservation.ReserveNowRequest{ID: -1, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: reservation.ConnectorTypeCCS1, EvseID: newInt(1), IdToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}, GroupIdToken: &types.IdToken{IdToken: "1234", Type: types.IdTokenTypeISO15693}}, false},
+		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: "invalidConnectorType", EvseID: newInt(1), IdToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}, GroupIdToken: &types.IdToken{IdToken: "1234", Type: types.IdTokenTypeISO15693}}, false},
+		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: reservation.ConnectorTypeCCS1, EvseID: newInt(-1), IdToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}, GroupIdToken: &types.IdToken{IdToken: "1234", Type: types.IdTokenTypeISO15693}}, false},
+		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: reservation.ConnectorTypeCCS1, EvseID: newInt(1), IdToken: types.IdToken{IdToken: "1234", Type: "invalidIdToken"}, GroupIdToken: &types.IdToken{IdToken: "1234", Type: types.IdTokenTypeISO15693}}, false},
+		{reservation.ReserveNowRequest{ID: 42, ExpiryDateTime: types.NewDateTime(time.Now()), ConnectorType: reservation.ConnectorTypeCCS1, EvseID: newInt(1), IdToken: types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}, GroupIdToken: &types.IdToken{IdToken: "1234", Type: "invalidIdToken"}}, false},
 	}
 	ExecuteGenericTestTable(t, requestTable)
 }
@@ -54,12 +54,12 @@ func (suite *OcppV2TestSuite) TestReserveNowE2EMocked() {
 	expiryDateTime := types.NewDateTime(time.Now())
 	connectorType := reservation.ConnectorTypeCCS1
 	evseID := newInt(1)
-	idToken := types.IdTokenTypeKeyCode
-	groupIdToken := types.IdTokenTypeISO15693
+	idToken := types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}
+	groupIdToken := types.IdToken{IdToken: "1234", Type: types.IdTokenTypeISO15693}
 	status := reservation.ReserveNowStatusAccepted
 	statusInfo := types.StatusInfo{ReasonCode: "200"}
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"id":%v,"expiryDateTime":"%v","connectorType":"%v","evseId":%v,"idToken":"%v","groupIdToken":"%v"}]`,
-		messageId, reservation.ReserveNowFeatureName, id, expiryDateTime.FormatTimestamp(), connectorType, *evseID, idToken, groupIdToken)
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"id":%v,"expiryDateTime":"%v","connectorType":"%v","evseId":%v,"idToken":{"idToken":"%s","type":"%s"},"groupIdToken":{"idToken":"%s","type":"%s"}}]`,
+		messageId, reservation.ReserveNowFeatureName, id, expiryDateTime.FormatTimestamp(), connectorType, *evseID, idToken.IdToken, idToken.Type, groupIdToken.IdToken, groupIdToken.Type)
 	responseJson := fmt.Sprintf(`[3,"%v",{"status":"%v","statusInfo":{"reasonCode":"%v"}}]`,
 		messageId, status, statusInfo.ReasonCode)
 	reserveNowResponse := reservation.NewReserveNowResponse(status)
@@ -74,8 +74,11 @@ func (suite *OcppV2TestSuite) TestReserveNowE2EMocked() {
 		assert.Equal(t, expiryDateTime.FormatTimestamp(), request.ExpiryDateTime.FormatTimestamp())
 		assert.Equal(t, connectorType, request.ConnectorType)
 		assert.Equal(t, *evseID, *request.EvseID)
-		assert.Equal(t, idToken, request.IdToken)
-		assert.Equal(t, groupIdToken, request.GroupIdToken)
+		assert.Equal(t, idToken.IdToken, request.IdToken.IdToken)
+		assert.Equal(t, idToken.Type, request.IdToken.Type)
+		require.NotNil(t, request.GroupIdToken)
+		assert.Equal(t, groupIdToken.IdToken, request.GroupIdToken.IdToken)
+		assert.Equal(t, groupIdToken.Type, request.GroupIdToken.Type)
 	})
 	setupDefaultCSMSHandlers(suite, expectedCSMSOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargingStationHandlers(suite, expectedChargingStationOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true}, handler)
@@ -93,7 +96,7 @@ func (suite *OcppV2TestSuite) TestReserveNowE2EMocked() {
 	}, id, expiryDateTime, idToken, func(request *reservation.ReserveNowRequest) {
 		request.ConnectorType = connectorType
 		request.EvseID = evseID
-		request.GroupIdToken = groupIdToken
+		request.GroupIdToken = &groupIdToken
 	})
 	require.Nil(t, err)
 	result := <-resultChannel
@@ -106,17 +109,17 @@ func (suite *OcppV2TestSuite) TestReserveNowInvalidEndpoint() {
 	expiryDateTime := types.NewDateTime(time.Now())
 	connectorType := reservation.ConnectorTypeCCS1
 	evseID := newInt(1)
-	idToken := types.IdTokenTypeKeyCode
-	groupIdToken := types.IdTokenTypeISO15693
+	idToken := types.IdToken{IdToken: "1234", Type: types.IdTokenTypeKeyCode}
+	groupIdToken := types.IdToken{IdToken: "1234", Type: types.IdTokenTypeISO15693}
 	reserveNowRequest := reservation.ReserveNowRequest{
 		ID:             id,
 		ExpiryDateTime: expiryDateTime,
 		ConnectorType:  connectorType,
 		EvseID:         evseID,
 		IdToken:        idToken,
-		GroupIdToken:   groupIdToken,
+		GroupIdToken:   &groupIdToken,
 	}
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"id":%v,"expiryDateTime":"%v","connectorType":"%v","evseId":%v,"idToken":"%v","groupIdToken":"%v"}]`,
-		messageId, reservation.ReserveNowFeatureName, id, expiryDateTime.FormatTimestamp(), connectorType, *evseID, idToken, groupIdToken)
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"id":%v,"expiryDateTime":"%v","connectorType":"%v","evseId":%v,"idToken":{"idToken":"%s","type":"%s"},"groupIdToken":{"idToken":"%s","type":"%s"}}]`,
+		messageId, reservation.ReserveNowFeatureName, id, expiryDateTime.FormatTimestamp(), connectorType, *evseID, idToken.IdToken, idToken.Type, groupIdToken.IdToken, groupIdToken.Type)
 	testUnsupportedRequestFromChargingStation(suite, reserveNowRequest, requestJson, messageId)
 }


### PR DESCRIPTION
Fixes incorrect type of `IDToken` fields in the following v2.0.1 requests:
- reservation.ReserveNow
- remotecontrol.RequestStartTransaction

The tpye was previously a string alias, now it is correctly a struct of type `IDToken`.

Closes #160 