### PR TITLE
Fix SetVariableStatus validation tag

### DIFF
--- a/ocpp2.0.1/provisioning/set_variables.go
+++ b/ocpp2.0.1/provisioning/set_variables.go
@@ -42,7 +42,7 @@ type SetVariableData struct {
 
 type SetVariableResult struct {
 	AttributeType   types.Attribute   `json:"attributeType,omitempty" validate:"omitempty,attribute"`
-	AttributeStatus SetVariableStatus `json:"attributeStatus" validate:"required,getVariableStatus"`
+	AttributeStatus SetVariableStatus `json:"attributeStatus" validate:"required,setVariableStatus"`
 	Component       types.Component   `json:"component" validate:"required"`
 	Variable        types.Variable    `json:"variable" validate:"required"`
 	StatusInfo      *types.StatusInfo `json:"statusInfo,omitempty" validate:"omitempty"`


### PR DESCRIPTION
Fixes incorrect validation tag for the `SetVariablesResponse.SetVariableResult.AttributeStatus` field.

Closes #194 