### PR TITLE
Implement method `SetNewChargingStationValidationHandler` on ocpp1.6 (central system)

### DIFF
--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -360,6 +360,10 @@ func (cs *centralSystem) SetSmartChargingHandler(handler smartcharging.CentralSy
 	cs.smartChargingHandler = handler
 }
 
+func (cs *centralSystem) SetNewChargingStationValidationHandler(handler ws.CheckClientHandler) {
+	cs.server.SetNewClientValidationHandler(handler)
+}
+
 func (cs *centralSystem) SetNewChargePointHandler(handler ChargePointConnectionHandler) {
 	cs.server.SetNewClientHandler(func(chargePoint ws.Channel) {
 		handler(chargePoint)

--- a/ocpp1.6/v16.go
+++ b/ocpp1.6/v16.go
@@ -236,6 +236,8 @@ type CentralSystem interface {
 	SetRemoteTriggerHandler(handler remotetrigger.CentralSystemHandler)
 	// Registers a handler for incoming smart charging profile messages.
 	SetSmartChargingHandler(handler smartcharging.CentralSystemHandler)
+	// Registers a handler for new incoming Charging station connections.
+	SetNewChargingStationValidationHandler(handler ws.CheckClientHandler)
 	// Registers a handler for new incoming charge point connections.
 	SetNewChargePointHandler(handler ChargePointConnectionHandler)
 	// Registers a handler for charge point disconnections.


### PR DESCRIPTION
Hello,

Relate to this closed pull request (https://github.com/lorenzodonini/ocpp-go/pull/170), I'm forget to implement method `SetNewChargingStationValidationHandler` on ocpp1.6

I have added on this pull request, sorry for this omission.

Thx