### PR TITLE
Add AddHttpHandler 

### DIFF
--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -9,7 +9,6 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
-	"github.com/gorilla/mux"
 	"io"
 	"net"
 	"net/http"
@@ -18,9 +17,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/lorenzodonini/ocpp-go/logging"
-
+	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
+	"github.com/lorenzodonini/ocpp-go/logging"
 )
 
 const (

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
+	"github.com/gorilla/mux"
 	"io"
 	"net"
 	"net/http"
@@ -19,7 +20,6 @@ import (
 
 	"github.com/lorenzodonini/ocpp-go/logging"
 
-	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 )
 
@@ -256,6 +256,7 @@ type Server struct {
 	errC                chan error
 	connMutex           sync.RWMutex
 	addr                *net.TCPAddr
+	httpHandler         *mux.Router
 }
 
 // Creates a new simple websocket server (the websockets are not secured).
@@ -282,6 +283,7 @@ func NewServer() *Server {
 // If no tlsConfig parameter is passed, the server will by default
 // not perform any client certificate verification.
 func NewTLSServer(certificatePath string, certificateKey string, tlsConfig *tls.Config) *Server {
+	router := mux.NewRouter()
 	return &Server{
 		tlsCertificatePath: certificatePath,
 		tlsCertificateKey:  certificateKey,
@@ -290,6 +292,7 @@ func NewTLSServer(certificatePath string, certificateKey string, tlsConfig *tls.
 		},
 		timeoutConfig: NewServerTimeoutConfig(),
 		upgrader:      websocket.Upgrader{Subprotocols: []string{}},
+		httpHandler:   router,
 	}
 }
 
@@ -345,11 +348,12 @@ func (server *Server) Addr() *net.TCPAddr {
 	return server.addr
 }
 
+func (server *Server) AddHttpHandler(listenPath string, handler func(w http.ResponseWriter, r *http.Request)) {
+	server.httpHandler.HandleFunc(listenPath, handler)
+}
+
 func (server *Server) Start(port int, listenPath string) {
-	router := mux.NewRouter()
-	router.HandleFunc(listenPath, func(w http.ResponseWriter, r *http.Request) {
-		server.wsHandler(w, r)
-	})
+
 	server.connections = make(map[string]*WebSocket)
 	if server.httpServer == nil {
 		server.httpServer = &http.Server{}
@@ -357,7 +361,11 @@ func (server *Server) Start(port int, listenPath string) {
 
 	addr := fmt.Sprintf(":%v", port)
 	server.httpServer.Addr = addr
-	server.httpServer.Handler = router
+
+	server.AddHttpHandler(listenPath, func(w http.ResponseWriter, r *http.Request) {
+		server.wsHandler(w, r)
+	})
+	server.httpServer.Handler = server.httpHandler
 
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -261,10 +261,12 @@ type Server struct {
 
 // Creates a new simple websocket server (the websockets are not secured).
 func NewServer() *Server {
+	router := mux.NewRouter()
 	return &Server{
 		httpServer:    &http.Server{},
 		timeoutConfig: NewServerTimeoutConfig(),
 		upgrader:      websocket.Upgrader{Subprotocols: []string{}},
+		httpHandler:   router,
 	}
 }
 


### PR DESCRIPTION
We are running OCPP's CentralSystem in a container. 
Since only one port can be exported in a container, it is difficult to start an HTTP server and a websocket server at the same time to accept health checks, remoteTransaction, and so on. Therefore, we would like to add a function that can implement OCPP websocket and other handlers.