### PR TITLE
Debug logs for raw json messages

### DIFF
--- a/ocppj/client.go
+++ b/ocppj/client.go
@@ -177,6 +177,7 @@ func (c *Client) SendResponse(requestId string, response ocpp.Response) error {
 		return err
 	}
 	log.Debugf("sent CALL RESULT [%s]", callResult.UniqueId)
+	log.Debugf("sent JSON message to server: %s", string(jsonMessage))
 	return nil
 }
 
@@ -211,6 +212,7 @@ func (c *Client) ocppMessageHandler(data []byte) error {
 		log.Error(err)
 		return err
 	}
+	log.Debugf("received JSON message from server: %s", string(data))
 	message, err := c.ParseMessage(parsedJson, c.RequestState)
 	if err != nil {
 		ocppErr := err.(*ocpp.Error)

--- a/ocppj/dispatcher.go
+++ b/ocppj/dispatcher.go
@@ -232,6 +232,8 @@ func (d *DefaultClientDispatcher) dispatchNextRequest() {
 				ocpp.NewError(InternalError, err.Error(), bundle.Call.UniqueId))
 		}
 	}
+	log.Infof("dispatched request %s to server", bundle.Call.UniqueId)
+	log.Debugf("sent JSON message to server: %s", string(jsonMessage))
 }
 
 func (d *DefaultClientDispatcher) Pause() {
@@ -569,6 +571,7 @@ func (d *DefaultServerDispatcher) dispatchNextRequest(clientID string) (clientCt
 		clientCtx = clientTimeoutContext{ctx: ctx, cancel: cancel}
 	}
 	log.Infof("dispatched request %s for %s", callID, clientID)
+	log.Debugf("sent JSON message to %s: %s", clientID, string(jsonMessage))
 	return
 }
 

--- a/ocppj/server.go
+++ b/ocppj/server.go
@@ -171,6 +171,7 @@ func (s *Server) SendResponse(clientID string, requestId string, response ocpp.R
 		return err
 	}
 	log.Debugf("sent CALL RESULT [%s] for %s", callResult.UniqueId, clientID)
+	log.Debugf("sent JSON message to %s: %s", clientID, string(jsonMessage))
 	return nil
 }
 
@@ -205,6 +206,7 @@ func (s *Server) ocppMessageHandler(wsChannel ws.Channel, data []byte) error {
 		log.Error(err)
 		return err
 	}
+	log.Debugf("received JSON message from %s: %s", wsChannel.ID(), string(data))
 	// Get pending requests for client
 	pending := s.RequestState.GetClientState(wsChannel.ID())
 	message, err := s.ParseMessage(parsedJson, pending)


### PR DESCRIPTION
Adds debug logs for incoming/outgoing raw JSON messages.

Logs for incoming messages are skipped if the message couldn't be parsed, i.e. if JSON unmarshaling fails.

Outgoing messages are logged directly after a `Write` operation occurred.