### PR TITLE
Use numbers option during json decoding

### DIFF
--- a/ocpp1.6_test/meter_values_test.go
+++ b/ocpp1.6_test/meter_values_test.go
@@ -38,11 +38,12 @@ func (suite *OcppV16TestSuite) TestMeterValuesE2EMocked() {
 	messageId := defaultMessageId
 	wsUrl := "someUrl"
 	connectorId := 1
+	transactionId := newInt(9223372036854775807)
 	mockValue := "value"
 	mockUnit := types.UnitOfMeasureKW
 	meterValues := []types.MeterValue{{Timestamp: types.NewDateTime(time.Now()), SampledValue: []types.SampledValue{{Value: mockValue, Unit: mockUnit}}}}
 	timestamp := types.DateTime{Time: time.Now()}
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"connectorId":%v,"meterValue":[{"timestamp":"%v","sampledValue":[{"value":"%v","unit":"%v"}]}]}]`, messageId, core.MeterValuesFeatureName, connectorId, timestamp.FormatTimestamp(), mockValue, mockUnit)
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"connectorId":%v,"transactionId":%v,"meterValue":[{"timestamp":"%v","sampledValue":[{"value":"%v","unit":"%v"}]}]}]`, messageId, core.MeterValuesFeatureName, connectorId, *transactionId, timestamp.FormatTimestamp(), mockValue, mockUnit)
 	responseJson := fmt.Sprintf(`[3,"%v",{}]`, messageId)
 	meterValuesConfirmation := core.NewMeterValuesConfirmation()
 	channel := NewMockWebSocket(wsId)
@@ -67,7 +68,9 @@ func (suite *OcppV16TestSuite) TestMeterValuesE2EMocked() {
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)
 	require.Nil(t, err)
-	confirmation, err := suite.chargePoint.MeterValues(connectorId, meterValues)
+	confirmation, err := suite.chargePoint.MeterValues(connectorId, meterValues, func(request *core.MeterValuesRequest) {
+		request.TransactionId = transactionId
+	})
 	require.Nil(t, err)
 	require.NotNil(t, confirmation)
 }

