### PR TITLE
feature to add a custom client validation handler before connected

### DIFF
--- a/ocpp1.6_test/ocpp16_test.go
+++ b/ocpp1.6_test/ocpp16_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -89,7 +90,7 @@ func (websocketServer *MockWebsocketServer) NewClient(websocketId string, client
 	websocketServer.MethodCalled("NewClient", websocketId, client)
 }
 
-func (websocketServer *MockWebsocketServer) SetCheckClientHandler(handler ws.CheckClientHandler) {
+func (websocketServer *MockWebsocketServer) SetCheckClientHandler(handler func(id string, r *http.Request) bool) {
 	websocketServer.CheckClientHandler = handler
 }
 

--- a/ocpp1.6_test/ocpp16_test.go
+++ b/ocpp1.6_test/ocpp16_test.go
@@ -53,6 +53,7 @@ type MockWebsocketServer struct {
 	ws.WsServer
 	MessageHandler            func(ws ws.Channel, data []byte) error
 	NewClientHandler          func(ws ws.Channel)
+	CheckClientHandler        ws.CheckClientHandler
 	DisconnectedClientHandler func(ws ws.Channel)
 }
 
@@ -86,6 +87,10 @@ func (websocketServer *MockWebsocketServer) AddSupportedSubprotocol(subProto str
 
 func (websocketServer *MockWebsocketServer) NewClient(websocketId string, client interface{}) {
 	websocketServer.MethodCalled("NewClient", websocketId, client)
+}
+
+func (websocketServer *MockWebsocketServer) SetCheckClientHandler(handler ws.CheckClientHandler) {
+	websocketServer.CheckClientHandler = handler
 }
 
 // ---------------------- MOCK WEBSOCKET CLIENT ----------------------

--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -735,6 +735,10 @@ func (cs *csms) SetDataHandler(handler data.CSMSHandler) {
 	cs.dataHandler = handler
 }
 
+func (cs *csms) SetNewChargingStationValidationHandler(handler ws.CheckClientHandler) {
+	cs.server.SetNewClientValidationHandler(handler)
+}
+
 func (cs *csms) SetNewChargingStationHandler(handler ChargingStationConnectionHandler) {
 	cs.server.SetNewClientHandler(func(chargingStation ws.Channel) {
 		handler(chargingStation)

--- a/ocpp2.0.1/v2.go
+++ b/ocpp2.0.1/v2.go
@@ -34,6 +34,7 @@ type ChargingStationConnection interface {
 	TLSConnectionState() *tls.ConnectionState
 }
 
+type ChargingStationValidationHandler ws.CheckClientHandler
 type ChargingStationConnectionHandler func(chargePoint ChargingStationConnection)
 
 // -------------------- v2.0 Charging Station --------------------
@@ -365,6 +366,8 @@ type CSMS interface {
 	SetDisplayHandler(handler display.CSMSHandler)
 	// Registers a handler for incoming data transfer messages
 	SetDataHandler(handler data.CSMSHandler)
+	// Registers a handler for new incoming Charging station connections.
+	SetNewChargingStationValidationHandler(handler ws.CheckClientHandler)
 	// Registers a handler for new incoming Charging station connections.
 	SetNewChargingStationHandler(handler ChargingStationConnectionHandler)
 	// Registers a handler for Charging station disconnections.

--- a/ocpp2.0.1_test/ocpp2_test.go
+++ b/ocpp2.0.1_test/ocpp2_test.go
@@ -68,6 +68,7 @@ type MockWebsocketServer struct {
 	ws.WsServer
 	MessageHandler            func(ws ws.Channel, data []byte) error
 	NewClientHandler          func(ws ws.Channel)
+	CheckClientHandler        ws.CheckClientHandler
 	DisconnectedClientHandler func(ws ws.Channel)
 }
 
@@ -101,6 +102,10 @@ func (websocketServer *MockWebsocketServer) AddSupportedSubprotocol(subProto str
 
 func (websocketServer *MockWebsocketServer) NewClient(websocketId string, client interface{}) {
 	websocketServer.MethodCalled("NewClient", websocketId, client)
+}
+
+func (websocketServer *MockWebsocketServer) SetCheckClientHandler(handler ws.CheckClientHandler) {
+	websocketServer.CheckClientHandler = handler
 }
 
 // ---------------------- MOCK WEBSOCKET CLIENT ----------------------

--- a/ocpp2.0.1_test/ocpp2_test.go
+++ b/ocpp2.0.1_test/ocpp2_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -104,7 +105,7 @@ func (websocketServer *MockWebsocketServer) NewClient(websocketId string, client
 	websocketServer.MethodCalled("NewClient", websocketId, client)
 }
 
-func (websocketServer *MockWebsocketServer) SetCheckClientHandler(handler ws.CheckClientHandler) {
+func (websocketServer *MockWebsocketServer) SetCheckClientHandler(handler func(id string, r *http.Request) bool) {
 	websocketServer.CheckClientHandler = handler
 }
 

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -51,6 +51,7 @@ type MockWebsocketServer struct {
 	ws.WsServer
 	MessageHandler            func(ws ws.Channel, data []byte) error
 	NewClientHandler          func(ws ws.Channel)
+	CheckClientHandler        ws.CheckClientHandler
 	DisconnectedClientHandler func(ws ws.Channel)
 	errC                      chan error
 }
@@ -98,6 +99,10 @@ func (websocketServer *MockWebsocketServer) ThrowError(err error) {
 
 func (websocketServer *MockWebsocketServer) NewClient(websocketId string, client interface{}) {
 	websocketServer.MethodCalled("NewClient", websocketId, client)
+}
+
+func (websocketServer *MockWebsocketServer) SetCheckClientHandler(handler ws.CheckClientHandler) {
+	websocketServer.CheckClientHandler = handler
 }
 
 // ---------------------- MOCK WEBSOCKET CLIENT ----------------------

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -101,7 +102,7 @@ func (websocketServer *MockWebsocketServer) NewClient(websocketId string, client
 	websocketServer.MethodCalled("NewClient", websocketId, client)
 }
 
-func (websocketServer *MockWebsocketServer) SetCheckClientHandler(handler ws.CheckClientHandler) {
+func (websocketServer *MockWebsocketServer) SetCheckClientHandler(handler func(id string, r *http.Request) bool) {
 	websocketServer.CheckClientHandler = handler
 }
 

--- a/ocppj/server.go
+++ b/ocppj/server.go
@@ -12,6 +12,7 @@ import (
 type Server struct {
 	Endpoint
 	server                    ws.WsServer
+	checkClientHandler        ws.CheckClientHandler
 	newClientHandler          ClientHandler
 	disconnectedClientHandler ClientHandler
 	requestHandler            RequestHandler
@@ -86,6 +87,11 @@ func (s *Server) SetNewClientHandler(handler ClientHandler) {
 	s.newClientHandler = handler
 }
 
+// Registers a handler for validate incoming client connections.
+func (s *Server) SetNewClientValidationHandler(handler ws.CheckClientHandler) {
+	s.checkClientHandler = handler
+}
+
 // Registers a handler for client disconnections.
 func (s *Server) SetDisconnectedClientHandler(handler ClientHandler) {
 	s.disconnectedClientHandler = handler
@@ -99,6 +105,7 @@ func (s *Server) SetDisconnectedClientHandler(handler ClientHandler) {
 // An error may be returned, if the websocket server couldn't be started.
 func (s *Server) Start(listenPort int, listenPath string) {
 	// Set internal message handler
+	s.server.SetCheckClientHandler(s.checkClientHandler)
 	s.server.SetNewClientHandler(s.onClientConnected)
 	s.server.SetDisconnectedClientHandler(s.onClientDisconnected)
 	s.server.SetMessageHandler(s.ocppMessageHandler)


### PR DESCRIPTION
Feature to add a custom client validation handler before connected
For example: used for validate the charging station id on database or API before connected upgraded(ws)