### PR TITLE
fix certificateType on CertificateSignedRequest & GetInstalledCertifi…

### DIFF
--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -297,8 +297,8 @@ func (cs *csms) GetDisplayMessages(clientId string, callback func(*display.GetDi
 	return cs.SendRequestAsync(clientId, request, genericCallback)
 }
 
-func (cs *csms) GetInstalledCertificateIds(clientId string, callback func(*iso15118.GetInstalledCertificateIdsResponse, error), typeOfCertificate types.CertificateUse, props ...func(*iso15118.GetInstalledCertificateIdsRequest)) error {
-	request := iso15118.NewGetInstalledCertificateIdsRequest(typeOfCertificate)
+func (cs *csms) GetInstalledCertificateIds(clientId string, callback func(*iso15118.GetInstalledCertificateIdsResponse, error), props ...func(*iso15118.GetInstalledCertificateIdsRequest)) error {
+	request := iso15118.NewGetInstalledCertificateIdsRequest()
 	for _, fn := range props {
 		fn(request)
 	}

--- a/ocpp2.0.1/iso15118/get_installed_certificate_ids.go
+++ b/ocpp2.0.1/iso15118/get_installed_certificate_ids.go
@@ -31,13 +31,14 @@ func isValidGetInstalledCertificateStatus(fl validator.FieldLevel) bool {
 
 // The field definition of the GetInstalledCertificateIdsRequest PDU sent by the CSMS to the Charging Station.
 type GetInstalledCertificateIdsRequest struct {
-	TypeOfCertificate types.CertificateUse `json:"typeOfCertificate" validate:"required,certificateUse"`
+	CertificateTypes []types.CertificateUse `json:"certificateType" validate:"omitempty,dive,certificateUse"`
 }
 
 // The field definition of the GetInstalledCertificateIds response payload sent by the Charging Station to the CSMS in response to a GetInstalledCertificateIdsRequest.
 type GetInstalledCertificateIdsResponse struct {
-	Status              GetInstalledCertificateStatus `json:"status" validate:"required,getInstalledCertificateStatus"`
-	CertificateHashData []types.CertificateHashData   `json:"certificateHashData,omitempty" validate:"omitempty,dive"`
+	Status                   GetInstalledCertificateStatus    `json:"status" validate:"required,getInstalledCertificateStatus"`
+	StatusInfo               *types.StatusInfo                `json:"statusInfo,omitempty" validate:"omitempty"`
+	CertificateHashDataChain []types.CertificateHashDataChain `json:"certificateHashDataChain,omitempty" validate:"omitempty,dive"`
 }
 
 // To facilitate the management of the Charging Station’s installed certificates, a method of retrieving the installed certificates is provided.
@@ -66,8 +67,8 @@ func (c GetInstalledCertificateIdsResponse) GetFeatureName() string {
 }
 
 // Creates a new GetInstalledCertificateIdsRequest, containing all required fields. There are no optional fields for this message.
-func NewGetInstalledCertificateIdsRequest(typeOfCertificate types.CertificateUse) *GetInstalledCertificateIdsRequest {
-	return &GetInstalledCertificateIdsRequest{TypeOfCertificate: typeOfCertificate}
+func NewGetInstalledCertificateIdsRequest() *GetInstalledCertificateIdsRequest {
+	return &GetInstalledCertificateIdsRequest{}
 }
 
 // Creates a new NewGetInstalledCertificateIdsResponse, containing all required fields. Additional optional fields may be set afterwards.

--- a/ocpp2.0.1/security/certificate_signed.go
+++ b/ocpp2.0.1/security/certificate_signed.go
@@ -33,7 +33,7 @@ func isValidCertificateSignedStatus(fl validator.FieldLevel) bool {
 // The field definition of the CertificateSignedRequest PDU sent by the CSMS to the Charging Station.
 type CertificateSignedRequest struct {
 	CertificateChain  string                      `json:"certificateChain" validate:"required,max=10000"`
-	TypeOfCertificate types.CertificateSigningUse `json:"typeOfCertificate,omitempty" validate:"omitempty,certificateSigningUse"`
+	TypeOfCertificate types.CertificateSigningUse `json:"certificateType,omitempty" validate:"omitempty,certificateSigningUse"`
 }
 
 // The field definition of the CertificateSignedResponse payload sent by the Charging Station to the CSMS in response to a CertificateSignedRequest.

--- a/ocpp2.0.1/types/types.go
+++ b/ocpp2.0.1/types/types.go
@@ -154,6 +154,13 @@ type CertificateHashData struct {
 	SerialNumber   string            `json:"serialNumber" validate:"required,max=20"`
 }
 
+// CertificateHashDataChain
+type CertificateHashDataChain struct {
+	CertificateType          CertificateUse        `json:"certificateType" validate:"required,certificateUse"`
+	CertificateHashData      CertificateHashData   `json:"certificateHashData" validate:"required"`
+	ChildCertificateHashData []CertificateHashData `json:"childCertificateHashData,omitempty" validate:"omitempty,dive"`
+}
+
 // Certificate15118EVStatus
 type Certificate15118EVStatus string
 
@@ -202,13 +209,14 @@ const (
 	CSOSubCA1                   CertificateUse = "CSOSubCA1"
 	CSOSubCA2                   CertificateUse = "CSOSubCA2"
 	CSMSRootCertificate         CertificateUse = "CSMSRootCertificate"
+	V2GCertificateChain         CertificateUse = "V2GCertificateChain"
 	ManufacturerRootCertificate CertificateUse = "ManufacturerRootCertificate"
 )
 
 func isValidCertificateUse(fl validator.FieldLevel) bool {
 	use := CertificateUse(fl.Field().String())
 	switch use {
-	case V2GRootCertificate, MORootCertificate, CSOSubCA1, CSOSubCA2, CSMSRootCertificate, ManufacturerRootCertificate:
+	case V2GRootCertificate, MORootCertificate, CSOSubCA1, CSOSubCA2, CSMSRootCertificate, V2GCertificateChain, ManufacturerRootCertificate:
 		return true
 	default:
 		return false

--- a/ocpp2.0.1/v2.go
+++ b/ocpp2.0.1/v2.go
@@ -284,7 +284,7 @@ type CSMS interface {
 	// Retrieves all messages currently configured on a charging station.
 	GetDisplayMessages(clientId string, callback func(*display.GetDisplayMessagesResponse, error), requestId int, props ...func(*display.GetDisplayMessagesRequest)) error
 	// Retrieves all installed certificates on a charging station.
-	GetInstalledCertificateIds(clientId string, callback func(*iso15118.GetInstalledCertificateIdsResponse, error), typeOfCertificate types.CertificateUse, props ...func(*iso15118.GetInstalledCertificateIdsRequest)) error
+	GetInstalledCertificateIds(clientId string, callback func(*iso15118.GetInstalledCertificateIdsResponse, error), props ...func(*iso15118.GetInstalledCertificateIdsRequest)) error
 	// Queries a charging station for version number of the Local Authorization List.
 	GetLocalListVersion(clientId string, callback func(*localauth.GetLocalListVersionResponse, error), props ...func(*localauth.GetLocalListVersionRequest)) error
 	// Instructs a charging station to upload a diagnostics or security logfile to the CSMS.

--- a/ocpp2.0.1_test/certificate_signed_test.go
+++ b/ocpp2.0.1_test/certificate_signed_test.go
@@ -46,7 +46,7 @@ func (suite *OcppV2TestSuite) TestCertificateSignedE2EMocked() {
 	certificateChain := "someX509CertificateChain"
 	certificateType := types.ChargingStationCert
 	status := security.CertificateSignedStatusAccepted
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificateChain":"%v","typeOfCertificate":"%v"}]`,
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificateChain":"%v","certificateType":"%v"}]`,
 		messageId, security.CertificateSignedFeatureName, certificateChain, certificateType)
 	responseJson := fmt.Sprintf(`[3,"%v",{"status":"%v"}]`, messageId, status)
 	certificateSignedConfirmation := security.NewCertificateSignedResponse(status)
@@ -85,6 +85,6 @@ func (suite *OcppV2TestSuite) TestCertificateSignedInvalidEndpoint() {
 	certificateType := types.ChargingStationCert
 	certificateSignedRequest := security.NewCertificateSignedRequest(certificate)
 	certificateSignedRequest.TypeOfCertificate = certificateType
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificateChain":"%v","typeOfCertificate":"%v"}]`, messageId, security.CertificateSignedFeatureName, certificate, certificateType)
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificateChain":"%v","certificateType":"%v"}]`, messageId, security.CertificateSignedFeatureName, certificate, certificateType)
 	testUnsupportedRequestFromChargingStation(suite, certificateSignedRequest, requestJson, messageId)
 }

--- a/ocpp2.0.1_test/get_installed_certificate_ids_test.go
+++ b/ocpp2.0.1_test/get_installed_certificate_ids_test.go
@@ -14,14 +14,14 @@ import (
 func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsRequestValidation() {
 	t := suite.T()
 	var testTable = []GenericTestEntry{
-		{iso15118.GetInstalledCertificateIdsRequest{TypeOfCertificate: types.V2GRootCertificate}, true},
-		{iso15118.GetInstalledCertificateIdsRequest{TypeOfCertificate: types.MORootCertificate}, true},
-		{iso15118.GetInstalledCertificateIdsRequest{TypeOfCertificate: types.CSOSubCA1}, true},
-		{iso15118.GetInstalledCertificateIdsRequest{TypeOfCertificate: types.CSOSubCA2}, true},
-		{iso15118.GetInstalledCertificateIdsRequest{TypeOfCertificate: types.CSMSRootCertificate}, true},
-		{iso15118.GetInstalledCertificateIdsRequest{TypeOfCertificate: types.ManufacturerRootCertificate}, true},
-		{iso15118.GetInstalledCertificateIdsRequest{}, false},
-		{iso15118.GetInstalledCertificateIdsRequest{TypeOfCertificate: "invalidCertificateUse"}, false},
+		{iso15118.GetInstalledCertificateIdsRequest{CertificateTypes: []types.CertificateUse{types.V2GRootCertificate}}, true},
+		{iso15118.GetInstalledCertificateIdsRequest{CertificateTypes: []types.CertificateUse{types.MORootCertificate}}, true},
+		{iso15118.GetInstalledCertificateIdsRequest{CertificateTypes: []types.CertificateUse{types.CSOSubCA1}}, true},
+		{iso15118.GetInstalledCertificateIdsRequest{CertificateTypes: []types.CertificateUse{types.CSOSubCA2}}, true},
+		{iso15118.GetInstalledCertificateIdsRequest{CertificateTypes: []types.CertificateUse{types.CSMSRootCertificate}}, true},
+		{iso15118.GetInstalledCertificateIdsRequest{CertificateTypes: []types.CertificateUse{types.ManufacturerRootCertificate}}, true},
+		{iso15118.GetInstalledCertificateIdsRequest{}, true},
+		{iso15118.GetInstalledCertificateIdsRequest{CertificateTypes: []types.CertificateUse{"invalidCertificateUse"}}, false},
 	}
 	ExecuteGenericTestTable(t, testTable)
 }
@@ -29,13 +29,13 @@ func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsRequestValidation() 
 func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsConfirmationValidation() {
 	t := suite.T()
 	var testTable = []GenericTestEntry{
-		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusAccepted, CertificateHashData: []types.CertificateHashData{{HashAlgorithm: types.SHA256, IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"}}}, true},
-		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusNotFound, CertificateHashData: []types.CertificateHashData{{HashAlgorithm: types.SHA256, IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"}}}, true},
-		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusAccepted, CertificateHashData: []types.CertificateHashData{}}, true},
+		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusAccepted, CertificateHashDataChain: []types.CertificateHashDataChain{{CertificateType: types.CSMSRootCertificate, CertificateHashData: types.CertificateHashData{HashAlgorithm: types.SHA256, IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"}}}}, true},
+		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusNotFound, CertificateHashDataChain: []types.CertificateHashDataChain{{CertificateType: types.CSMSRootCertificate, CertificateHashData: types.CertificateHashData{HashAlgorithm: types.SHA256, IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"}}}}, true},
+		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusAccepted, CertificateHashDataChain: []types.CertificateHashDataChain{}}, true},
 		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusAccepted}, true},
 		{iso15118.GetInstalledCertificateIdsResponse{}, false},
 		{iso15118.GetInstalledCertificateIdsResponse{Status: "invalidGetInstalledCertificateStatus"}, false},
-		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusAccepted, CertificateHashData: []types.CertificateHashData{{HashAlgorithm: "invalidHashAlgorithm", IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"}}}, false},
+		{iso15118.GetInstalledCertificateIdsResponse{Status: iso15118.GetInstalledCertificateStatusAccepted, CertificateHashDataChain: []types.CertificateHashDataChain{{CertificateType: types.CSMSRootCertificate, CertificateHashData: types.CertificateHashData{HashAlgorithm: "invalidHashAlgorithm", IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"}}}}, false},
 	}
 	ExecuteGenericTestTable(t, testTable)
 }
@@ -46,16 +46,16 @@ func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsE2EMocked() {
 	wsId := "test_id"
 	messageId := defaultMessageId
 	wsUrl := "someUrl"
-	certificateType := types.CSMSRootCertificate
+	certificateTypes := []types.CertificateUse{types.CSMSRootCertificate}
 	status := iso15118.GetInstalledCertificateStatusAccepted
-	certificateHashData := []types.CertificateHashData{
-		{HashAlgorithm: types.SHA256, IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"},
+	certificateHashDataChain := []types.CertificateHashDataChain{
+		{CertificateType: types.CSMSRootCertificate, CertificateHashData: types.CertificateHashData{HashAlgorithm: types.SHA256, IssuerNameHash: "name0", IssuerKeyHash: "key0", SerialNumber: "serial0"}},
 	}
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"typeOfCertificate":"%v"}]`, messageId, iso15118.GetInstalledCertificateIdsFeatureName, certificateType)
-	responseJson := fmt.Sprintf(`[3,"%v",{"status":"%v","certificateHashData":[{"hashAlgorithm":"%v","issuerNameHash":"%v","issuerKeyHash":"%v","serialNumber":"%v"}]}]`,
-		messageId, status, certificateHashData[0].HashAlgorithm, certificateHashData[0].IssuerNameHash, certificateHashData[0].IssuerKeyHash, certificateHashData[0].SerialNumber)
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificateType":["%v"]}]`, messageId, iso15118.GetInstalledCertificateIdsFeatureName, certificateTypes[0])
+	responseJson := fmt.Sprintf(`[3,"%v",{"status":"%v","certificateHashDataChain":[{"certificateType":"%v","certificateHashData":{"hashAlgorithm":"%v","issuerNameHash":"%v","issuerKeyHash":"%v","serialNumber":"%v"}}]}]`,
+		messageId, status, certificateHashDataChain[0].CertificateType, certificateHashDataChain[0].CertificateHashData.HashAlgorithm, certificateHashDataChain[0].CertificateHashData.IssuerNameHash, certificateHashDataChain[0].CertificateHashData.IssuerKeyHash, certificateHashDataChain[0].CertificateHashData.SerialNumber)
 	getInstalledCertificateIdsConfirmation := iso15118.NewGetInstalledCertificateIdsResponse(status)
-	getInstalledCertificateIdsConfirmation.CertificateHashData = certificateHashData
+	getInstalledCertificateIdsConfirmation.CertificateHashDataChain = certificateHashDataChain
 	channel := NewMockWebSocket(wsId)
 	// Setting handlers
 	handler := &MockChargingStationIso15118Handler{}
@@ -63,7 +63,7 @@ func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsE2EMocked() {
 		request, ok := args.Get(0).(*iso15118.GetInstalledCertificateIdsRequest)
 		require.True(t, ok)
 		require.NotNil(t, request)
-		assert.Equal(t, certificateType, request.TypeOfCertificate)
+		assert.Equal(t, certificateTypes, request.CertificateTypes)
 	})
 	setupDefaultCSMSHandlers(suite, expectedCSMSOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargingStationHandlers(suite, expectedChargingStationOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true}, handler)
@@ -76,13 +76,15 @@ func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsE2EMocked() {
 		require.Nil(t, err)
 		require.NotNil(t, confirmation)
 		assert.Equal(t, status, confirmation.Status)
-		require.Len(t, confirmation.CertificateHashData, len(certificateHashData))
-		assert.Equal(t, certificateHashData[0].HashAlgorithm, confirmation.CertificateHashData[0].HashAlgorithm)
-		assert.Equal(t, certificateHashData[0].IssuerNameHash, confirmation.CertificateHashData[0].IssuerNameHash)
-		assert.Equal(t, certificateHashData[0].IssuerKeyHash, confirmation.CertificateHashData[0].IssuerKeyHash)
-		assert.Equal(t, certificateHashData[0].SerialNumber, confirmation.CertificateHashData[0].SerialNumber)
+		require.Len(t, confirmation.CertificateHashDataChain, len(certificateHashDataChain))
+		assert.Equal(t, certificateHashDataChain[0].CertificateHashData.HashAlgorithm, confirmation.CertificateHashDataChain[0].CertificateHashData.HashAlgorithm)
+		assert.Equal(t, certificateHashDataChain[0].CertificateHashData.IssuerNameHash, confirmation.CertificateHashDataChain[0].CertificateHashData.IssuerNameHash)
+		assert.Equal(t, certificateHashDataChain[0].CertificateHashData.IssuerKeyHash, confirmation.CertificateHashDataChain[0].CertificateHashData.IssuerKeyHash)
+		assert.Equal(t, certificateHashDataChain[0].CertificateHashData.SerialNumber, confirmation.CertificateHashDataChain[0].CertificateHashData.SerialNumber)
 		resultChannel <- true
-	}, certificateType)
+	}, func(request *iso15118.GetInstalledCertificateIdsRequest) {
+		request.CertificateTypes = certificateTypes
+	})
 	require.Nil(t, err)
 	result := <-resultChannel
 	assert.True(t, result)
@@ -90,8 +92,9 @@ func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsE2EMocked() {
 
 func (suite *OcppV2TestSuite) TestGetInstalledCertificateIdsInvalidEndpoint() {
 	messageId := defaultMessageId
-	certificateType := types.CSMSRootCertificate
-	GetInstalledCertificateIdsRequest := iso15118.NewGetInstalledCertificateIdsRequest(certificateType)
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"typeOfCertificate":"%v"}]`, messageId, iso15118.GetInstalledCertificateIdsFeatureName, certificateType)
+	certificateTypes := []types.CertificateUse{types.CSMSRootCertificate}
+	GetInstalledCertificateIdsRequest := iso15118.NewGetInstalledCertificateIdsRequest()
+	GetInstalledCertificateIdsRequest.CertificateTypes = certificateTypes
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificateType":["%v"]}]`, messageId, iso15118.GetInstalledCertificateIdsFeatureName, certificateTypes[0])
 	testUnsupportedRequestFromChargingStation(suite, GetInstalledCertificateIdsRequest, requestJson, messageId)
 }


### PR DESCRIPTION
Hello,

I just split PR that referring to this PR review: https://github.com/lorenzodonini/ocpp-go/pull/202#discussion_r1245696628

Changes:
- fix `typeOfCertificate` to `certificateType` on `CertificateSignedRequest`
-  fix `typeOfCertificate` to `certificateType` and modify field `certificateType` to array (base on json schema) on `GetInstalledCertificateIdsRequest`
- Add field `certificateHashDataChain` that contain array of `certificateHashData` on `GetInstalledCertificateIdsResponse` (base on json schema)


Thx