--- a/ocpp1.6_test/set_charging_profile_test.go
+++ b/ocpp1.6_test/set_charging_profile_test.go
@@ -13,7 +13,7 @@ import (
 // Test
 func (suite *OcppV16TestSuite) TestSetChargingProfileRequestValidation() {
 	t := suite.T()
-	chargingSchedule := types.NewChargingSchedule(types.ChargingRateUnitWatts, types.NewChargingSchedulePeriod(0, 10.0))
+	chargingSchedule := types.NewChargingSchedule(types.ChargingRateUnitWatts, types.NewChargingSchedulePeriod(0, 10.94210))
 	chargingProfile := types.NewChargingProfile(1, 1, types.ChargingProfilePurposeChargePointMaxProfile, types.ChargingProfileKindAbsolute, chargingSchedule)
 	var requestTable = []GenericTestEntry{
 		{smartcharging.SetChargingProfileRequest{ConnectorId: 1, ChargingProfile: chargingProfile}, true},
@@ -47,7 +47,7 @@ func (suite *OcppV16TestSuite) TestSetChargingProfileE2EMocked() {
 	chargingProfileKind := types.ChargingProfileKindAbsolute
 	chargingRateUnit := types.ChargingRateUnitWatts
 	startPeriod := 0
-	limit := 10.0
+	limit := 10.94210
 	status := smartcharging.ChargingProfileStatusAccepted
 	chargingSchedule := types.NewChargingSchedule(chargingRateUnit, types.NewChargingSchedulePeriod(startPeriod, limit))
 	chargingProfile := types.NewChargingProfile(chargingProfileId, stackLevel, chargingProfilePurpose, chargingProfileKind, chargingSchedule)

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -2,10 +2,12 @@ package ocppj_test
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
 	"reflect"
+	"strconv"
 	"testing"
 
 	ut "github.com/go-playground/universal-translator"
@@ -343,6 +345,11 @@ func assertPanic(t *testing.T, f func(), recoveredAssertion func(interface{})) {
 	f()
 }
 
+func newMockMessageType(typ ocppj.MessageType) json.Number {
+	s := strconv.Itoa(int(typ))
+	return json.Number(s)
+}
+
 var Validate = validator.New()
 
 func init() {
@@ -527,8 +534,8 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidLength() {
 	mockMessage := make([]interface{}, 2)
 	messageId := "12345"
 	// Test invalid message length
-	mockMessage[0] = ocppj.CALL // Message Type ID
-	mockMessage[1] = messageId  // Unique ID
+	mockMessage[0] = newMockMessageType(ocppj.CALL) // Message Type ID
+	mockMessage[1] = messageId                      // Unique ID
 	message, err := suite.chargePoint.ParseMessage(mockMessage, suite.chargePoint.RequestState)
 	require.Nil(t, message)
 	require.Error(t, err)
@@ -562,8 +569,8 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidMessageId() {
 	mockMessage := make([]interface{}, 3)
 	invalidMessageId := 12345
 	// Test invalid message length
-	mockMessage[0] = float64(ocppj.CALL) // Message Type ID
-	mockMessage[1] = invalidMessageId    // Unique ID
+	mockMessage[0] = newMockMessageType(ocppj.CALL) // Message Type ID
+	mockMessage[1] = invalidMessageId               // Unique ID
 	message, err := suite.chargePoint.ParseMessage(mockMessage, suite.chargePoint.RequestState)
 	require.Nil(t, message)
 	require.Error(t, err)
@@ -578,10 +585,10 @@ func (suite *OcppJTestSuite) TestParseMessageUnknownTypeId() {
 	t := suite.T()
 	mockMessage := make([]interface{}, 3)
 	messageId := "12345"
-	invalidTypeId := 1
+	invalidTypeId := ocppj.MessageType(1)
 	// Test invalid message length
-	mockMessage[0] = float64(invalidTypeId) // Message Type ID
-	mockMessage[1] = messageId              // Unique ID
+	mockMessage[0] = newMockMessageType(invalidTypeId) // Message Type ID
+	mockMessage[1] = messageId                         // Unique ID
 	message, err := suite.chargePoint.ParseMessage(mockMessage, suite.chargePoint.RequestState)
 	require.Nil(t, message)
 	require.Error(t, err)
@@ -598,9 +605,9 @@ func (suite *OcppJTestSuite) TestParseMessageUnsupported() {
 	messageId := "12345"
 	invalidAction := "SomeAction"
 	// Test invalid message length
-	mockMessage[0] = float64(ocppj.CALL) // Message Type ID
-	mockMessage[1] = messageId           // Unique ID
-	mockMessage[2] = invalidAction       // Action
+	mockMessage[0] = newMockMessageType(ocppj.CALL) // Message Type ID
+	mockMessage[1] = messageId                      // Unique ID
+	mockMessage[2] = invalidAction                  // Action
 	message, err := suite.chargePoint.ParseMessage(mockMessage, suite.chargePoint.RequestState)
 	require.Nil(t, message)
 	require.Error(t, err)
@@ -616,8 +623,8 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidCall() {
 	mockMessage := make([]interface{}, 3)
 	messageId := "12345"
 	// Test invalid message length
-	mockMessage[0] = float64(ocppj.CALL) // Message Type ID
-	mockMessage[1] = messageId           // Unique ID
+	mockMessage[0] = newMockMessageType(ocppj.CALL) // Message Type ID
+	mockMessage[1] = messageId                      // Unique ID
 	mockMessage[2] = MockFeatureName
 	message, err := suite.chargePoint.ParseMessage(mockMessage, suite.chargePoint.RequestState)
 	require.Nil(t, message)
@@ -635,8 +642,8 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidCallResult() {
 	messageId := "12345"
 	mockConfirmation := newMockConfirmation("testValue")
 	// Test invalid message length
-	mockMessage[0] = float64(ocppj.CALL_RESULT) // Message Type ID
-	mockMessage[1] = messageId                  // Unique ID
+	mockMessage[0] = newMockMessageType(ocppj.CALL_RESULT) // Message Type ID
+	mockMessage[1] = messageId                             // Unique ID
 	mockMessage[2] = mockConfirmation
 	message, err := suite.chargePoint.ParseMessage(mockMessage, suite.chargePoint.RequestState)
 	// Both message and error should be nil
@@ -650,8 +657,8 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidCallError() {
 	messageId := "12345"
 	pendingRequest := newMockRequest("request")
 	// Test invalid message length
-	mockMessage[0] = float64(ocppj.CALL_ERROR) // Message Type ID
-	mockMessage[1] = messageId                 // Unique ID
+	mockMessage[0] = newMockMessageType(ocppj.CALL_ERROR) // Message Type ID
+	mockMessage[1] = messageId                            // Unique ID
 	mockMessage[2] = ocppj.GenericError
 	suite.chargePoint.RequestState.AddPendingRequest(messageId, pendingRequest) // Manually add a pending request, so that response is not rejected
 	message, err := suite.chargePoint.ParseMessage(mockMessage, suite.chargePoint.RequestState)
@@ -669,9 +676,9 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidRawErrorCode() {
 	mockMessage := make([]interface{}, 5)
 	messageId := "12345"
 	pendingRequest := newMockRequest("request")
-	mockMessage[0] = float64(ocppj.CALL_ERROR) // Message Type ID
-	mockMessage[1] = messageId                 // Unique ID
-	mockMessage[2] = float64(42)               // test invalid typecast
+	mockMessage[0] = newMockMessageType(ocppj.CALL_ERROR) // Message Type ID
+	mockMessage[1] = messageId                            // Unique ID
+	mockMessage[2] = float64(42)                          // test invalid typecast
 	mockMessage[3] = "error description"
 	mockMessage[4] = "error details"
 	suite.chargePoint.RequestState.AddPendingRequest(messageId, pendingRequest) // Manually add a pending request, so that response is not rejected
@@ -691,8 +698,8 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidRequest() {
 	messageId := "12345"
 	// Test invalid request -> required field missing
 	mockRequest := newMockRequest("")
-	mockMessage[0] = float64(ocppj.CALL) // Message Type ID
-	mockMessage[1] = messageId           // Unique ID
+	mockMessage[0] = newMockMessageType(ocppj.CALL) // Message Type ID
+	mockMessage[1] = messageId                      // Unique ID
 	mockMessage[2] = MockFeatureName
 	mockMessage[3] = mockRequest
 	message, err := suite.chargePoint.ParseMessage(mockMessage, suite.chargePoint.RequestState)
@@ -720,8 +727,8 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidConfirmation() {
 	// Test invalid confirmation -> required field missing
 	pendingRequest := newMockRequest("request")
 	mockConfirmation := newMockConfirmation("")
-	mockMessage[0] = float64(ocppj.CALL_RESULT) // Message Type ID
-	mockMessage[1] = messageId                  // Unique ID
+	mockMessage[0] = newMockMessageType(ocppj.CALL_RESULT) // Message Type ID
+	mockMessage[1] = messageId                             // Unique ID
 	mockMessage[2] = mockConfirmation
 	suite.chargePoint.RequestState.AddPendingRequest(messageId, pendingRequest) // Manually add a pending request, so that response is not rejected
 	message, err := suite.chargePoint.ParseMessage(mockMessage, suite.chargePoint.RequestState)
@@ -750,8 +757,8 @@ func (suite *OcppJTestSuite) TestParseCall() {
 	mockValue := "somevalue"
 	mockRequest := newMockRequest(mockValue)
 	// Test invalid message length
-	mockMessage[0] = float64(ocppj.CALL) // Message Type ID
-	mockMessage[1] = messageId           // Unique ID
+	mockMessage[0] = newMockMessageType(ocppj.CALL) // Message Type ID
+	mockMessage[1] = messageId                      // Unique ID
 	mockMessage[2] = MockFeatureName
 	mockMessage[3] = mockRequest
 	message, protoErr := suite.chargePoint.ParseMessage(mockMessage, suite.chargePoint.RequestState)


### PR DESCRIPTION
Forces the `UseNumber` option on the JSON decoder while parsing a message. This prevents intermediate conversion to float64 values, which may cut off values on very high numbers and cause rounding errors.

This will likely introduce some performance decrease, since the `json.Decoder` is more memory-intensive. Optimization will be analyzed later on.

Solves #188 