### PR TITLE
resolves issues/173 checking and handling invalid message property for CALL_ERROR in ParseMessage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/Shopify/toxiproxy v2.1.4+incompatible
 	github.com/go-playground/locales v0.12.1 // indirect
-	github.com/go-playground/universal-translator v0.16.0 // indirect
+	github.com/go-playground/universal-translator v0.16.0
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.1
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/Shopify/toxiproxy v2.1.4+incompatible
 	github.com/go-playground/locales v0.12.1 // indirect
-	github.com/go-playground/universal-translator v0.16.0
+	github.com/go-playground/universal-translator v0.16.0 // indirect
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.1
 	github.com/kr/pretty v0.1.0 // indirect

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -443,7 +443,10 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 		if len(arr) > 4 {
 			details = arr[4]
 		}
-		rawErrorCode := arr[2].(string)
+		rawErrorCode, ok := arr[2].(string)
+		if !ok {
+			return nil, ocpp.NewError(FormationViolation, fmt.Sprintf("Invalid element %v at 2, expected rawErrorCode (string)", arr[2]), rawErrorCode)
+		}
 		errorCode := ocpp.ErrorCode(rawErrorCode)
 		errorDescription := ""
 		if v, ok := arr[3].(string); ok {


### PR DESCRIPTION
https://github.com/lorenzodonini/ocpp-go/issues/173

Currently in the (Endpoint).ParseMessage() fun there are several type cast checks in place. However for CALL_ERROR message types there is no type case check for error code thus allowing for a runtime panic. This pull request resolve this issue and returns a conventional error message. 