### PR TITLE
Use correct name to validate ClearChargingProfileConfirmation

### DIFF
--- a/ocpp1.6/smartcharging/clear_charging_profile.go
+++ b/ocpp1.6/smartcharging/clear_charging_profile.go
@@ -39,7 +39,7 @@ type ClearChargingProfileRequest struct {
 // This field definition of the ClearChargingProfile confirmation payload, sent by the Charge Point to the Central System in response to a ClearChargingProfileRequest.
 // In case the request was invalid, or couldn't be processed, an error will be sent instead.
 type ClearChargingProfileConfirmation struct {
-	Status ClearChargingProfileStatus `json:"status" validate:"required,chargingProfileStatus"`
+	Status ClearChargingProfileStatus `json:"status" validate:"required,clearChargingProfileStatus"`
 }
 
 // If the Central System wishes to clear some or all of the charging profiles that were previously sent the Charge Point,


### PR DESCRIPTION
ClearChargingProfileConfirmation should use clearChargingProfileStatus for validating the status, not chargingProfileStatus