### PR TITLE
fix FormationViolation to FormatViolation on CallError (OCPP 2.0.1 Specification, Table B06.FR.17)

### DIFF
--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -297,8 +297,8 @@ func (cs *csms) GetDisplayMessages(clientId string, callback func(*display.GetDi
 	return cs.SendRequestAsync(clientId, request, genericCallback)
 }
 
-func (cs *csms) GetInstalledCertificateIds(clientId string, callback func(*iso15118.GetInstalledCertificateIdsResponse, error), typeOfCertificate types.CertificateUse, props ...func(*iso15118.GetInstalledCertificateIdsRequest)) error {
-	request := iso15118.NewGetInstalledCertificateIdsRequest(typeOfCertificate)
+func (cs *csms) GetInstalledCertificateIds(clientId string, callback func(*iso15118.GetInstalledCertificateIdsResponse, error), certificateTypes []types.CertificateUse, props ...func(*iso15118.GetInstalledCertificateIdsRequest)) error {
+	request := iso15118.NewGetInstalledCertificateIdsRequest(certificateTypes)
 	for _, fn := range props {
 		fn(request)
 	}

--- a/ocpp2.0.1/firmware/firmware_status_notification.go
+++ b/ocpp2.0.1/firmware/firmware_status_notification.go
@@ -16,19 +16,26 @@ const FirmwareStatusNotificationFeatureName = "FirmwareStatusNotification"
 type FirmwareStatus string
 
 const (
-	FirmwareStatusDownloaded         FirmwareStatus = "Downloaded"
-	FirmwareStatusDownloadFailed     FirmwareStatus = "DownloadFailed"
-	FirmwareStatusDownloading        FirmwareStatus = "Downloading"
-	FirmwareStatusIdle               FirmwareStatus = "Idle"
-	FirmwareStatusInstallationFailed FirmwareStatus = "InstallationFailed"
-	FirmwareStatusInstalling         FirmwareStatus = "Installing"
-	FirmwareStatusInstalled          FirmwareStatus = "Installed"
+	FirmwareStatusDownloaded                FirmwareStatus = "Downloaded"
+	FirmwareStatusDownloadFailed            FirmwareStatus = "DownloadFailed"
+	FirmwareStatusDownloading               FirmwareStatus = "Downloading"
+	FirmwareStatusDownloadScheduled         FirmwareStatus = "DownloadScheduled"
+	FirmwareStatusDownloadPaused            FirmwareStatus = "DownloadPaused"
+	FirmwareStatusIdle                      FirmwareStatus = "Idle"
+	FirmwareStatusInstallationFailed        FirmwareStatus = "InstallationFailed"
+	FirmwareStatusInstalling                FirmwareStatus = "Installing"
+	FirmwareStatusInstalled                 FirmwareStatus = "Installed"
+	FirmwareStatusInstallRebooting          FirmwareStatus = "InstallRebooting"
+	FirmwareStatusInstallScheduled          FirmwareStatus = "InstallScheduled"
+	FirmwareStatusInstallVerificationFailed FirmwareStatus = "InstallVerificationFailed"
+	FirmwareStatusInvalidSignature          FirmwareStatus = "InvalidSignature"
+	FirmwareStatusSignatureVerified         FirmwareStatus = "SignatureVerified"
 )
 
 func isValidFirmwareStatus(fl validator.FieldLevel) bool {
 	status := FirmwareStatus(fl.Field().String())
 	switch status {
-	case FirmwareStatusDownloaded, FirmwareStatusDownloadFailed, FirmwareStatusDownloading, FirmwareStatusIdle, FirmwareStatusInstallationFailed, FirmwareStatusInstalling, FirmwareStatusInstalled:
+	case FirmwareStatusDownloaded, FirmwareStatusDownloadFailed, FirmwareStatusDownloading, FirmwareStatusDownloadScheduled, FirmwareStatusDownloadPaused, FirmwareStatusIdle, FirmwareStatusInstallationFailed, FirmwareStatusInstalling, FirmwareStatusInstalled, FirmwareStatusInstallRebooting, FirmwareStatusInstallScheduled, FirmwareStatusInstallVerificationFailed, FirmwareStatusInvalidSignature, FirmwareStatusSignatureVerified:
 		return true
 	default:
 		return false

--- a/ocpp2.0.1/iso15118/get_installed_certificate_ids.go
+++ b/ocpp2.0.1/iso15118/get_installed_certificate_ids.go
@@ -31,13 +31,14 @@ func isValidGetInstalledCertificateStatus(fl validator.FieldLevel) bool {
 
 // The field definition of the GetInstalledCertificateIdsRequest PDU sent by the CSMS to the Charging Station.
 type GetInstalledCertificateIdsRequest struct {
-	TypeOfCertificate types.CertificateUse `json:"typeOfCertificate" validate:"required,certificateUse"`
+	CertificateTypes []types.CertificateUse `json:"certificateType" validate:"required,min=1,dive,certificateUse"`
 }
 
 // The field definition of the GetInstalledCertificateIds response payload sent by the Charging Station to the CSMS in response to a GetInstalledCertificateIdsRequest.
 type GetInstalledCertificateIdsResponse struct {
-	Status              GetInstalledCertificateStatus `json:"status" validate:"required,getInstalledCertificateStatus"`
-	CertificateHashData []types.CertificateHashData   `json:"certificateHashData,omitempty" validate:"omitempty,dive"`
+	Status                   GetInstalledCertificateStatus    `json:"status" validate:"required,getInstalledCertificateStatus"`
+	StatusInfo               *types.StatusInfo                `json:"statusInfo,omitempty" validate:"omitempty"`
+	CertificateHashDataChain []types.CertificateHashDataChain `json:"certificateHashDataChain,omitempty" validate:"omitempty,dive"`
 }
 
 // To facilitate the management of the Charging Station’s installed certificates, a method of retrieving the installed certificates is provided.
@@ -66,8 +67,8 @@ func (c GetInstalledCertificateIdsResponse) GetFeatureName() string {
 }
 
 // Creates a new GetInstalledCertificateIdsRequest, containing all required fields. There are no optional fields for this message.
-func NewGetInstalledCertificateIdsRequest(typeOfCertificate types.CertificateUse) *GetInstalledCertificateIdsRequest {
-	return &GetInstalledCertificateIdsRequest{TypeOfCertificate: typeOfCertificate}
+func NewGetInstalledCertificateIdsRequest(certificateTypes []types.CertificateUse) *GetInstalledCertificateIdsRequest {
+	return &GetInstalledCertificateIdsRequest{CertificateTypes: certificateTypes}
 }
 
 // Creates a new NewGetInstalledCertificateIdsResponse, containing all required fields. Additional optional fields may be set afterwards.

--- a/ocpp2.0.1/security/certificate_signed.go
+++ b/ocpp2.0.1/security/certificate_signed.go
@@ -32,8 +32,8 @@ func isValidCertificateSignedStatus(fl validator.FieldLevel) bool {
 
 // The field definition of the CertificateSignedRequest PDU sent by the CSMS to the Charging Station.
 type CertificateSignedRequest struct {
-	CertificateChain  string                      `json:"certificateChain" validate:"required,max=10000"`
-	TypeOfCertificate types.CertificateSigningUse `json:"typeOfCertificate,omitempty" validate:"omitempty,certificateSigningUse"`
+	CertificateChain string                      `json:"certificateChain" validate:"required,max=10000"`
+	CertificateType  types.CertificateSigningUse `json:"certificateType,omitempty" validate:"omitempty,certificateSigningUse"`
 }
 
 // The field definition of the CertificateSignedResponse payload sent by the Charging Station to the CSMS in response to a CertificateSignedRequest.

--- a/ocpp2.0.1/types/types.go
+++ b/ocpp2.0.1/types/types.go
@@ -154,6 +154,13 @@ type CertificateHashData struct {
 	SerialNumber   string            `json:"serialNumber" validate:"required,max=20"`
 }
 
+// CertificateHashDataChain
+type CertificateHashDataChain struct {
+	CertificateType          CertificateUse        `json:"certificateType" validate:"required,certificateUse"`
+	CertificateHashData      CertificateHashData   `json:"certificateHashData" validate:"required"`
+	ChildCertificateHashData []CertificateHashData `json:"childCertificateHashData,omitempty" validate:"omitempty,dive"`
+}
+
 // Certificate15118EVStatus
 type Certificate15118EVStatus string
 

--- a/ocpp2.0.1/v2.go
+++ b/ocpp2.0.1/v2.go
@@ -284,7 +284,7 @@ type CSMS interface {
 	// Retrieves all messages currently configured on a charging station.
 	GetDisplayMessages(clientId string, callback func(*display.GetDisplayMessagesResponse, error), requestId int, props ...func(*display.GetDisplayMessagesRequest)) error
 	// Retrieves all installed certificates on a charging station.
-	GetInstalledCertificateIds(clientId string, callback func(*iso15118.GetInstalledCertificateIdsResponse, error), typeOfCertificate types.CertificateUse, props ...func(*iso15118.GetInstalledCertificateIdsRequest)) error
+	GetInstalledCertificateIds(clientId string, callback func(*iso15118.GetInstalledCertificateIdsResponse, error), certificateTypes []types.CertificateUse, props ...func(*iso15118.GetInstalledCertificateIdsRequest)) error
 	// Queries a charging station for version number of the Local Authorization List.
 	GetLocalListVersion(clientId string, callback func(*localauth.GetLocalListVersionResponse, error), props ...func(*localauth.GetLocalListVersionRequest)) error
 	// Instructs a charging station to upload a diagnostics or security logfile to the CSMS.

--- a/ocpp2.0.1_test/certificate_signed_test.go
+++ b/ocpp2.0.1_test/certificate_signed_test.go
@@ -14,12 +14,12 @@ import (
 func (suite *OcppV2TestSuite) TestCertificateSignedRequestValidation() {
 	t := suite.T()
 	var testTable = []GenericTestEntry{
-		{security.CertificateSignedRequest{CertificateChain: "sampleCert", TypeOfCertificate: types.ChargingStationCert}, true},
+		{security.CertificateSignedRequest{CertificateChain: "sampleCert", CertificateType: types.ChargingStationCert}, true},
 		{security.CertificateSignedRequest{CertificateChain: "sampleCert"}, true},
 		{security.CertificateSignedRequest{CertificateChain: ""}, false},
 		{security.CertificateSignedRequest{}, false},
 		{security.CertificateSignedRequest{CertificateChain: newLongString(100001)}, false},
-		{security.CertificateSignedRequest{CertificateChain: "sampleCert", TypeOfCertificate: "invalidCertificateType"}, false},
+		{security.CertificateSignedRequest{CertificateChain: "sampleCert", CertificateType: "invalidCertificateType"}, false},
 	}
 	ExecuteGenericTestTable(t, testTable)
 }
@@ -46,7 +46,7 @@ func (suite *OcppV2TestSuite) TestCertificateSignedE2EMocked() {
 	certificateChain := "someX509CertificateChain"
 	certificateType := types.ChargingStationCert
 	status := security.CertificateSignedStatusAccepted
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificateChain":"%v","typeOfCertificate":"%v"}]`,
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificateChain":"%v","certificateType":"%v"}]`,
 		messageId, security.CertificateSignedFeatureName, certificateChain, certificateType)
 	responseJson := fmt.Sprintf(`[3,"%v",{"status":"%v"}]`, messageId, status)
 	certificateSignedConfirmation := security.NewCertificateSignedResponse(status)
@@ -57,7 +57,7 @@ func (suite *OcppV2TestSuite) TestCertificateSignedE2EMocked() {
 		request, ok := args.Get(0).(*security.CertificateSignedRequest)
 		require.True(t, ok)
 		assert.Equal(t, certificateChain, request.CertificateChain)
-		assert.Equal(t, certificateType, request.TypeOfCertificate)
+		assert.Equal(t, certificateType, request.CertificateType)
 	})
 	setupDefaultCSMSHandlers(suite, expectedCSMSOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargingStationHandlers(suite, expectedChargingStationOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true}, handler)
@@ -72,7 +72,7 @@ func (suite *OcppV2TestSuite) TestCertificateSignedE2EMocked() {
 		assert.Equal(t, status, confirmation.Status)
 		resultChannel <- true
 	}, certificateChain, func(request *security.CertificateSignedRequest) {
-		request.TypeOfCertificate = certificateType
+		request.CertificateType = certificateType
 	})
 	require.Nil(t, err)
 	result := <-resultChannel
@@ -84,7 +84,7 @@ func (suite *OcppV2TestSuite) TestCertificateSignedInvalidEndpoint() {
 	certificate := "someX509Certificate"
 	certificateType := types.ChargingStationCert
 	certificateSignedRequest := security.NewCertificateSignedRequest(certificate)
-	certificateSignedRequest.TypeOfCertificate = certificateType
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificateChain":"%v","typeOfCertificate":"%v"}]`, messageId, security.CertificateSignedFeatureName, certificate, certificateType)
+	certificateSignedRequest.CertificateType = certificateType
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificateChain":"%v","certificateType":"%v"}]`, messageId, security.CertificateSignedFeatureName, certificate, certificateType)
 	testUnsupportedRequestFromChargingStation(suite, certificateSignedRequest, requestJson, messageId)
 }

--- a/ocpp2.0.1_test/get_installed_certificate_ids_test.go
+++ b/ocpp2.0.1_test/get_installed_certificate_ids_test.go
@@ -14,14 +14,14 @@ import (
 func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsRequestValidation() {
 	t := suite.T()
 	var testTable = []GenericTestEntry{
-		{iso15118.GetInstalledCertificateIdsRequest{TypeOfCertificate: types.V2GRootCertificate}, true},
-		{iso15118.GetInstalledCertificateIdsRequest{TypeOfCertificate: types.MORootCertificate}, true},
-		{iso15118.GetInstalledCertificateIdsRequest{TypeOfCertificate: types.CSOSubCA1}, true},
-		{iso15118.GetInstalledCertificateIdsRequest{TypeOfCertificate: types.CSOSubCA2}, true},
-		{iso15118.GetInstalledCertificateIdsRequest{TypeOfCertificate: types.CSMSRootCertificate}, true},
-		{iso15118.GetInstalledCertificateIdsRequest{TypeOfCertificate: types.ManufacturerRootCertificate}, true},
+		{iso15118.GetInstalledCertificateIdsRequest{CertificateTypes: []types.CertificateUse{types.V2GRootCertificate}}, true},
+		{iso15118.GetInstalledCertificateIdsRequest{CertificateTypes: []types.CertificateUse{types.MORootCertificate}}, true},
+		{iso15118.GetInstalledCertificateIdsRequest{CertificateTypes: []types.CertificateUse{types.CSOSubCA1}}, true},
+		{iso15118.GetInstalledCertificateIdsRequest{CertificateTypes: []types.CertificateUse{types.CSOSubCA2}}, true},
+		{iso15118.GetInstalledCertificateIdsRequest{CertificateTypes: []types.CertificateUse{types.CSMSRootCertificate}}, true},
+		{iso15118.GetInstalledCertificateIdsRequest{CertificateTypes: []types.CertificateUse{types.ManufacturerRootCertificate}}, true},
 		{iso15118.GetInstalledCertificateIdsRequest{}, false},
-		{iso15118.GetInstalledCertificateIdsRequest{TypeOfCertificate: "invalidCertificateUse"}, false},
+		{iso15118.GetInstalledCertificateIdsRequest{CertificateTypes: []types.CertificateUse{"invalidCertificateUse"}}, false},
 	}
 	ExecuteGenericTestTable(t, testTable)
 }
@@ -29,13 +29,13 @@ func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsRequestValidation() 
 func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsConfirmationValidation() {
 	t := suite.T()
 	var testTable = []GenericTestEntry{
-		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusAccepted, CertificateHashData: []types.CertificateHashData{{HashAlgorithm: types.SHA256, IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"}}}, true},
-		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusNotFound, CertificateHashData: []types.CertificateHashData{{HashAlgorithm: types.SHA256, IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"}}}, true},
-		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusAccepted, CertificateHashData: []types.CertificateHashData{}}, true},
+		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusAccepted, CertificateHashDataChain: []types.CertificateHashDataChain{{CertificateType: types.CSMSRootCertificate, CertificateHashData: types.CertificateHashData{HashAlgorithm: types.SHA256, IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"}}}}, true},
+		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusNotFound, CertificateHashDataChain: []types.CertificateHashDataChain{{CertificateType: types.CSMSRootCertificate, CertificateHashData: types.CertificateHashData{HashAlgorithm: types.SHA256, IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"}}}}, true},
+		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusAccepted, CertificateHashDataChain: []types.CertificateHashDataChain{}}, true},
 		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusAccepted}, true},
 		{iso15118.GetInstalledCertificateIdsResponse{}, false},
 		{iso15118.GetInstalledCertificateIdsResponse{Status: "invalidGetInstalledCertificateStatus"}, false},
-		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusAccepted, CertificateHashData: []types.CertificateHashData{{HashAlgorithm: "invalidHashAlgorithm", IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"}}}, false},
+		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusAccepted, CertificateHashDataChain: []types.CertificateHashDataChain{{CertificateType: types.CSMSRootCertificate, CertificateHashData: types.CertificateHashData{HashAlgorithm: "invalidHashAlgorithm", IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"}}}}, false},
 	}
 	ExecuteGenericTestTable(t, testTable)
 }
@@ -46,16 +46,16 @@ func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsE2EMocked() {
 	wsId := "test_id"
 	messageId := defaultMessageId
 	wsUrl := "someUrl"
-	certificateType := types.CSMSRootCertificate
+	certificateTypes := []types.CertificateUse{types.CSMSRootCertificate}
 	status := iso15118.GetInstalledCertificateStatusAccepted
-	certificateHashData := []types.CertificateHashData{
-		{HashAlgorithm: types.SHA256, IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"},
+	certificateHashDataChain := []types.CertificateHashDataChain{
+		{CertificateType: types.CSMSRootCertificate, CertificateHashData: types.CertificateHashData{HashAlgorithm: types.SHA256, IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"}},
 	}
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"typeOfCertificate":"%v"}]`, messageId, iso15118.GetInstalledCertificateIdsFeatureName, certificateType)
-	responseJson := fmt.Sprintf(`[3,"%v",{"status":"%v","certificateHashData":[{"hashAlgorithm":"%v","issuerNameHash":"%v","issuerKeyHash":"%v","serialNumber":"%v"}]}]`,
-		messageId, status, certificateHashData[0].HashAlgorithm, certificateHashData[0].IssuerNameHash, certificateHashData[0].IssuerKeyHash, certificateHashData[0].SerialNumber)
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificateType":["%v"]}]`, messageId, iso15118.GetInstalledCertificateIdsFeatureName, certificateTypes[0])
+	responseJson := fmt.Sprintf(`[3,"%v",{"status":"%v","certificateHashDataChain":[{"certificateType":"%v","certificateHashData":{"hashAlgorithm":"%v","issuerNameHash":"%v","issuerKeyHash":"%v","serialNumber":"%v"}}]}]`,
+		messageId, status, certificateHashDataChain[0].CertificateType, certificateHashDataChain[0].CertificateHashData.HashAlgorithm, certificateHashDataChain[0].CertificateHashData.IssuerNameHash, certificateHashDataChain[0].CertificateHashData.IssuerKeyHash, certificateHashDataChain[0].CertificateHashData.SerialNumber)
 	getInstalledCertificateIdsConfirmation := iso15118.NewGetInstalledCertificateIdsResponse(status)
-	getInstalledCertificateIdsConfirmation.CertificateHashData = certificateHashData
+	getInstalledCertificateIdsConfirmation.CertificateHashDataChain = certificateHashDataChain
 	channel := NewMockWebSocket(wsId)
 	// Setting handlers
 	handler := &MockChargingStationIso15118Handler{}
@@ -63,7 +63,7 @@ func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsE2EMocked() {
 		request, ok := args.Get(0).(*iso15118.GetInstalledCertificateIdsRequest)
 		require.True(t, ok)
 		require.NotNil(t, request)
-		assert.Equal(t, certificateType, request.TypeOfCertificate)
+		assert.Equal(t, certificateTypes, request.CertificateTypes)
 	})
 	setupDefaultCSMSHandlers(suite, expectedCSMSOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargingStationHandlers(suite, expectedChargingStationOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true}, handler)
@@ -76,13 +76,13 @@ func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsE2EMocked() {
 		require.Nil(t, err)
 		require.NotNil(t, confirmation)
 		assert.Equal(t, status, confirmation.Status)
-		require.Len(t, confirmation.CertificateHashData, len(certificateHashData))
-		assert.Equal(t, certificateHashData[0].HashAlgorithm, confirmation.CertificateHashData[0].HashAlgorithm)
-		assert.Equal(t, certificateHashData[0].IssuerNameHash, confirmation.CertificateHashData[0].IssuerNameHash)
-		assert.Equal(t, certificateHashData[0].IssuerKeyHash, confirmation.CertificateHashData[0].IssuerKeyHash)
-		assert.Equal(t, certificateHashData[0].SerialNumber, confirmation.CertificateHashData[0].SerialNumber)
+		require.Len(t, confirmation.CertificateHashDataChain, len(certificateHashDataChain))
+		assert.Equal(t, certificateHashDataChain[0].CertificateHashData.HashAlgorithm, confirmation.CertificateHashDataChain[0].CertificateHashData.HashAlgorithm)
+		assert.Equal(t, certificateHashDataChain[0].CertificateHashData.IssuerNameHash, confirmation.CertificateHashDataChain[0].CertificateHashData.IssuerNameHash)
+		assert.Equal(t, certificateHashDataChain[0].CertificateHashData.IssuerKeyHash, confirmation.CertificateHashDataChain[0].CertificateHashData.IssuerKeyHash)
+		assert.Equal(t, certificateHashDataChain[0].CertificateHashData.SerialNumber, confirmation.CertificateHashDataChain[0].CertificateHashData.SerialNumber)
 		resultChannel <- true
-	}, certificateType)
+	}, certificateTypes)
 	require.Nil(t, err)
 	result := <-resultChannel
 	assert.True(t, result)
@@ -90,8 +90,8 @@ func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsE2EMocked() {
 
 func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsInvalidEndpoint() {
 	messageId := defaultMessageId
-	certificateType := types.CSMSRootCertificate
-	GetInstalledCertificateIdsRequest := iso15118.NewGetInstalledCertificateIdsRequest(certificateType)
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"typeOfCertificate":"%v"}]`, messageId, iso15118.GetInstalledCertificateIdsFeatureName, certificateType)
+	certificateTypes := []types.CertificateUse{types.CSMSRootCertificate}
+	GetInstalledCertificateIdsRequest := iso15118.NewGetInstalledCertificateIdsRequest(certificateTypes)
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificateType":["%v"]}]`, messageId, iso15118.GetInstalledCertificateIdsFeatureName, certificateTypes[0])
 	testUnsupportedRequestFromChargingStation(suite, GetInstalledCertificateIdsRequest, requestJson, messageId)
 }

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -190,7 +190,7 @@ const (
 	MessageTypeNotSupported       ocpp.ErrorCode = "MessageTypeNotSupported"       // A message with an Message Type Number received that is not supported by this implementation.
 	ProtocolError                 ocpp.ErrorCode = "ProtocolError"                 // Payload for Action is incomplete.
 	SecurityError                 ocpp.ErrorCode = "SecurityError"                 // During the processing of Action a security issue occurred preventing receiver from completing the Action successfully.
-	FormationViolation            ocpp.ErrorCode = "FormationViolation"            // Payload for Action is syntactically incorrect or not conform the PDU structure for Action.
+	FormatViolation               ocpp.ErrorCode = "FormatViolation"               // Payload for Action is syntactically incorrect or not conform the PDU structure for Action.
 	PropertyConstraintViolation   ocpp.ErrorCode = "PropertyConstraintViolation"   // Payload is syntactically correct but at least one field contains an invalid value.
 	OccurrenceConstraintViolation ocpp.ErrorCode = "OccurrenceConstraintViolation" // Payload for Action is syntactically correct but at least one of the fields violates occurrence constraints.
 	TypeConstraintViolation       ocpp.ErrorCode = "TypeConstraintViolation"       // Payload for Action is syntactically correct but at least one of the fields violates data type constraints (e.g. “somestring”: 12).
@@ -200,7 +200,7 @@ const (
 func IsErrorCodeValid(fl validator.FieldLevel) bool {
 	code := ocpp.ErrorCode(fl.Field().String())
 	switch code {
-	case NotImplemented, NotSupported, InternalError, MessageTypeNotSupported, ProtocolError, SecurityError, FormationViolation, PropertyConstraintViolation, OccurrenceConstraintViolation, TypeConstraintViolation, GenericError:
+	case NotImplemented, NotSupported, InternalError, MessageTypeNotSupported, ProtocolError, SecurityError, FormatViolation, PropertyConstraintViolation, OccurrenceConstraintViolation, TypeConstraintViolation, GenericError:
 		return true
 	}
 	return false
@@ -373,21 +373,21 @@ func parseRawJsonConfirmation(raw interface{}, confirmationType reflect.Type) (o
 func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState ClientState) (Message, error) {
 	// Checking message fields
 	if len(arr) < 3 {
-		return nil, ocpp.NewError(FormationViolation, "Invalid message. Expected array length >= 3", "")
+		return nil, ocpp.NewError(FormatViolation, "Invalid message. Expected array length >= 3", "")
 	}
 	rawTypeId, ok := arr[0].(float64)
 	if !ok {
-		return nil, ocpp.NewError(FormationViolation, fmt.Sprintf("Invalid element %v at 0, expected message type (int)", arr[0]), "")
+		return nil, ocpp.NewError(FormatViolation, fmt.Sprintf("Invalid element %v at 0, expected message type (int)", arr[0]), "")
 	}
 	typeId := MessageType(rawTypeId)
 	uniqueId, ok := arr[1].(string)
 	if !ok {
-		return nil, ocpp.NewError(FormationViolation, fmt.Sprintf("Invalid element %v at 1, expected unique ID (string)", arr[1]), uniqueId)
+		return nil, ocpp.NewError(FormatViolation, fmt.Sprintf("Invalid element %v at 1, expected unique ID (string)", arr[1]), uniqueId)
 	}
 	// Parse message
 	if typeId == CALL {
 		if len(arr) != 4 {
-			return nil, ocpp.NewError(FormationViolation, "Invalid Call message. Expected array length 4", uniqueId)
+			return nil, ocpp.NewError(FormatViolation, "Invalid Call message. Expected array length 4", uniqueId)
 		}
 		action := arr[2].(string)
 		profile, ok := endpoint.GetProfileForFeature(action)
@@ -396,7 +396,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 		}
 		request, err := profile.ParseRequest(action, arr[3], parseRawJsonRequest)
 		if err != nil {
-			return nil, ocpp.NewError(FormationViolation, err.Error(), uniqueId)
+			return nil, ocpp.NewError(FormatViolation, err.Error(), uniqueId)
 		}
 		call := Call{
 			MessageTypeId: CALL,
@@ -418,7 +418,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 		profile, _ := endpoint.GetProfileForFeature(request.GetFeatureName())
 		confirmation, err := profile.ParseResponse(request.GetFeatureName(), arr[2], parseRawJsonConfirmation)
 		if err != nil {
-			return nil, ocpp.NewError(FormationViolation, err.Error(), uniqueId)
+			return nil, ocpp.NewError(FormatViolation, err.Error(), uniqueId)
 		}
 		callResult := CallResult{
 			MessageTypeId: CALL_RESULT,
@@ -437,7 +437,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 			return nil, nil
 		}
 		if len(arr) < 4 {
-			return nil, ocpp.NewError(FormationViolation, "Invalid Call Error message. Expected array length >= 4", uniqueId)
+			return nil, ocpp.NewError(FormatViolation, "Invalid Call Error message. Expected array length >= 4", uniqueId)
 		}
 		var details interface{}
 		if len(arr) > 4 {
@@ -445,7 +445,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 		}
 		rawErrorCode, ok := arr[2].(string)
 		if !ok {
-			return nil, ocpp.NewError(FormationViolation, fmt.Sprintf("Invalid element %v at 2, expected rawErrorCode (string)", arr[2]), rawErrorCode)
+			return nil, ocpp.NewError(FormatViolation, fmt.Sprintf("Invalid element %v at 2, expected rawErrorCode (string)", arr[2]), rawErrorCode)
 		}
 		errorCode := ocpp.ErrorCode(rawErrorCode)
 		errorDescription := ""

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -535,7 +535,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidLength() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, "", protoErr.MessageId)
-	assert.Equal(t, ocppj.FormationViolation, protoErr.Code)
+	assert.Equal(t, ocppj.FormatViolation, protoErr.Code)
 	assert.Equal(t, "Invalid message. Expected array length >= 3", protoErr.Description)
 }
 
@@ -553,7 +553,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidTypeId() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, "", protoErr.MessageId)
-	assert.Equal(t, ocppj.FormationViolation, protoErr.Code)
+	assert.Equal(t, ocppj.FormatViolation, protoErr.Code)
 	assert.Equal(t, fmt.Sprintf("Invalid element %v at 0, expected message type (int)", invalidTypeId), protoErr.Description)
 }
 
@@ -570,7 +570,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidMessageId() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, "", protoErr.MessageId)
-	assert.Equal(t, ocppj.FormationViolation, protoErr.Code)
+	assert.Equal(t, ocppj.FormatViolation, protoErr.Code)
 	assert.Equal(t, fmt.Sprintf("Invalid element %v at 1, expected unique ID (string)", invalidMessageId), protoErr.Description)
 }
 
@@ -625,7 +625,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidCall() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, messageId, protoErr.MessageId)
-	assert.Equal(t, ocppj.FormationViolation, protoErr.Code)
+	assert.Equal(t, ocppj.FormatViolation, protoErr.Code)
 	assert.Equal(t, "Invalid Call message. Expected array length 4", protoErr.Description)
 }
 
@@ -660,7 +660,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidCallError() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, messageId, protoErr.MessageId)
-	assert.Equal(t, ocppj.FormationViolation, protoErr.Code)
+	assert.Equal(t, ocppj.FormatViolation, protoErr.Code)
 	assert.Equal(t, "Invalid Call Error message. Expected array length >= 4", protoErr.Description)
 }
 
@@ -681,7 +681,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidRawErrorCode() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, protoErr.MessageId, "") // unique id is never set after invalid type cast return
-	assert.Equal(t, ocppj.FormationViolation, protoErr.Code)
+	assert.Equal(t, ocppj.FormatViolation, protoErr.Code)
 	assert.Equal(t, "Invalid element 42 at 2, expected rawErrorCode (string)", protoErr.Description)
 }
 


### PR DESCRIPTION
`FormationViolation` to `FormatViolation` base on `OCPP 2.0.1 Specification` Table `B06.FR.17`