### PR TITLE
Fix property constraint violation on ConfigurationKey

### DIFF
--- a/ocpp1.6/core/get_configuration.go
+++ b/ocpp1.6/core/get_configuration.go
@@ -12,7 +12,7 @@ const GetConfigurationFeatureName = "GetConfiguration"
 type ConfigurationKey struct {
 	Key      string  `json:"key" validate:"required,max=50"`
 	Readonly bool    `json:"readonly"`
-	Value    *string `json:"value,omitempty" validate:"max=500"`
+	Value    *string `json:"value,omitempty" validate:"omitempty,max=500"`
 }
 
 // The field definition of the GetConfiguration request payload sent by the Central System to the Charge Point.


### PR DESCRIPTION
Fixes the immediate issue identified in #175.

The validation for the `ConfigurationKey.Value` field now is run on when the value is not nil. This will prevent a `PropertyConstraintViolation` error to be thrown, when a nil value is set for a specific key.