### PR TITLE
Remove validation for IdToken in RequestStartTransactionRequest

### DIFF
--- a/ocpp2.0.1/remotecontrol/request_start_transaction.go
+++ b/ocpp2.0.1/remotecontrol/request_start_transaction.go
@@ -33,7 +33,7 @@ func isValidRequestStartStopStatus(fl validator.FieldLevel) bool {
 type RequestStartTransactionRequest struct {
 	EvseID          *int                   `json:"evseId,omitempty" validate:"omitempty,gt=0"`
 	RemoteStartID   int                    `json:"remoteStartId" validate:"gte=0"`
-	IDToken         types.IdToken          `json:"idToken" validate:"idTokenType"`
+	IDToken         types.IdToken          `json:"idToken"`
 	ChargingProfile *types.ChargingProfile `json:"chargingProfile,omitempty"`
 	GroupIdToken    *types.IdToken         `json:"groupIdToken,omitempty" validate:"omitempty,dive"`
 }


### PR DESCRIPTION
The validation tag on `types.IdToken` should not be `idTokenType`. Regardless, the validation here didn't serve any purpose and was therefore removed.