### PR TITLE
Fix newline in json encoding

### DIFF
--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -291,7 +291,7 @@ func jsonMarshal(t interface{}) ([]byte, error) {
 	encoder := json.NewEncoder(buffer)
 	encoder.SetEscapeHTML(EscapeHTML)
 	err := encoder.Encode(t)
-	return buffer.Bytes(), err
+	return bytes.TrimRight(buffer.Bytes(), "\n"), err
 }
 
 // -------------------- Endpoint --------------------


### PR DESCRIPTION
The new `json.Encoder` approach introduced in https://github.com/lorenzodonini/ocpp-go/pull/168 didn't trim newlines from json messages, which is the default behavior of the `Encode` function ([see reference](https://go.dev/src/encoding/json/stream.go#L220)).
 
Per OCPP spec a message shouldn't contain any trailing newline. This PR fixes the wrong behavior by trimming the introduced newline at the end of each generated message.