### PR TITLE
Fix common validation keys in v1.6 and v2.0.1

### DIFF
--- a/ocpp1.6/core/remote_start_transaction.go
+++ b/ocpp1.6/core/remote_start_transaction.go
@@ -1,8 +1,9 @@
 package core
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 )
 
 // -------------------- Remote Start Transaction (CS -> CP) --------------------
@@ -19,7 +20,7 @@ type RemoteStartTransactionRequest struct {
 // This field definition of the RemoteStartTransaction confirmation payload, sent by the Charge Point to the Central System in response to a RemoteStartTransactionRequest.
 // In case the request was invalid, or couldn't be processed, an error will be sent instead.
 type RemoteStartTransactionConfirmation struct {
-	Status types.RemoteStartStopStatus `json:"status" validate:"required,remoteStartStopStatus"`
+	Status types.RemoteStartStopStatus `json:"status" validate:"required,remoteStartStopStatus16"`
 }
 
 // Central System can request a Charge Point to start a transaction by sending a RemoteStartTransactionRequest.

--- a/ocpp1.6/core/remote_stop_transaction.go
+++ b/ocpp1.6/core/remote_stop_transaction.go
@@ -1,8 +1,9 @@
 package core
 
 import (
-	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 )
 
 // -------------------- Remote Stop Transaction (CS -> CP) --------------------
@@ -17,7 +18,7 @@ type RemoteStopTransactionRequest struct {
 // This field definition of the RemoteStopTransaction confirmation payload, sent by the Charge Point to the Central System in response to a RemoteStopTransactionRequest.
 // In case the request was invalid, or couldn't be processed, an error will be sent instead.
 type RemoteStopTransactionConfirmation struct {
-	Status types.RemoteStartStopStatus `json:"status" validate:"required,remoteStartStopStatus"`
+	Status types.RemoteStartStopStatus `json:"status" validate:"required,remoteStartStopStatus16"`
 }
 
 // Central System can request a Charge Point to stop a transaction by sending a RemoteStopTransactionRequest to Charge Point with the identifier of the transaction.

--- a/ocpp1.6/smartcharging/clear_charging_profile.go
+++ b/ocpp1.6/smartcharging/clear_charging_profile.go
@@ -1,9 +1,10 @@
 package smartcharging
 
 import (
+	"reflect"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"gopkg.in/go-playground/validator.v9"
-	"reflect"
 )
 
 // -------------------- Clear Charging Profile (CS -> CP) --------------------
@@ -32,7 +33,7 @@ func isValidClearChargingProfileStatus(fl validator.FieldLevel) bool {
 type ClearChargingProfileRequest struct {
 	Id                     *int                             `json:"id,omitempty" validate:"omitempty"`
 	ConnectorId            *int                             `json:"connectorId,omitempty" validate:"omitempty,gte=0"`
-	ChargingProfilePurpose types.ChargingProfilePurposeType `json:"chargingProfilePurpose,omitempty" validate:"omitempty,chargingProfilePurpose"`
+	ChargingProfilePurpose types.ChargingProfilePurposeType `json:"chargingProfilePurpose,omitempty" validate:"omitempty,chargingProfilePurpose16"`
 	StackLevel             *int                             `json:"stackLevel,omitempty" validate:"omitempty,gte=0"`
 }
 

--- a/ocpp1.6/smartcharging/get_composite_schedule.go
+++ b/ocpp1.6/smartcharging/get_composite_schedule.go
@@ -1,9 +1,10 @@
 package smartcharging
 
 import (
+	"reflect"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"gopkg.in/go-playground/validator.v9"
-	"reflect"
 )
 
 // -------------------- Get Composite Schedule (CS -> CP) --------------------
@@ -32,7 +33,7 @@ func isValidGetCompositeScheduleStatus(fl validator.FieldLevel) bool {
 type GetCompositeScheduleRequest struct {
 	ConnectorId      int                        `json:"connectorId" validate:"gte=0"`
 	Duration         int                        `json:"duration" validate:"gte=0"`
-	ChargingRateUnit types.ChargingRateUnitType `json:"chargingRateUnit,omitempty" validate:"omitempty,chargingRateUnit"`
+	ChargingRateUnit types.ChargingRateUnitType `json:"chargingRateUnit,omitempty" validate:"omitempty,chargingRateUnit16"`
 }
 
 // This field definition of the GetCompositeSchedule confirmation payload, sent by the Charge Point to the Central System in response to a GetCompositeScheduleRequest.

--- a/ocpp1.6/types/types.go
+++ b/ocpp1.6/types/types.go
@@ -42,7 +42,7 @@ func isValidAuthorizationStatus(fl validator.FieldLevel) bool {
 type IdTagInfo struct {
 	ExpiryDate  *DateTime           `json:"expiryDate,omitempty" validate:"omitempty"`
 	ParentIdTag string              `json:"parentIdTag,omitempty" validate:"omitempty,max=20"`
-	Status      AuthorizationStatus `json:"status" validate:"required,authorizationStatus"`
+	Status      AuthorizationStatus `json:"status" validate:"required,authorizationStatus16"`
 }
 
 func NewIdTagInfo(status AuthorizationStatus) *IdTagInfo {
@@ -121,7 +121,7 @@ func NewChargingSchedulePeriod(startPeriod int, limit float64) ChargingScheduleP
 type ChargingSchedule struct {
 	Duration               *int                     `json:"duration,omitempty" validate:"omitempty,gte=0"`
 	StartSchedule          *DateTime                `json:"startSchedule,omitempty"`
-	ChargingRateUnit       ChargingRateUnitType     `json:"chargingRateUnit" validate:"required,chargingRateUnit"`
+	ChargingRateUnit       ChargingRateUnitType     `json:"chargingRateUnit" validate:"required,chargingRateUnit16"`
 	ChargingSchedulePeriod []ChargingSchedulePeriod `json:"chargingSchedulePeriod" validate:"required,min=1"`
 	MinChargingRate        *float64                 `json:"minChargingRate,omitempty" validate:"omitempty,gte=0"`
 }
@@ -134,9 +134,9 @@ type ChargingProfile struct {
 	ChargingProfileId      int                        `json:"chargingProfileId"`
 	TransactionId          int                        `json:"transactionId,omitempty"`
 	StackLevel             int                        `json:"stackLevel" validate:"gte=0"`
-	ChargingProfilePurpose ChargingProfilePurposeType `json:"chargingProfilePurpose" validate:"required,chargingProfilePurpose"`
-	ChargingProfileKind    ChargingProfileKindType    `json:"chargingProfileKind" validate:"required,chargingProfileKind"`
-	RecurrencyKind         RecurrencyKindType         `json:"recurrencyKind,omitempty" validate:"omitempty,recurrencyKind"`
+	ChargingProfilePurpose ChargingProfilePurposeType `json:"chargingProfilePurpose" validate:"required,chargingProfilePurpose16"`
+	ChargingProfileKind    ChargingProfileKindType    `json:"chargingProfileKind" validate:"required,chargingProfileKind16"`
+	RecurrencyKind         RecurrencyKindType         `json:"recurrencyKind,omitempty" validate:"omitempty,recurrencyKind16"`
 	ValidFrom              *DateTime                  `json:"validFrom,omitempty"`
 	ValidTo                *DateTime                  `json:"validTo,omitempty"`
 	ChargingSchedule       *ChargingSchedule          `json:"chargingSchedule" validate:"required"`
@@ -300,11 +300,11 @@ func isValidUnitOfMeasure(fl validator.FieldLevel) bool {
 
 type SampledValue struct {
 	Value     string         `json:"value" validate:"required"`
-	Context   ReadingContext `json:"context,omitempty" validate:"omitempty,readingContext"`
+	Context   ReadingContext `json:"context,omitempty" validate:"omitempty,readingContext16"`
 	Format    ValueFormat    `json:"format,omitempty" validate:"omitempty,valueFormat"`
-	Measurand Measurand      `json:"measurand,omitempty" validate:"omitempty,measurand"`
-	Phase     Phase          `json:"phase,omitempty" validate:"omitempty,phase"`
-	Location  Location       `json:"location,omitempty" validate:"omitempty,location"`
+	Measurand Measurand      `json:"measurand,omitempty" validate:"omitempty,measurand16"`
+	Phase     Phase          `json:"phase,omitempty" validate:"omitempty,phase16"`
+	Location  Location       `json:"location,omitempty" validate:"omitempty,location16"`
 	Unit      UnitOfMeasure  `json:"unit,omitempty" validate:"omitempty,unitOfMeasure"`
 }
 
@@ -317,16 +317,16 @@ type MeterValue struct {
 var Validate = ocppj.Validate
 
 func init() {
-	_ = Validate.RegisterValidation("authorizationStatus", isValidAuthorizationStatus)
-	_ = Validate.RegisterValidation("chargingProfilePurpose", isValidChargingProfilePurpose)
-	_ = Validate.RegisterValidation("chargingProfileKind", isValidChargingProfileKind)
-	_ = Validate.RegisterValidation("recurrencyKind", isValidRecurrencyKind)
-	_ = Validate.RegisterValidation("chargingRateUnit", isValidChargingRateUnit)
-	_ = Validate.RegisterValidation("remoteStartStopStatus", isValidRemoteStartStopStatus)
-	_ = Validate.RegisterValidation("readingContext", isValidReadingContext)
+	_ = Validate.RegisterValidation("authorizationStatus16", isValidAuthorizationStatus)
+	_ = Validate.RegisterValidation("chargingProfilePurpose16", isValidChargingProfilePurpose)
+	_ = Validate.RegisterValidation("chargingProfileKind16", isValidChargingProfileKind)
+	_ = Validate.RegisterValidation("recurrencyKind16", isValidRecurrencyKind)
+	_ = Validate.RegisterValidation("chargingRateUnit16", isValidChargingRateUnit)
+	_ = Validate.RegisterValidation("remoteStartStopStatus16", isValidRemoteStartStopStatus)
+	_ = Validate.RegisterValidation("readingContext16", isValidReadingContext)
 	_ = Validate.RegisterValidation("valueFormat", isValidValueFormat)
-	_ = Validate.RegisterValidation("measurand", isValidMeasurand)
-	_ = Validate.RegisterValidation("phase", isValidPhase)
-	_ = Validate.RegisterValidation("location", isValidLocation)
+	_ = Validate.RegisterValidation("measurand16", isValidMeasurand)
+	_ = Validate.RegisterValidation("phase16", isValidPhase)
+	_ = Validate.RegisterValidation("location16", isValidLocation)
 	_ = Validate.RegisterValidation("unitOfMeasure", isValidUnitOfMeasure)
 }

--- a/ocpp2.0.1/smartcharging/clear_charging_profile.go
+++ b/ocpp2.0.1/smartcharging/clear_charging_profile.go
@@ -22,7 +22,7 @@ const (
 
 type ClearChargingProfileType struct {
 	EvseID                 *int                             `json:"evseId,omitempty" validate:"omitempty,gte=0"`
-	ChargingProfilePurpose types.ChargingProfilePurposeType `json:"chargingProfilePurpose,omitempty" validate:"omitempty,chargingProfilePurpose"`
+	ChargingProfilePurpose types.ChargingProfilePurposeType `json:"chargingProfilePurpose,omitempty" validate:"omitempty,chargingProfilePurpose201"`
 	StackLevel             *int                             `json:"stackLevel,omitempty" validate:"omitempty,gt=0"`
 }
 

--- a/ocpp2.0.1/smartcharging/get_charging_profiles.go
+++ b/ocpp2.0.1/smartcharging/get_charging_profiles.go
@@ -33,7 +33,7 @@ func isValidGetChargingProfileStatus(fl validator.FieldLevel) bool {
 // ChargingProfileCriterion specifies the charging profile within a GetChargingProfilesRequest.
 // A ChargingProfile consists of ChargingSchedule, describing the amount of power or current that can be delivered per time interval.
 type ChargingProfileCriterion struct {
-	ChargingProfilePurpose types.ChargingProfilePurposeType `json:"chargingProfilePurpose,omitempty" validate:"omitempty,chargingProfilePurpose"`
+	ChargingProfilePurpose types.ChargingProfilePurposeType `json:"chargingProfilePurpose,omitempty" validate:"omitempty,chargingProfilePurpose201"`
 	StackLevel             *int                             `json:"stackLevel,omitempty" validate:"omitempty,gte=0"`
 	ChargingProfileID      []int                            `json:"chargingProfileId,omitempty" validate:"omitempty"` // This field SHALL NOT contain more ids than set in ChargingProfileEntries.maxLimit
 	ChargingLimitSource    []types.ChargingLimitSourceType  `json:"chargingLimitSource,omitempty" validate:"omitempty,max=4,dive,chargingLimitSource"`

--- a/ocpp2.0.1/smartcharging/get_composite_schedule.go
+++ b/ocpp2.0.1/smartcharging/get_composite_schedule.go
@@ -37,7 +37,7 @@ type CompositeSchedule struct {
 // The field definition of the GetCompositeSchedule request payload sent by the CSMS to the Charging System.
 type GetCompositeScheduleRequest struct {
 	Duration         int                        `json:"duration" validate:"gte=0"`
-	ChargingRateUnit types.ChargingRateUnitType `json:"chargingRateUnit,omitempty" validate:"omitempty,chargingRateUnit"`
+	ChargingRateUnit types.ChargingRateUnitType `json:"chargingRateUnit,omitempty" validate:"omitempty,chargingRateUnit201"`
 	EvseID           int                        `json:"evseId" validate:"gte=0"`
 }
 

--- a/ocpp2.0.1/types/types.go
+++ b/ocpp2.0.1/types/types.go
@@ -247,7 +247,7 @@ type GroupIdToken struct {
 }
 
 type IdTokenInfo struct {
-	Status              AuthorizationStatus `json:"status" validate:"required,authorizationStatus"`
+	Status              AuthorizationStatus `json:"status" validate:"required,authorizationStatus201"`
 	CacheExpiryDateTime *DateTime           `json:"cacheExpiryDateTime,omitempty" validate:"omitempty"`
 	ChargingPriority    int                 `json:"chargingPriority,omitempty" validate:"min=-9,max=9"`
 	Language1           string              `json:"language1,omitempty" validate:"max=8"`
@@ -479,7 +479,7 @@ type ChargingSchedule struct {
 	ID                     int                      `json:"id" validate:"gte=0"` // Identifies the ChargingSchedule.
 	StartSchedule          *DateTime                `json:"startSchedule,omitempty" validate:"omitempty"`
 	Duration               *int                     `json:"duration,omitempty" validate:"omitempty,gte=0"`
-	ChargingRateUnit       ChargingRateUnitType     `json:"chargingRateUnit" validate:"required,chargingRateUnit"`
+	ChargingRateUnit       ChargingRateUnitType     `json:"chargingRateUnit" validate:"required,chargingRateUnit201"`
 	MinChargingRate        *float64                 `json:"minChargingRate,omitempty" validate:"omitempty,gte=0"`
 	ChargingSchedulePeriod []ChargingSchedulePeriod `json:"chargingSchedulePeriod" validate:"required,min=1,max=1024"`
 	SalesTariff            *SalesTariff             `json:"salesTariff,omitempty" validate:"omitempty"` // Sales tariff associated with this charging schedule.
@@ -492,9 +492,9 @@ func NewChargingSchedule(id int, chargingRateUnit ChargingRateUnitType, schedule
 type ChargingProfile struct {
 	ID                     int                        `json:"id" validate:"gte=0"`
 	StackLevel             int                        `json:"stackLevel" validate:"gte=0"`
-	ChargingProfilePurpose ChargingProfilePurposeType `json:"chargingProfilePurpose" validate:"required,chargingProfilePurpose"`
-	ChargingProfileKind    ChargingProfileKindType    `json:"chargingProfileKind" validate:"required,chargingProfileKind"`
-	RecurrencyKind         RecurrencyKindType         `json:"recurrencyKind,omitempty" validate:"omitempty,recurrencyKind"`
+	ChargingProfilePurpose ChargingProfilePurposeType `json:"chargingProfilePurpose" validate:"required,chargingProfilePurpose201"`
+	ChargingProfileKind    ChargingProfileKindType    `json:"chargingProfileKind" validate:"required,chargingProfileKind201"`
+	RecurrencyKind         RecurrencyKindType         `json:"recurrencyKind,omitempty" validate:"omitempty,recurrencyKind201"`
 	ValidFrom              *DateTime                  `json:"validFrom,omitempty"`
 	ValidTo                *DateTime                  `json:"validTo,omitempty"`
 	TransactionID          string                     `json:"transactionId,omitempty" validate:"omitempty,max=36"`
@@ -526,7 +526,6 @@ func isValidRemoteStartStopStatus(fl validator.FieldLevel) bool {
 // Meter Value
 
 type ReadingContext string
-type ValueFormat string
 type Measurand string
 type Phase string
 type Location string
@@ -681,13 +680,13 @@ type SignedMeterValue struct {
 }
 
 type SampledValue struct {
-	Value            float64           `json:"value"`                                                 // Indicates the measured value. This value is required.
-	Context          ReadingContext    `json:"context,omitempty" validate:"omitempty,readingContext"` // Type of detail value: start, end or sample. Default = "Sample.Periodic"
-	Measurand        Measurand         `json:"measurand,omitempty" validate:"omitempty,measurand"`    // Type of measurement. Default = "Energy.Active.Import.Register"
-	Phase            Phase             `json:"phase,omitempty" validate:"omitempty,phase"`            // Indicates how the measured value is to be interpreted. For instance between L1 and neutral (L1-N) Please note that not all values of phase are applicable to all Measurands. When phase is absent, the measured value is interpreted as an overall value.
-	Location         Location          `json:"location,omitempty" validate:"omitempty,location"`      // Indicates where the measured value has been sampled.
-	SignedMeterValue *SignedMeterValue `json:"signedMeterValue,omitempty" validate:"omitempty"`       // Contains the MeterValueSignature with sign/encoding method information.
-	UnitOfMeasure    *UnitOfMeasure    `json:"unitOfMeasure,omitempty" validate:"omitempty"`          // Represents a UnitOfMeasure including a multiplier.
+	Value            float64           `json:"value"`                                                    // Indicates the measured value. This value is required.
+	Context          ReadingContext    `json:"context,omitempty" validate:"omitempty,readingContext201"` // Type of detail value: start, end or sample. Default = "Sample.Periodic"
+	Measurand        Measurand         `json:"measurand,omitempty" validate:"omitempty,measurand201"`    // Type of measurement. Default = "Energy.Active.Import.Register"
+	Phase            Phase             `json:"phase,omitempty" validate:"omitempty,phase201"`            // Indicates how the measured value is to be interpreted. For instance between L1 and neutral (L1-N) Please note that not all values of phase are applicable to all Measurands. When phase is absent, the measured value is interpreted as an overall value.
+	Location         Location          `json:"location,omitempty" validate:"omitempty,location201"`      // Indicates where the measured value has been sampled.
+	SignedMeterValue *SignedMeterValue `json:"signedMeterValue,omitempty" validate:"omitempty"`          // Contains the MeterValueSignature with sign/encoding method information.
+	UnitOfMeasure    *UnitOfMeasure    `json:"unitOfMeasure,omitempty" validate:"omitempty"`             // Represents a UnitOfMeasure including a multiplier.
 }
 
 type MeterValue struct {
@@ -705,18 +704,18 @@ func init() {
 	_ = Validate.RegisterValidation("genericStatus", isValidGenericStatus)
 	_ = Validate.RegisterValidation("hashAlgorithm", isValidHashAlgorithmType)
 	_ = Validate.RegisterValidation("messageFormat", isValidMessageFormatType)
-	_ = Validate.RegisterValidation("authorizationStatus", isValidAuthorizationStatus)
+	_ = Validate.RegisterValidation("authorizationStatus201", isValidAuthorizationStatus)
 	_ = Validate.RegisterValidation("attribute", isValidAttribute)
-	_ = Validate.RegisterValidation("chargingProfilePurpose", isValidChargingProfilePurpose)
-	_ = Validate.RegisterValidation("chargingProfileKind", isValidChargingProfileKind)
-	_ = Validate.RegisterValidation("recurrencyKind", isValidRecurrencyKind)
-	_ = Validate.RegisterValidation("chargingRateUnit", isValidChargingRateUnit)
+	_ = Validate.RegisterValidation("chargingProfilePurpose201", isValidChargingProfilePurpose)
+	_ = Validate.RegisterValidation("chargingProfileKind201", isValidChargingProfileKind)
+	_ = Validate.RegisterValidation("recurrencyKind201", isValidRecurrencyKind)
+	_ = Validate.RegisterValidation("chargingRateUnit201", isValidChargingRateUnit)
 	_ = Validate.RegisterValidation("chargingLimitSource", isValidChargingLimitSource)
-	_ = Validate.RegisterValidation("remoteStartStopStatus", isValidRemoteStartStopStatus)
-	_ = Validate.RegisterValidation("readingContext", isValidReadingContext)
-	_ = Validate.RegisterValidation("measurand", isValidMeasurand)
-	_ = Validate.RegisterValidation("phase", isValidPhase)
-	_ = Validate.RegisterValidation("location", isValidLocation)
+	_ = Validate.RegisterValidation("remoteStartStopStatus201", isValidRemoteStartStopStatus)
+	_ = Validate.RegisterValidation("readingContext201", isValidReadingContext)
+	_ = Validate.RegisterValidation("measurand201", isValidMeasurand)
+	_ = Validate.RegisterValidation("phase201", isValidPhase)
+	_ = Validate.RegisterValidation("location201", isValidLocation)
 	_ = Validate.RegisterValidation("signatureMethod", isValidSignatureMethod)
 	_ = Validate.RegisterValidation("encodingMethod", isValidEncodingMethod)
 	_ = Validate.RegisterValidation("certificateSigningUse", isValidCertificateSigningUse)

--- a/ocpp2.0.1_test/boot_notification_test.go
+++ b/ocpp2.0.1_test/boot_notification_test.go
@@ -63,7 +63,6 @@ func (suite *OcppV2TestSuite) TestBootNotificationE2EMocked() {
 	currentTime := types.NewDateTime(time.Now())
 	requestJson := fmt.Sprintf(`[2,"%v","%v",{"reason":"%v","chargingStation":{"model":"%v","vendorName":"%v"}}]`, messageId, provisioning.BootNotificationFeatureName, reason, chargePointModel, chargePointVendor)
 	responseJson := fmt.Sprintf(`[3,"%v",{"currentTime":"%v","interval":%v,"status":"%v"}]`, messageId, currentTime.FormatTimestamp(), interval, registrationStatus)
-	fmt.Println(responseJson)
 	bootNotificationConfirmation := provisioning.NewBootNotificationResponse(currentTime, interval, registrationStatus)
 	channel := NewMockWebSocket(wsId)
 


### PR DESCRIPTION
Fixes issues caused by common validation keys between the two protocol versions, which would lead one version to override the other, leading to undefined runtime errors.

The change simply splits the offending validation keys into:
- `key16`
- `key201`

therefore solving existing conflicts.