### PR TITLE
Fix missed responses for validation errors

### DIFF
--- a/ocpp1.6_test/authorize_test.go
+++ b/ocpp1.6_test/authorize_test.go
@@ -2,12 +2,13 @@ package ocpp16_test
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"time"
 )
 
 // Test
@@ -48,7 +49,7 @@ func (suite *OcppV16TestSuite) TestAuthorizeE2EMocked() {
 	responseRaw := []byte(responseJson)
 	channel := NewMockWebSocket(wsId)
 
-	coreListener := MockCentralSystemCoreListener{}
+	coreListener := &MockCentralSystemCoreListener{}
 	coreListener.On("OnAuthorize", mock.AnythingOfType("string"), mock.Anything).Return(authorizeConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(1).(*core.AuthorizeRequest)
 		require.True(t, ok)

--- a/ocpp1.6_test/boot_notification_test.go
+++ b/ocpp1.6_test/boot_notification_test.go
@@ -2,12 +2,13 @@ package ocpp16_test
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"time"
 )
 
 // Tests
@@ -61,7 +62,7 @@ func (suite *OcppV16TestSuite) TestBootNotificationE2EMocked() {
 	bootNotificationConfirmation := core.NewBootNotificationConfirmation(currentTime, interval, registrationStatus)
 	channel := NewMockWebSocket(wsId)
 
-	coreListener := MockCentralSystemCoreListener{}
+	coreListener := &MockCentralSystemCoreListener{}
 	coreListener.On("OnBootNotification", mock.AnythingOfType("string"), mock.Anything).Return(bootNotificationConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(1).(*core.BootNotificationRequest)
 		require.True(t, ok)

--- a/ocpp1.6_test/change_availability_test.go
+++ b/ocpp1.6_test/change_availability_test.go
@@ -2,6 +2,7 @@ package ocpp16_test
 
 import (
 	"fmt"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -47,7 +48,7 @@ func (suite *OcppV16TestSuite) TestChangeAvailabilityE2EMocked() {
 	changeAvailabilityConfirmation := core.NewChangeAvailabilityConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 	// Setting handlers
-	coreListener := MockChargePointCoreListener{}
+	coreListener := &MockChargePointCoreListener{}
 	coreListener.On("OnChangeAvailability", mock.Anything).Return(changeAvailabilityConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*core.ChangeAvailabilityRequest)
 		require.NotNil(t, request)

--- a/ocpp1.6_test/change_configuration_test.go
+++ b/ocpp1.6_test/change_configuration_test.go
@@ -2,6 +2,7 @@ package ocpp16_test
 
 import (
 	"fmt"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -47,7 +48,7 @@ func (suite *OcppV16TestSuite) TestChangeConfigurationE2EMocked() {
 	changeConfigurationConfirmation := core.NewChangeConfigurationConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 
-	coreListener := MockChargePointCoreListener{}
+	coreListener := &MockChargePointCoreListener{}
 	coreListener.On("OnChangeConfiguration", mock.Anything).Return(changeConfigurationConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*core.ChangeConfigurationRequest)
 		require.NotNil(t, request)

--- a/ocpp1.6_test/clear_cache_test.go
+++ b/ocpp1.6_test/clear_cache_test.go
@@ -2,6 +2,7 @@ package ocpp16_test
 
 import (
 	"fmt"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -39,7 +40,7 @@ func (suite *OcppV16TestSuite) TestClearCacheE2EMocked() {
 	clearCacheConfirmation := core.NewClearCacheConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 
-	coreListener := MockChargePointCoreListener{}
+	coreListener := &MockChargePointCoreListener{}
 	coreListener.On("OnClearCache", mock.Anything).Return(clearCacheConfirmation, nil)
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargePointHandlers(suite, coreListener, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})

--- a/ocpp1.6_test/data_transfer_test.go
+++ b/ocpp1.6_test/data_transfer_test.go
@@ -3,6 +3,7 @@ package ocpp16_test
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -61,7 +62,7 @@ func (suite *OcppV16TestSuite) TestDataTransferFromChargePointE2EMocked() {
 	dataTransferConfirmation := core.NewDataTransferConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 
-	coreListener := MockCentralSystemCoreListener{}
+	coreListener := &MockCentralSystemCoreListener{}
 	coreListener.On("OnDataTransfer", mock.AnythingOfType("string"), mock.Anything).Return(dataTransferConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(1).(*core.DataTransferRequest)
 		require.NotNil(t, request)
@@ -101,7 +102,7 @@ func (suite *OcppV16TestSuite) TestDataTransferFromCentralSystemE2EMocked() {
 	dataTransferConfirmation := core.NewDataTransferConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 
-	coreListener := MockChargePointCoreListener{}
+	coreListener := &MockChargePointCoreListener{}
 	coreListener.On("OnDataTransfer", mock.Anything).Return(dataTransferConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*core.DataTransferRequest)
 		require.NotNil(t, request)

--- a/ocpp1.6_test/get_configuration_test.go
+++ b/ocpp1.6_test/get_configuration_test.go
@@ -63,7 +63,7 @@ func (suite *OcppV16TestSuite) TestGetConfigurationE2EMocked() {
 	getConfigurationConfirmation.UnknownKey = unknownKeys
 	channel := NewMockWebSocket(wsId)
 
-	coreListener := MockChargePointCoreListener{}
+	coreListener := &MockChargePointCoreListener{}
 	coreListener.On("OnGetConfiguration", mock.Anything).Return(getConfigurationConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*core.GetConfigurationRequest)
 		require.NotNil(t, request)

--- a/ocpp1.6_test/heartbeat_test.go
+++ b/ocpp1.6_test/heartbeat_test.go
@@ -2,11 +2,12 @@ package ocpp16_test
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"time"
 )
 
 // Test
@@ -38,7 +39,7 @@ func (suite *OcppV16TestSuite) TestHeartbeatE2EMocked() {
 	heartbeatConfirmation := core.NewHeartbeatConfirmation(currentTime)
 	channel := NewMockWebSocket(wsId)
 
-	coreListener := MockCentralSystemCoreListener{}
+	coreListener := &MockCentralSystemCoreListener{}
 	coreListener.On("OnHeartbeat", mock.AnythingOfType("string"), mock.Anything).Return(heartbeatConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(1).(*core.HeartbeatRequest)
 		require.NotNil(t, request)

--- a/ocpp1.6_test/meter_values_test.go
+++ b/ocpp1.6_test/meter_values_test.go
@@ -2,12 +2,13 @@ package ocpp16_test
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"time"
 )
 
 // Test
@@ -46,7 +47,7 @@ func (suite *OcppV16TestSuite) TestMeterValuesE2EMocked() {
 	meterValuesConfirmation := core.NewMeterValuesConfirmation()
 	channel := NewMockWebSocket(wsId)
 
-	coreListener := MockCentralSystemCoreListener{}
+	coreListener := &MockCentralSystemCoreListener{}
 	coreListener.On("OnMeterValues", mock.AnythingOfType("string"), mock.Anything).Return(meterValuesConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(1).(*core.MeterValuesRequest)
 		require.NotNil(t, request)

--- a/ocpp1.6_test/ocpp16_test.go
+++ b/ocpp1.6_test/ocpp16_test.go
@@ -209,49 +209,49 @@ type MockCentralSystemCoreListener struct {
 	mock.Mock
 }
 
-func (coreListener MockCentralSystemCoreListener) OnAuthorize(chargePointId string, request *core.AuthorizeRequest) (confirmation *core.AuthorizeConfirmation, err error) {
+func (coreListener *MockCentralSystemCoreListener) OnAuthorize(chargePointId string, request *core.AuthorizeRequest) (confirmation *core.AuthorizeConfirmation, err error) {
 	args := coreListener.MethodCalled("OnAuthorize", chargePointId, request)
 	conf := args.Get(0).(*core.AuthorizeConfirmation)
 	return conf, args.Error(1)
 }
 
-func (coreListener MockCentralSystemCoreListener) OnBootNotification(chargePointId string, request *core.BootNotificationRequest) (confirmation *core.BootNotificationConfirmation, err error) {
+func (coreListener *MockCentralSystemCoreListener) OnBootNotification(chargePointId string, request *core.BootNotificationRequest) (confirmation *core.BootNotificationConfirmation, err error) {
 	args := coreListener.MethodCalled("OnBootNotification", chargePointId, request)
 	conf := args.Get(0).(*core.BootNotificationConfirmation)
 	return conf, args.Error(1)
 }
 
-func (coreListener MockCentralSystemCoreListener) OnDataTransfer(chargePointId string, request *core.DataTransferRequest) (confirmation *core.DataTransferConfirmation, err error) {
+func (coreListener *MockCentralSystemCoreListener) OnDataTransfer(chargePointId string, request *core.DataTransferRequest) (confirmation *core.DataTransferConfirmation, err error) {
 	args := coreListener.MethodCalled("OnDataTransfer", chargePointId, request)
 	conf := args.Get(0).(*core.DataTransferConfirmation)
 	return conf, args.Error(1)
 }
 
-func (coreListener MockCentralSystemCoreListener) OnHeartbeat(chargePointId string, request *core.HeartbeatRequest) (confirmation *core.HeartbeatConfirmation, err error) {
+func (coreListener *MockCentralSystemCoreListener) OnHeartbeat(chargePointId string, request *core.HeartbeatRequest) (confirmation *core.HeartbeatConfirmation, err error) {
 	args := coreListener.MethodCalled("OnHeartbeat", chargePointId, request)
 	conf := args.Get(0).(*core.HeartbeatConfirmation)
 	return conf, args.Error(1)
 }
 
-func (coreListener MockCentralSystemCoreListener) OnMeterValues(chargePointId string, request *core.MeterValuesRequest) (confirmation *core.MeterValuesConfirmation, err error) {
+func (coreListener *MockCentralSystemCoreListener) OnMeterValues(chargePointId string, request *core.MeterValuesRequest) (confirmation *core.MeterValuesConfirmation, err error) {
 	args := coreListener.MethodCalled("OnMeterValues", chargePointId, request)
 	conf := args.Get(0).(*core.MeterValuesConfirmation)
 	return conf, args.Error(1)
 }
 
-func (coreListener MockCentralSystemCoreListener) OnStartTransaction(chargePointId string, request *core.StartTransactionRequest) (confirmation *core.StartTransactionConfirmation, err error) {
+func (coreListener *MockCentralSystemCoreListener) OnStartTransaction(chargePointId string, request *core.StartTransactionRequest) (confirmation *core.StartTransactionConfirmation, err error) {
 	args := coreListener.MethodCalled("OnStartTransaction", chargePointId, request)
 	conf := args.Get(0).(*core.StartTransactionConfirmation)
 	return conf, args.Error(1)
 }
 
-func (coreListener MockCentralSystemCoreListener) OnStatusNotification(chargePointId string, request *core.StatusNotificationRequest) (confirmation *core.StatusNotificationConfirmation, err error) {
+func (coreListener *MockCentralSystemCoreListener) OnStatusNotification(chargePointId string, request *core.StatusNotificationRequest) (confirmation *core.StatusNotificationConfirmation, err error) {
 	args := coreListener.MethodCalled("OnStatusNotification", chargePointId, request)
 	conf := args.Get(0).(*core.StatusNotificationConfirmation)
 	return conf, args.Error(1)
 }
 
-func (coreListener MockCentralSystemCoreListener) OnStopTransaction(chargePointId string, request *core.StopTransactionRequest) (confirmation *core.StopTransactionConfirmation, err error) {
+func (coreListener *MockCentralSystemCoreListener) OnStopTransaction(chargePointId string, request *core.StopTransactionRequest) (confirmation *core.StopTransactionConfirmation, err error) {
 	args := coreListener.MethodCalled("OnStopTransaction", chargePointId, request)
 	conf := args.Get(0).(*core.StopTransactionConfirmation)
 	return conf, args.Error(1)
@@ -262,55 +262,55 @@ type MockChargePointCoreListener struct {
 	mock.Mock
 }
 
-func (coreListener MockChargePointCoreListener) OnChangeAvailability(request *core.ChangeAvailabilityRequest) (confirmation *core.ChangeAvailabilityConfirmation, err error) {
+func (coreListener *MockChargePointCoreListener) OnChangeAvailability(request *core.ChangeAvailabilityRequest) (confirmation *core.ChangeAvailabilityConfirmation, err error) {
 	args := coreListener.MethodCalled("OnChangeAvailability", request)
 	conf := args.Get(0).(*core.ChangeAvailabilityConfirmation)
 	return conf, args.Error(1)
 }
 
-func (coreListener MockChargePointCoreListener) OnDataTransfer(request *core.DataTransferRequest) (confirmation *core.DataTransferConfirmation, err error) {
+func (coreListener *MockChargePointCoreListener) OnDataTransfer(request *core.DataTransferRequest) (confirmation *core.DataTransferConfirmation, err error) {
 	args := coreListener.MethodCalled("OnDataTransfer", request)
 	conf := args.Get(0).(*core.DataTransferConfirmation)
 	return conf, args.Error(1)
 }
 
-func (coreListener MockChargePointCoreListener) OnChangeConfiguration(request *core.ChangeConfigurationRequest) (confirmation *core.ChangeConfigurationConfirmation, err error) {
+func (coreListener *MockChargePointCoreListener) OnChangeConfiguration(request *core.ChangeConfigurationRequest) (confirmation *core.ChangeConfigurationConfirmation, err error) {
 	args := coreListener.MethodCalled("OnChangeConfiguration", request)
 	conf := args.Get(0).(*core.ChangeConfigurationConfirmation)
 	return conf, args.Error(1)
 }
 
-func (coreListener MockChargePointCoreListener) OnClearCache(request *core.ClearCacheRequest) (confirmation *core.ClearCacheConfirmation, err error) {
+func (coreListener *MockChargePointCoreListener) OnClearCache(request *core.ClearCacheRequest) (confirmation *core.ClearCacheConfirmation, err error) {
 	args := coreListener.MethodCalled("OnClearCache", request)
 	conf := args.Get(0).(*core.ClearCacheConfirmation)
 	return conf, args.Error(1)
 }
 
-func (coreListener MockChargePointCoreListener) OnGetConfiguration(request *core.GetConfigurationRequest) (confirmation *core.GetConfigurationConfirmation, err error) {
+func (coreListener *MockChargePointCoreListener) OnGetConfiguration(request *core.GetConfigurationRequest) (confirmation *core.GetConfigurationConfirmation, err error) {
 	args := coreListener.MethodCalled("OnGetConfiguration", request)
 	conf := args.Get(0).(*core.GetConfigurationConfirmation)
 	return conf, args.Error(1)
 }
 
-func (coreListener MockChargePointCoreListener) OnReset(request *core.ResetRequest) (confirmation *core.ResetConfirmation, err error) {
+func (coreListener *MockChargePointCoreListener) OnReset(request *core.ResetRequest) (confirmation *core.ResetConfirmation, err error) {
 	args := coreListener.MethodCalled("OnReset", request)
 	conf := args.Get(0).(*core.ResetConfirmation)
 	return conf, args.Error(1)
 }
 
-func (coreListener MockChargePointCoreListener) OnUnlockConnector(request *core.UnlockConnectorRequest) (confirmation *core.UnlockConnectorConfirmation, err error) {
+func (coreListener *MockChargePointCoreListener) OnUnlockConnector(request *core.UnlockConnectorRequest) (confirmation *core.UnlockConnectorConfirmation, err error) {
 	args := coreListener.MethodCalled("OnUnlockConnector", request)
 	conf := args.Get(0).(*core.UnlockConnectorConfirmation)
 	return conf, args.Error(1)
 }
 
-func (coreListener MockChargePointCoreListener) OnRemoteStartTransaction(request *core.RemoteStartTransactionRequest) (confirmation *core.RemoteStartTransactionConfirmation, err error) {
+func (coreListener *MockChargePointCoreListener) OnRemoteStartTransaction(request *core.RemoteStartTransactionRequest) (confirmation *core.RemoteStartTransactionConfirmation, err error) {
 	args := coreListener.MethodCalled("OnRemoteStartTransaction", request)
 	conf := args.Get(0).(*core.RemoteStartTransactionConfirmation)
 	return conf, args.Error(1)
 }
 
-func (coreListener MockChargePointCoreListener) OnRemoteStopTransaction(request *core.RemoteStopTransactionRequest) (confirmation *core.RemoteStopTransactionConfirmation, err error) {
+func (coreListener *MockChargePointCoreListener) OnRemoteStopTransaction(request *core.RemoteStopTransactionRequest) (confirmation *core.RemoteStopTransactionConfirmation, err error) {
 	args := coreListener.MethodCalled("OnRemoteStopTransaction", request)
 	conf := args.Get(0).(*core.RemoteStopTransactionConfirmation)
 	return conf, args.Error(1)
@@ -557,7 +557,7 @@ func testUnsupportedRequestFromChargePoint(suite *OcppV16TestSuite, request ocpp
 	channel := NewMockWebSocket(wsId)
 
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(errorJson), forwardWrittenMessage: false})
-	coreListener := MockCentralSystemCoreListener{}
+	coreListener := &MockCentralSystemCoreListener{}
 	setupDefaultCentralSystemHandlers(suite, coreListener, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(errorJson), forwardWrittenMessage: true})
 	resultChannel := make(chan bool, 1)
 	suite.ocppjChargePoint.SetErrorHandler(func(err *ocpp.Error, details interface{}) {
@@ -595,7 +595,7 @@ func testUnsupportedRequestFromCentralSystem(suite *OcppV16TestSuite, request oc
 	channel := NewMockWebSocket(wsId)
 
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: false})
-	coreListener := MockChargePointCoreListener{}
+	coreListener := &MockChargePointCoreListener{}
 	setupDefaultChargePointHandlers(suite, coreListener, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(errorJson), forwardWrittenMessage: true})
 	suite.ocppjCentralSystem.SetErrorHandler(func(chargePoint ws.Channel, err *ocpp.Error, details interface{}) {
 		assert.Equal(t, messageId, err.MessageId)

--- a/ocpp1.6_test/ocpp16_test.go
+++ b/ocpp1.6_test/ocpp16_test.go
@@ -223,8 +223,12 @@ func (coreListener *MockCentralSystemCoreListener) OnBootNotification(chargePoin
 
 func (coreListener *MockCentralSystemCoreListener) OnDataTransfer(chargePointId string, request *core.DataTransferRequest) (confirmation *core.DataTransferConfirmation, err error) {
 	args := coreListener.MethodCalled("OnDataTransfer", chargePointId, request)
-	conf := args.Get(0).(*core.DataTransferConfirmation)
-	return conf, args.Error(1)
+	rawConf := args.Get(0)
+	err = args.Error(1)
+	if rawConf != nil {
+		confirmation = rawConf.(*core.DataTransferConfirmation)
+	}
+	return
 }
 
 func (coreListener *MockCentralSystemCoreListener) OnHeartbeat(chargePointId string, request *core.HeartbeatRequest) (confirmation *core.HeartbeatConfirmation, err error) {
@@ -270,8 +274,12 @@ func (coreListener *MockChargePointCoreListener) OnChangeAvailability(request *c
 
 func (coreListener *MockChargePointCoreListener) OnDataTransfer(request *core.DataTransferRequest) (confirmation *core.DataTransferConfirmation, err error) {
 	args := coreListener.MethodCalled("OnDataTransfer", request)
-	conf := args.Get(0).(*core.DataTransferConfirmation)
-	return conf, args.Error(1)
+	rawConf := args.Get(0)
+	err = args.Error(1)
+	if rawConf != nil {
+		confirmation = rawConf.(*core.DataTransferConfirmation)
+	}
+	return
 }
 
 func (coreListener *MockChargePointCoreListener) OnChangeConfiguration(request *core.ChangeConfigurationRequest) (confirmation *core.ChangeConfigurationConfirmation, err error) {

--- a/ocpp1.6_test/proto_test.go
+++ b/ocpp1.6_test/proto_test.go
@@ -1,0 +1,154 @@
+package ocpp16_test
+
+import (
+	"fmt"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/lorenzodonini/ocpp-go/ocppj"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func (suite *OcppV16TestSuite) TestChargePointSendResponseError() {
+	t := suite.T()
+	wsId := "test_id"
+	channel := NewMockWebSocket(wsId)
+	var ocppErr *ocpp.Error
+	// Setup internal communication and listeners
+	coreListener := &MockChargePointCoreListener{}
+	suite.chargePoint.SetCoreHandler(coreListener)
+	suite.mockWsClient.On("Start", mock.AnythingOfType("string")).Return(nil).Run(func(args mock.Arguments) {
+		// Notify server of incoming connection
+		suite.mockWsServer.NewClientHandler(channel)
+	})
+	suite.mockWsClient.On("Write", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		rawMsg := args.Get(0)
+		bytes := rawMsg.([]byte)
+		err := suite.mockWsServer.MessageHandler(channel, bytes)
+		assert.Nil(t, err)
+	})
+	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
+	suite.mockWsServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		rawMsg := args.Get(1)
+		bytes := rawMsg.([]byte)
+		err := suite.mockWsClient.MessageHandler(bytes)
+		assert.NoError(t, err)
+	})
+	// Run Tests
+	suite.centralSystem.Start(8887, "somePath")
+	err := suite.chargePoint.Start("someUrl")
+	require.Nil(t, err)
+	resultChannel := make(chan error, 1)
+	// Test 1: occurrence validation error
+	dataTransferConfirmation := core.NewDataTransferConfirmation(core.DataTransferStatusAccepted)
+	dataTransferConfirmation.Data = CustomData{Field1: "", Field2: 42}
+	coreListener.On("OnDataTransfer", mock.Anything).Return(dataTransferConfirmation, nil)
+	err = suite.centralSystem.DataTransfer(wsId, func(confirmation *core.DataTransferConfirmation, err error) {
+		require.Nil(t, confirmation)
+		require.Error(t, err)
+		resultChannel <- err
+	}, "vendor1")
+	require.Nil(t, err)
+	result := <-resultChannel
+	require.IsType(t, &ocpp.Error{}, result)
+	ocppErr = result.(*ocpp.Error)
+	assert.Equal(t, ocppj.OccurrenceConstraintViolation, ocppErr.Code)
+	assert.Equal(t, "Field CallResult.Payload.Data.Field1 required but not found for feature DataTransfer", ocppErr.Description)
+	// Test 2: marshaling error
+	dataTransferConfirmation = core.NewDataTransferConfirmation(core.DataTransferStatusAccepted)
+	dataTransferConfirmation.Data = make(chan struct{})
+	coreListener.ExpectedCalls = nil
+	coreListener.On("OnDataTransfer", mock.Anything).Return(dataTransferConfirmation, nil)
+	err = suite.centralSystem.DataTransfer(wsId, func(confirmation *core.DataTransferConfirmation, err error) {
+		require.Nil(t, confirmation)
+		require.Error(t, err)
+		resultChannel <- err
+	}, "vendor1")
+	require.Nil(t, err)
+	result = <-resultChannel
+	require.IsType(t, &ocpp.Error{}, result)
+	ocppErr = result.(*ocpp.Error)
+	assert.Equal(t, ocppj.GenericError, ocppErr.Code)
+	assert.Equal(t, "json: unsupported type: chan struct {}", ocppErr.Description)
+	// Test 3: no results in callback
+	coreListener.ExpectedCalls = nil
+	coreListener.On("OnDataTransfer", mock.Anything).Return(nil, nil)
+	err = suite.centralSystem.DataTransfer(wsId, func(confirmation *core.DataTransferConfirmation, err error) {
+		require.Nil(t, confirmation)
+		require.Error(t, err)
+		resultChannel <- err
+	}, "vendor1")
+	require.Nil(t, err)
+	result = <-resultChannel
+	require.IsType(t, &ocpp.Error{}, result)
+	ocppErr = result.(*ocpp.Error)
+	assert.Equal(t, ocppj.GenericError, ocppErr.Code)
+	assert.Equal(t, "empty confirmation to request 1234", ocppErr.Description)
+}
+
+func (suite *OcppV16TestSuite) TestCentralSystemSendResponseError() {
+	t := suite.T()
+	wsId := "test_id"
+	channel := NewMockWebSocket(wsId)
+	var ocppErr *ocpp.Error
+	var response *core.DataTransferConfirmation
+	// Setup internal communication and listeners
+	coreListener := &MockCentralSystemCoreListener{}
+	suite.centralSystem.SetCoreHandler(coreListener)
+	suite.mockWsClient.On("Start", mock.AnythingOfType("string")).Return(nil).Run(func(args mock.Arguments) {
+		// Notify server of incoming connection
+		suite.mockWsServer.NewClientHandler(channel)
+	})
+	suite.mockWsClient.On("Write", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		rawMsg := args.Get(0)
+		bytes := rawMsg.([]byte)
+		err := suite.mockWsServer.MessageHandler(channel, bytes)
+		assert.Nil(t, err)
+	})
+	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
+	suite.mockWsServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		rawMsg := args.Get(1)
+		bytes := rawMsg.([]byte)
+		err := suite.mockWsClient.MessageHandler(bytes)
+		assert.NoError(t, err)
+	})
+	// Run Tests
+	suite.centralSystem.Start(8887, "somePath")
+	err := suite.chargePoint.Start("someUrl")
+	require.Nil(t, err)
+	// Test 1: occurrence validation error
+	dataTransferConfirmation := core.NewDataTransferConfirmation(core.DataTransferStatusAccepted)
+	dataTransferConfirmation.Data = CustomData{Field1: "", Field2: 42}
+	coreListener.On("OnDataTransfer", mock.AnythingOfType("string"), mock.Anything).Return(dataTransferConfirmation, nil)
+	response, err = suite.chargePoint.DataTransfer("vendor1")
+	require.Nil(t, response)
+	require.Error(t, err)
+	require.IsType(t, &ocpp.Error{}, err)
+	ocppErr = err.(*ocpp.Error)
+	assert.Equal(t, ocppj.OccurrenceConstraintViolation, ocppErr.Code)
+	assert.Equal(t, "Field CallResult.Payload.Data.Field1 required but not found for feature DataTransfer", ocppErr.Description)
+	// Test 2: marshaling error
+	dataTransferConfirmation = core.NewDataTransferConfirmation(core.DataTransferStatusAccepted)
+	dataTransferConfirmation.Data = make(chan struct{})
+	coreListener.ExpectedCalls = nil
+	coreListener.On("OnDataTransfer", mock.AnythingOfType("string"), mock.Anything).Return(dataTransferConfirmation, nil)
+	response, err = suite.chargePoint.DataTransfer("vendor1")
+	require.Nil(t, response)
+	require.Error(t, err)
+	require.IsType(t, &ocpp.Error{}, err)
+	ocppErr = err.(*ocpp.Error)
+	assert.Equal(t, ocppj.GenericError, ocppErr.Code)
+	assert.Equal(t, "json: unsupported type: chan struct {}", ocppErr.Description)
+	// Test 3: no results in callback
+	coreListener.ExpectedCalls = nil
+	coreListener.On("OnDataTransfer", mock.AnythingOfType("string"), mock.Anything).Return(nil, nil)
+	response, err = suite.chargePoint.DataTransfer("vendor1")
+	require.Nil(t, response)
+	require.Error(t, err)
+	require.IsType(t, &ocpp.Error{}, err)
+	ocppErr = err.(*ocpp.Error)
+	assert.Equal(t, ocppj.GenericError, ocppErr.Code)
+	assert.Equal(t, fmt.Sprintf("empty confirmation to %s for request 1234", wsId), ocppErr.Description)
+}

--- a/ocpp1.6_test/remote_start_transaction_test.go
+++ b/ocpp1.6_test/remote_start_transaction_test.go
@@ -2,6 +2,7 @@ package ocpp16_test
 
 import (
 	"fmt"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
@@ -69,7 +70,7 @@ func (suite *OcppV16TestSuite) TestRemoteStartTransactionE2EMocked() {
 	RemoteStartTransactionConfirmation := core.NewRemoteStartTransactionConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 
-	coreListener := MockChargePointCoreListener{}
+	coreListener := &MockChargePointCoreListener{}
 	coreListener.On("OnRemoteStartTransaction", mock.Anything).Return(RemoteStartTransactionConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*core.RemoteStartTransactionRequest)
 		require.NotNil(t, request)

--- a/ocpp1.6_test/remote_stop_transaction_test.go
+++ b/ocpp1.6_test/remote_stop_transaction_test.go
@@ -2,6 +2,7 @@ package ocpp16_test
 
 import (
 	"fmt"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
@@ -43,7 +44,7 @@ func (suite *OcppV16TestSuite) TestRemoteStopTransactionE2EMocked() {
 	RemoteStopTransactionConfirmation := core.NewRemoteStopTransactionConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 
-	coreListener := MockChargePointCoreListener{}
+	coreListener := &MockChargePointCoreListener{}
 	coreListener.On("OnRemoteStopTransaction", mock.Anything).Return(RemoteStopTransactionConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*core.RemoteStopTransactionRequest)
 		require.NotNil(t, request)

--- a/ocpp1.6_test/reset_test.go
+++ b/ocpp1.6_test/reset_test.go
@@ -2,6 +2,7 @@ package ocpp16_test
 
 import (
 	"fmt"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -43,7 +44,7 @@ func (suite *OcppV16TestSuite) TestResetE2EMocked() {
 	resetConfirmation := core.NewResetConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 	// Setting handlers
-	coreListener := MockChargePointCoreListener{}
+	coreListener := &MockChargePointCoreListener{}
 	coreListener.On("OnReset", mock.Anything).Return(resetConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*core.ResetRequest)
 		require.NotNil(t, request)

--- a/ocpp1.6_test/start_transaction_test.go
+++ b/ocpp1.6_test/start_transaction_test.go
@@ -2,12 +2,13 @@ package ocpp16_test
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"time"
 )
 
 // Test
@@ -60,7 +61,7 @@ func (suite *OcppV16TestSuite) TestStartTransactionE2EMocked() {
 	responseRaw := []byte(responseJson)
 	channel := NewMockWebSocket(wsId)
 
-	coreListener := MockCentralSystemCoreListener{}
+	coreListener := &MockCentralSystemCoreListener{}
 	coreListener.On("OnStartTransaction", mock.AnythingOfType("string"), mock.Anything).Return(startTransactionConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(1).(*core.StartTransactionRequest)
 		require.True(t, ok)

--- a/ocpp1.6_test/status_notification_test.go
+++ b/ocpp1.6_test/status_notification_test.go
@@ -57,7 +57,7 @@ func (suite *OcppV16TestSuite) TestStatusNotificationE2EMocked() {
 	statusNotificationConfirmation := core.NewStatusNotificationConfirmation()
 	channel := NewMockWebSocket(wsId)
 
-	coreListener := MockCentralSystemCoreListener{}
+	coreListener := &MockCentralSystemCoreListener{}
 	coreListener.On("OnStatusNotification", mock.AnythingOfType("string"), mock.Anything).Return(statusNotificationConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(1).(*core.StatusNotificationRequest)
 		require.True(t, ok)

--- a/ocpp1.6_test/stop_transaction_test.go
+++ b/ocpp1.6_test/stop_transaction_test.go
@@ -64,7 +64,7 @@ func (suite *OcppV16TestSuite) TestStopTransactionE2EMocked() {
 	responseRaw := []byte(responseJson)
 	channel := NewMockWebSocket(wsId)
 
-	coreListener := MockCentralSystemCoreListener{}
+	coreListener := &MockCentralSystemCoreListener{}
 	coreListener.On("OnStopTransaction", mock.AnythingOfType("string"), mock.Anything).Return(stopTransactionConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(1).(*core.StopTransactionRequest)
 		require.True(t, ok)

--- a/ocpp1.6_test/unlock_connector_test.go
+++ b/ocpp1.6_test/unlock_connector_test.go
@@ -2,6 +2,7 @@ package ocpp16_test
 
 import (
 	"fmt"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -41,7 +42,7 @@ func (suite *OcppV16TestSuite) TestUnlockConnectorE2EMocked() {
 	unlockConnectorConfirmation := core.NewUnlockConnectorConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 	// Setting handlers
-	coreListener := MockChargePointCoreListener{}
+	coreListener := &MockChargePointCoreListener{}
 	coreListener.On("OnUnlockConnector", mock.Anything).Return(unlockConnectorConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*core.UnlockConnectorRequest)
 		require.NotNil(t, request)

--- a/ocpp2.0.1/charging_station.go
+++ b/ocpp2.0.1/charging_station.go
@@ -2,6 +2,7 @@ package ocpp2
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/lorenzodonini/ocpp-go/internal/callbackqueue"
 	"github.com/lorenzodonini/ocpp-go/ocpp"
@@ -555,25 +556,35 @@ func (cs *chargingStation) asyncCallbackHandler() {
 }
 
 func (cs *chargingStation) sendResponse(response ocpp.Response, err error, requestId string) {
-	// send error response
 	if err != nil {
-		err = cs.client.SendError(requestId, ocppj.ProtocolError, err.Error(), nil)
+		// Send error response
+		err = cs.client.SendError(requestId, ocppj.InternalError, err.Error(), nil)
 		if err != nil {
-			cs.error(fmt.Errorf("replying cs to request %s with 'protocol error': %w", requestId, err))
+			// Error while sending an error. Will attempt to send a default error instead
+			cs.client.HandleFailedResponseError(requestId, err, "")
+			// Notify client implementation
+			err = fmt.Errorf("replying to request %s with 'internal error' failed: %w", requestId, err)
+			cs.error(err)
 		}
 		return
 	}
 
-	if response == nil {
+	if response == nil || reflect.ValueOf(response).IsNil() {
 		err = fmt.Errorf("empty response to request %s", requestId)
+		// Sending a dummy error to server instead, then notify client implementation
+		_ = cs.client.SendError(requestId, ocppj.GenericError, err.Error(), nil)
 		cs.error(err)
 		return
 	}
 
-	// send response
+	// send confirmation response
 	err = cs.client.SendResponse(requestId, response)
 	if err != nil {
-		cs.error(fmt.Errorf("replying to request %s with 'protocol error': %w", requestId, err))
+		// Error while sending an error. Will attempt to send a default error instead
+		cs.client.HandleFailedResponseError(requestId, err, response.GetFeatureName())
+		// Notify client implementation
+		err = fmt.Errorf("failed responding to request %s: %w", requestId, err)
+		cs.error(err)
 	}
 }
 

--- a/ocpp2.0.1_test/ocpp2_test.go
+++ b/ocpp2.0.1_test/ocpp2_test.go
@@ -400,10 +400,14 @@ type MockChargingStationDataHandler struct {
 	mock.Mock
 }
 
-func (handler *MockChargingStationDataHandler) OnDataTransfer(request *data.DataTransferRequest) (confirmation *data.DataTransferResponse, err error) {
+func (handler *MockChargingStationDataHandler) OnDataTransfer(request *data.DataTransferRequest) (response *data.DataTransferResponse, err error) {
 	args := handler.MethodCalled("OnDataTransfer", request)
-	conf := args.Get(0).(*data.DataTransferResponse)
-	return conf, args.Error(1)
+	rawResp := args.Get(0)
+	err = args.Error(1)
+	if rawResp != nil {
+		response = rawResp.(*data.DataTransferResponse)
+	}
+	return
 }
 
 // ---------------------- MOCK CSMS DATA HANDLER ----------------------
@@ -412,10 +416,14 @@ type MockCSMSDataHandler struct {
 	mock.Mock
 }
 
-func (handler *MockCSMSDataHandler) OnDataTransfer(chargingStationID string, request *data.DataTransferRequest) (confirmation *data.DataTransferResponse, err error) {
+func (handler *MockCSMSDataHandler) OnDataTransfer(chargingStationID string, request *data.DataTransferRequest) (response *data.DataTransferResponse, err error) {
 	args := handler.MethodCalled("OnDataTransfer", chargingStationID, request)
-	conf := args.Get(0).(*data.DataTransferResponse)
-	return conf, args.Error(1)
+	rawResp := args.Get(0)
+	err = args.Error(1)
+	if rawResp != nil {
+		response = rawResp.(*data.DataTransferResponse)
+	}
+	return
 }
 
 // ---------------------- MOCK CS DIAGNOSTICS HANDLER ----------------------

--- a/ocpp2.0.1_test/proto_test.go
+++ b/ocpp2.0.1_test/proto_test.go
@@ -1,0 +1,159 @@
+package ocpp2_test
+
+import (
+	"fmt"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/data"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp"
+	"github.com/lorenzodonini/ocpp-go/ocppj"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func (suite *OcppV2TestSuite) TestChargePointSendResponseError() {
+	t := suite.T()
+	wsId := "test_id"
+	channel := NewMockWebSocket(wsId)
+	var ocppErr *ocpp.Error
+	// Setup internal communication and listeners
+	dataListener := &MockChargingStationDataHandler{}
+	suite.chargingStation.SetDataHandler(dataListener)
+	suite.mockWsClient.On("Start", mock.AnythingOfType("string")).Return(nil).Run(func(args mock.Arguments) {
+		// Notify server of incoming connection
+		suite.mockWsServer.NewClientHandler(channel)
+	})
+	suite.mockWsClient.On("Write", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		rawMsg := args.Get(0)
+		bytes := rawMsg.([]byte)
+		err := suite.mockWsServer.MessageHandler(channel, bytes)
+		assert.Nil(t, err)
+	})
+	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
+	suite.mockWsServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		rawMsg := args.Get(1)
+		bytes := rawMsg.([]byte)
+		err := suite.mockWsClient.MessageHandler(bytes)
+		assert.NoError(t, err)
+	})
+	// Run Tests
+	suite.csms.Start(8887, "somePath")
+	err := suite.chargingStation.Start("someUrl")
+	require.Nil(t, err)
+	resultChannel := make(chan error, 1)
+	// Test 1: occurrence validation error
+	dataTransferResponse := data.NewDataTransferResponse(data.DataTransferStatusAccepted)
+	dataTransferResponse.Data = struct {
+		Field1 string `validate:"required"`
+	}{Field1: ""}
+	dataListener.On("OnDataTransfer", mock.Anything).Return(dataTransferResponse, nil)
+	err = suite.csms.DataTransfer(wsId, func(response *data.DataTransferResponse, err error) {
+		require.Nil(t, response)
+		require.Error(t, err)
+		resultChannel <- err
+	}, "vendor1")
+	require.Nil(t, err)
+	result := <-resultChannel
+	require.IsType(t, &ocpp.Error{}, result)
+	ocppErr = result.(*ocpp.Error)
+	assert.Equal(t, ocppj.OccurrenceConstraintViolation, ocppErr.Code)
+	assert.Equal(t, "Field CallResult.Payload.Data.Field1 required but not found for feature DataTransfer", ocppErr.Description)
+	// Test 2: marshaling error
+	dataTransferResponse = data.NewDataTransferResponse(data.DataTransferStatusAccepted)
+	dataTransferResponse.Data = make(chan struct{})
+	dataListener.ExpectedCalls = nil
+	dataListener.On("OnDataTransfer", mock.Anything).Return(dataTransferResponse, nil)
+	err = suite.csms.DataTransfer(wsId, func(response *data.DataTransferResponse, err error) {
+		require.Nil(t, response)
+		require.Error(t, err)
+		resultChannel <- err
+	}, "vendor1")
+	require.Nil(t, err)
+	result = <-resultChannel
+	require.IsType(t, &ocpp.Error{}, result)
+	ocppErr = result.(*ocpp.Error)
+	assert.Equal(t, ocppj.GenericError, ocppErr.Code)
+	assert.Equal(t, "json: unsupported type: chan struct {}", ocppErr.Description)
+	// Test 3: no results in callback
+	dataListener.ExpectedCalls = nil
+	dataListener.On("OnDataTransfer", mock.Anything).Return(nil, nil)
+	err = suite.csms.DataTransfer(wsId, func(response *data.DataTransferResponse, err error) {
+		require.Nil(t, response)
+		require.Error(t, err)
+		resultChannel <- err
+	}, "vendor1")
+	require.Nil(t, err)
+	result = <-resultChannel
+	require.IsType(t, &ocpp.Error{}, result)
+	ocppErr = result.(*ocpp.Error)
+	assert.Equal(t, ocppj.GenericError, ocppErr.Code)
+	assert.Equal(t, "empty response to request 1234", ocppErr.Description)
+}
+
+func (suite *OcppV2TestSuite) TestCentralSystemSendResponseError() {
+	t := suite.T()
+	wsId := "test_id"
+	channel := NewMockWebSocket(wsId)
+	var ocppErr *ocpp.Error
+	var response *data.DataTransferResponse
+	// Setup internal communication and listeners
+	dataListener := &MockCSMSDataHandler{}
+	suite.csms.SetDataHandler(dataListener)
+	suite.mockWsClient.On("Start", mock.AnythingOfType("string")).Return(nil).Run(func(args mock.Arguments) {
+		// Notify server of incoming connection
+		suite.mockWsServer.NewClientHandler(channel)
+	})
+	suite.mockWsClient.On("Write", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		rawMsg := args.Get(0)
+		bytes := rawMsg.([]byte)
+		err := suite.mockWsServer.MessageHandler(channel, bytes)
+		assert.Nil(t, err)
+	})
+	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
+	suite.mockWsServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		rawMsg := args.Get(1)
+		bytes := rawMsg.([]byte)
+		err := suite.mockWsClient.MessageHandler(bytes)
+		assert.NoError(t, err)
+	})
+	// Run Tests
+	suite.csms.Start(8887, "somePath")
+	err := suite.chargingStation.Start("someUrl")
+	require.Nil(t, err)
+	// Test 1: occurrence validation error
+	dataTransferResponse := data.NewDataTransferResponse(data.DataTransferStatusAccepted)
+	dataTransferResponse.Data = struct {
+		Field1 string `validate:"required"`
+	}{Field1: ""}
+	dataListener.On("OnDataTransfer", mock.AnythingOfType("string"), mock.Anything).Return(dataTransferResponse, nil)
+	response, err = suite.chargingStation.DataTransfer("vendor1")
+	require.Nil(t, response)
+	require.Error(t, err)
+	require.IsType(t, &ocpp.Error{}, err)
+	ocppErr = err.(*ocpp.Error)
+	assert.Equal(t, ocppj.OccurrenceConstraintViolation, ocppErr.Code)
+	assert.Equal(t, "Field CallResult.Payload.Data.Field1 required but not found for feature DataTransfer", ocppErr.Description)
+	// Test 2: marshaling error
+	dataTransferResponse = data.NewDataTransferResponse(data.DataTransferStatusAccepted)
+	dataTransferResponse.Data = make(chan struct{})
+	dataListener.ExpectedCalls = nil
+	dataListener.On("OnDataTransfer", mock.AnythingOfType("string"), mock.Anything).Return(dataTransferResponse, nil)
+	response, err = suite.chargingStation.DataTransfer("vendor1")
+	require.Nil(t, response)
+	require.Error(t, err)
+	require.IsType(t, &ocpp.Error{}, err)
+	ocppErr = err.(*ocpp.Error)
+	assert.Equal(t, ocppj.GenericError, ocppErr.Code)
+	assert.Equal(t, "json: unsupported type: chan struct {}", ocppErr.Description)
+	// Test 3: no results in callback
+	dataListener.ExpectedCalls = nil
+	dataListener.On("OnDataTransfer", mock.AnythingOfType("string"), mock.Anything).Return(nil, nil)
+	response, err = suite.chargingStation.DataTransfer("vendor1")
+	require.Nil(t, response)
+	require.Error(t, err)
+	require.IsType(t, &ocpp.Error{}, err)
+	ocppErr = err.(*ocpp.Error)
+	assert.Equal(t, ocppj.GenericError, ocppErr.Code)
+	assert.Equal(t, fmt.Sprintf("empty response to %s for request 1234", wsId), ocppErr.Description)
+}

--- a/ocppj/central_system_test.go
+++ b/ocppj/central_system_test.go
@@ -203,7 +203,8 @@ func (suite *OcppJTestSuite) TestCentralSystemSendConfirmationFailed() {
 	mockConfirmation := newMockConfirmation("mockValue")
 	err := suite.centralSystem.SendResponse(mockChargePointId, mockUniqueId, mockConfirmation)
 	assert.NotNil(t, err)
-	assert.Equal(t, "networkError", err.Error())
+	expectedErr := fmt.Sprintf("ocpp message (%v): GenericError - networkError", mockUniqueId)
+	assert.ErrorContains(t, err, expectedErr)
 }
 
 // SendError
@@ -244,6 +245,8 @@ func (suite *OcppJTestSuite) TestCentralSystemSendErrorFailed() {
 	mockConfirmation := newMockConfirmation("mockValue")
 	err := suite.centralSystem.SendResponse(mockChargePointId, mockUniqueId, mockConfirmation)
 	assert.NotNil(t, err)
+	expectedErr := fmt.Sprintf("ocpp message (%v): GenericError - networkError", mockUniqueId)
+	assert.ErrorContains(t, err, expectedErr)
 }
 
 func (suite *OcppJTestSuite) TestCentralSystemHandleFailedResponse() {

--- a/ocppj/central_system_test.go
+++ b/ocppj/central_system_test.go
@@ -2,14 +2,10 @@ package ocppj_test
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
-	"reflect"
 	"strconv"
 	"sync"
 	"time"
-
-	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -263,46 +259,64 @@ func (suite *OcppJTestSuite) TestCentralSystemHandleFailedResponse() {
 	})
 	suite.centralSystem.Start(8887, "/{ws}")
 	suite.serverDispatcher.CreateClient(mockChargePointID)
-	// 1. occurrence validation error
-	mockField := "MyStruct.Field1"
-	mockError := MockValidationError{
-		tag:       "required",
-		namespace: mockField,
-		typ:       reflect.TypeOf(""),
-	}
+	var callResult *ocppj.CallResult
+	var callError *ocppj.CallError
 	var err error
-	err = validator.ValidationErrors{mockError}
-	suite.centralSystem.HandleFailedResponseError(mockChargePointID, mockUniqueID, err, MockFeatureName)
+	// 1. occurrence validation error
+	mockField := "CallResult.Payload.MockValue"
+	mockResponse := newMockConfirmation("")
+	callResult, err = suite.centralSystem.CreateCallResult(mockResponse, mockUniqueID)
+	require.Error(t, err)
+	require.Nil(t, callResult)
+	suite.centralSystem.HandleFailedResponseError(mockChargePointID, mockUniqueID, err, mockResponse.GetFeatureName())
 	rawResponse := <-msgC
-	expectedErr := fmt.Sprintf(`[4,"%v","%v","Field %s required but not found for feature %s",{}]`, mockUniqueID, ocppj.OccurrenceConstraintViolation, mockField, MockFeatureName)
+	expectedErr := fmt.Sprintf(`[4,"%v","%v","Field %s required but not found for feature %s",{}]`, mockUniqueID, ocppj.OccurrenceConstraintViolation, mockField, mockResponse.GetFeatureName())
 	assert.Equal(t, expectedErr, string(rawResponse))
 	// 2. property constraint validation error
 	val := "len4"
-	mockError = MockValidationError{
-		tag:       "min",
-		namespace: mockField,
-		param:     "5",
-		value:     val,
-		typ:       reflect.TypeOf(val),
-	}
-	err = validator.ValidationErrors{mockError}
-	suite.centralSystem.HandleFailedResponseError(mockChargePointID, mockUniqueID, err, MockFeatureName)
+	minParamLength := "5"
+	mockResponse = newMockConfirmation(val)
+	callResult, err = suite.centralSystem.CreateCallResult(mockResponse, mockUniqueID)
+	require.Error(t, err)
+	require.Nil(t, callResult)
+	suite.centralSystem.HandleFailedResponseError(mockChargePointID, mockUniqueID, err, mockResponse.GetFeatureName())
 	rawResponse = <-msgC
 	expectedErr = fmt.Sprintf(`[4,"%v","%v","Field %s must be minimum %s, but was %d for feature %s",{}]`,
-		mockUniqueID, ocppj.PropertyConstraintViolation, mockField, mockError.param, len(val), MockFeatureName)
+		mockUniqueID, ocppj.PropertyConstraintViolation, mockField, minParamLength, len(val), mockResponse.GetFeatureName())
 	assert.Equal(t, expectedErr, string(rawResponse))
-	// 3. ocpp error validation failed
-	err = validator.ValidationErrors{}
+	// 3. profile not supported
+	mockUnsupportedResponse := &MockUnsupportedResponse{MockValue: "someValue"}
+	callResult, err = suite.centralSystem.CreateCallResult(mockUnsupportedResponse, mockUniqueID)
+	require.Error(t, err)
+	require.Nil(t, callResult)
+	suite.centralSystem.HandleFailedResponseError(mockChargePointID, mockUniqueID, err, mockUnsupportedResponse.GetFeatureName())
+	rawResponse = <-msgC
+	expectedErr = fmt.Sprintf(`[4,"%v","%v","couldn't create Call Result for unsupported action %s",{}]`,
+		mockUniqueID, ocppj.NotSupported, mockUnsupportedResponse.GetFeatureName())
+	assert.Equal(t, expectedErr, string(rawResponse))
+	// 4. ocpp error validation failed
+	invalidErrorCode := "InvalidErrorCode"
+	callError, err = suite.centralSystem.CreateCallError(mockUniqueID, ocpp.ErrorCode(invalidErrorCode), "", nil)
+	require.Error(t, err)
+	require.Nil(t, callError)
 	suite.centralSystem.HandleFailedResponseError(mockChargePointID, mockUniqueID, err, "")
 	rawResponse = <-msgC
-	expectedErr = fmt.Sprintf(`[4,"%v","%v","%s",{}]`, mockUniqueID, ocppj.GenericError, err.Error())
+	expectedErr = fmt.Sprintf(`[4,"%v","%v","Key: 'CallError.ErrorCode' Error:Field validation for 'ErrorCode' failed on the 'errorCode' tag",{}]`,
+		mockUniqueID, ocppj.GenericError)
 	assert.Equal(t, expectedErr, string(rawResponse))
-	// 4. profile error
-	err = errors.New("this is some uncharted error")
-	feature := "SomeFeature"
-	suite.centralSystem.HandleFailedResponseError(mockChargePointID, mockUniqueID, err, feature)
+	// 5. marshaling err
+	err = suite.centralSystem.SendError(mockChargePointID, mockUniqueID, ocppj.SecurityError, "", make(chan struct{}))
+	require.Error(t, err)
+	suite.centralSystem.HandleFailedResponseError(mockChargePointID, mockUniqueID, err, "")
 	rawResponse = <-msgC
-	expectedErr = fmt.Sprintf(`[4,"%v","%v","Unsupported feature %s",{}]`, mockUniqueID, ocppj.NotSupported, feature)
+	expectedErr = fmt.Sprintf(`[4,"%v","%v","json: unsupported type: chan struct {}",{}]`, mockUniqueID, ocppj.GenericError)
+	assert.Equal(t, expectedErr, string(rawResponse))
+	// 6. network error
+	rawErr := fmt.Sprintf("couldn't write to websocket. No socket with id %s is open", mockChargePointID)
+	err = ocpp.NewError(ocppj.GenericError, rawErr, mockUniqueID)
+	suite.centralSystem.HandleFailedResponseError(mockChargePointID, mockUniqueID, err, "")
+	rawResponse = <-msgC
+	expectedErr = fmt.Sprintf(`[4,"%v","%v","%s",{}]`, mockUniqueID, ocppj.GenericError, rawErr)
 	assert.Equal(t, expectedErr, string(rawResponse))
 }
 

--- a/ocppj/charge_point_test.go
+++ b/ocppj/charge_point_test.go
@@ -193,7 +193,8 @@ func (suite *OcppJTestSuite) TestChargePointSendConfirmationFailed() {
 	mockConfirmation := newMockConfirmation("mockValue")
 	err := suite.chargePoint.SendResponse(mockUniqueId, mockConfirmation)
 	assert.NotNil(t, err)
-	assert.Equal(t, "networkError", err.Error())
+	expectedErr := fmt.Sprintf("ocpp message (%v): GenericError - networkError", mockUniqueId)
+	assert.ErrorContains(t, err, expectedErr)
 }
 
 // ----------------- SendError tests -----------------
@@ -223,7 +224,8 @@ func (suite *OcppJTestSuite) TestChargePointSendErrorFailed() {
 	mockConfirmation := newMockConfirmation("mockValue")
 	err := suite.chargePoint.SendResponse(mockUniqueId, mockConfirmation)
 	assert.NotNil(t, err)
-	assert.Equal(t, "networkError", err.Error())
+	expectedErr := fmt.Sprintf("ocpp message (%v): GenericError - networkError", mockUniqueId)
+	assert.ErrorContains(t, err, expectedErr)
 }
 
 func (suite *OcppJTestSuite) TestChargePointHandleFailedResponse() {

--- a/ocppj/dispatcher_test.go
+++ b/ocppj/dispatcher_test.go
@@ -26,7 +26,7 @@ type ServerDispatcherTestSuite struct {
 
 func (s *ServerDispatcherTestSuite) SetupTest() {
 	s.endpoint = ocppj.Server{}
-	mockProfile := ocpp.NewProfile("mock", MockFeature{})
+	mockProfile := ocpp.NewProfile("mock", &MockFeature{})
 	s.endpoint.AddProfile(mockProfile)
 	s.queueMap = ocppj.NewFIFOQueueMap(10)
 	s.dispatcher = ocppj.NewDefaultServerDispatcher(s.queueMap)
@@ -242,7 +242,7 @@ type ClientDispatcherTestSuite struct {
 
 func (c *ClientDispatcherTestSuite) SetupTest() {
 	c.endpoint = ocppj.Client{Id: "client1"}
-	mockProfile := ocpp.NewProfile("mock", MockFeature{})
+	mockProfile := ocpp.NewProfile("mock", &MockFeature{})
 	c.endpoint.AddProfile(mockProfile)
 	c.queue = ocppj.NewFIFOClientQueue(10)
 	c.dispatcher = ocppj.NewDefaultClientDispatcher(c.queue)

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -157,7 +157,7 @@ type CallError struct {
 	MessageTypeId    MessageType    `json:"messageTypeId" validate:"required,eq=4"`
 	UniqueId         string         `json:"uniqueId" validate:"required,max=36"`
 	ErrorCode        ocpp.ErrorCode `json:"errorCode" validate:"errorCode"`
-	ErrorDescription string         `json:"errorDescription" validate:"required"`
+	ErrorDescription string         `json:"errorDescription" validate:"omitempty"`
 	ErrorDetails     interface{}    `json:"errorDetails" validate:"omitempty"`
 }
 
@@ -175,7 +175,11 @@ func (callError *CallError) MarshalJSON() ([]byte, error) {
 	fields[1] = callError.UniqueId
 	fields[2] = callError.ErrorCode
 	fields[3] = callError.ErrorDescription
-	fields[4] = callError.ErrorDetails
+	if callError.ErrorDetails == nil {
+		fields[4] = struct{}{}
+	} else {
+		fields[4] = callError.ErrorDetails
+	}
 	return ocppMessageToJson(fields)
 }
 

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -500,7 +500,7 @@ func (endpoint *Endpoint) CreateCallResult(confirmation ocpp.Response, uniqueId 
 	action := confirmation.GetFeatureName()
 	profile, _ := endpoint.GetProfileForFeature(action)
 	if profile == nil {
-		return nil, fmt.Errorf("Couldn't create Call Result for unsupported action %v", action)
+		return nil, ocpp.NewError(NotSupported, fmt.Sprintf("couldn't create Call Result for unsupported action %v", action), uniqueId)
 	}
 	callResult := CallResult{
 		MessageTypeId: CALL_RESULT,

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"testing"
 
+	ut "github.com/go-playground/universal-translator"
+
 	"github.com/lorenzodonini/ocpp-go/logging"
 
 	"github.com/lorenzodonini/ocpp-go/ocpp"
@@ -780,6 +782,27 @@ func (suite *OcppJTestSuite) TestLogger() {
 		assert.Equal(t, "cannot set a nil logger", r.(string))
 	})
 }
+
+type MockValidationError struct {
+	tag       string
+	namespace string
+	param     string
+	value     string
+	typ       reflect.Type
+}
+
+func (m MockValidationError) ActualTag() string                 { return m.tag }
+func (m MockValidationError) Tag() string                       { return m.tag }
+func (m MockValidationError) Namespace() string                 { return m.namespace }
+func (m MockValidationError) StructNamespace() string           { return m.namespace }
+func (m MockValidationError) Field() string                     { return m.namespace }
+func (m MockValidationError) StructField() string               { return m.namespace }
+func (m MockValidationError) Value() interface{}                { return m.value }
+func (m MockValidationError) Param() string                     { return m.param }
+func (m MockValidationError) Kind() reflect.Kind                { return m.typ.Kind() }
+func (m MockValidationError) Type() reflect.Type                { return m.typ }
+func (m MockValidationError) Translate(ut ut.Translator) string { return "" }
+func (m MockValidationError) Error() string                     { return fmt.Sprintf("some error for value %s", m.value) }
 
 func TestMockOcppJ(t *testing.T) {
 	suite.Run(t, new(ClientQueueTestSuite))

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -195,23 +195,23 @@ type MockFeature struct {
 	mock.Mock
 }
 
-func (f MockFeature) GetFeatureName() string {
+func (f *MockFeature) GetFeatureName() string {
 	return MockFeatureName
 }
 
-func (f MockFeature) GetRequestType() reflect.Type {
+func (f *MockFeature) GetRequestType() reflect.Type {
 	return reflect.TypeOf(MockRequest{})
 }
 
-func (f MockFeature) GetResponseType() reflect.Type {
+func (f *MockFeature) GetResponseType() reflect.Type {
 	return reflect.TypeOf(MockConfirmation{})
 }
 
-func (r MockRequest) GetFeatureName() string {
+func (r *MockRequest) GetFeatureName() string {
 	return MockFeatureName
 }
 
-func (c MockConfirmation) GetFeatureName() string {
+func (c *MockConfirmation) GetFeatureName() string {
 	return MockFeatureName
 }
 
@@ -221,6 +221,14 @@ func newMockRequest(value string) *MockRequest {
 
 func newMockConfirmation(value string) *MockConfirmation {
 	return &MockConfirmation{MockValue: value}
+}
+
+type MockUnsupportedResponse struct {
+	MockValue string `json:"mockValue" validate:"required,min=5"`
+}
+
+func (m *MockUnsupportedResponse) GetFeatureName() string {
+	return "SomeRandomFeature"
 }
 
 // ---------------------- COMMON UTILITY METHODS ----------------------
@@ -356,7 +364,7 @@ type OcppJTestSuite struct {
 }
 
 func (suite *OcppJTestSuite) SetupTest() {
-	mockProfile := ocpp.NewProfile("mock", MockFeature{})
+	mockProfile := ocpp.NewProfile("mock", &MockFeature{})
 	mockClient := MockWebsocketClient{}
 	mockServer := MockWebsocketServer{}
 	suite.mockClient = &mockClient


### PR DESCRIPTION
The bug discovered in https://github.com/lorenzodonini/ocpp-go/issues/175 would cause responses not being sent out to the original endpoint, making debugging such cases difficult and potentially leading to starvation.

With the PR, the following behavior is introduced in v1.6 and v2.0.1:
- if a response struct is invalid, an ocpp error is sent instead
- if an error struct is invalid, a `ocppj.GenericError` is sent instead
- if empty error and response struct are returned from a callback, a `ocppj.GenericError` is sent instead

These functionalities are covered by the `HandleFailedResponseError` method, added to both endpoints within the ocpp-j layer. The function is invoked by the actual `ocpp16` and `ocpp2` protocol packages.

> Note: the introduced behavior will be run only once. If the `HandleFailedResponseError` method fails, no further retransmission attempts will be made.