### PR TITLE
Use FormatViolation error code in v2.0.1

### DIFF
--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -404,6 +404,9 @@ func (cs *centralSystem) SendRequestAsync(clientId string, request ocpp.Request,
 }
 
 func (cs *centralSystem) Start(listenPort int, listenPath string) {
+	// Overriding some protocol-specific values in the lower layers globally
+	ocppj.FormationViolation = ocppj.FormatViolationV16
+	// Start server
 	cs.server.Start(listenPort, listenPath)
 }
 

--- a/ocpp1.6/charge_point.go
+++ b/ocpp1.6/charge_point.go
@@ -329,9 +329,12 @@ func (cp *chargePoint) sendResponse(confirmation ocpp.Response, err error, reque
 }
 
 func (cp *chargePoint) Start(centralSystemUrl string) error {
+	// Overriding some protocol-specific values in the lower layers globally
+	ocppj.FormationViolation = ocppj.FormatViolationV16
+	// Start client
 	cp.stopC = make(chan struct{}, 1)
-	// Async response handler receives incoming responses/errors and triggers callbacks
 	err := cp.client.Start(centralSystemUrl)
+	// Async response handler receives incoming responses/errors and triggers callbacks
 	if err == nil {
 		go cp.asyncCallbackHandler()
 	}

--- a/ocpp1.6_test/proto_test.go
+++ b/ocpp1.6_test/proto_test.go
@@ -152,3 +152,10 @@ func (suite *OcppV16TestSuite) TestCentralSystemSendResponseError() {
 	assert.Equal(t, ocppj.GenericError, ocppErr.Code)
 	assert.Equal(t, fmt.Sprintf("empty confirmation to %s for request 1234", wsId), ocppErr.Description)
 }
+
+func (suite *OcppV16TestSuite) TestErrorCodes() {
+	t := suite.T()
+	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
+	suite.centralSystem.Start(8887, "somePath")
+	assert.Equal(t, ocppj.FormatViolationV16, ocppj.FormationViolation)
+}

--- a/ocpp2.0.1/charging_station.go
+++ b/ocpp2.0.1/charging_station.go
@@ -589,9 +589,12 @@ func (cs *chargingStation) sendResponse(response ocpp.Response, err error, reque
 }
 
 func (cs *chargingStation) Start(csmsUrl string) error {
+	// Overriding some protocol-specific values in the lower layers globally
+	ocppj.FormationViolation = ocppj.FormatViolationV2
+	// Start client
 	cs.stopC = make(chan struct{}, 1)
-	// Async response handler receives incoming responses/errors and triggers callbacks
 	err := cs.client.Start(csmsUrl)
+	// Async response handler receives incoming responses/errors and triggers callbacks
 	if err == nil {
 		go cs.asyncCallbackHandler()
 	}

--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -810,6 +810,9 @@ func (cs *csms) SendRequestAsync(clientId string, request ocpp.Request, callback
 }
 
 func (cs *csms) Start(listenPort int, listenPath string) {
+	// Overriding some protocol-specific values in the lower layers globally
+	ocppj.FormationViolation = ocppj.FormatViolationV2
+	// Start server
 	cs.server.Start(listenPort, listenPath)
 }
 

--- a/ocpp2.0.1_test/proto_test.go
+++ b/ocpp2.0.1_test/proto_test.go
@@ -157,3 +157,10 @@ func (suite *OcppV2TestSuite) TestCentralSystemSendResponseError() {
 	assert.Equal(t, ocppj.GenericError, ocppErr.Code)
 	assert.Equal(t, fmt.Sprintf("empty response to %s for request 1234", wsId), ocppErr.Description)
 }
+
+func (suite *OcppV2TestSuite) TestErrorCodes() {
+	t := suite.T()
+	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
+	suite.csms.Start(8887, "somePath")
+	assert.Equal(t, ocppj.FormatViolationV2, ocppj.FormationViolation)
+}

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -190,11 +190,16 @@ const (
 	MessageTypeNotSupported       ocpp.ErrorCode = "MessageTypeNotSupported"       // A message with an Message Type Number received that is not supported by this implementation.
 	ProtocolError                 ocpp.ErrorCode = "ProtocolError"                 // Payload for Action is incomplete.
 	SecurityError                 ocpp.ErrorCode = "SecurityError"                 // During the processing of Action a security issue occurred preventing receiver from completing the Action successfully.
-	FormationViolation            ocpp.ErrorCode = "FormationViolation"            // Payload for Action is syntactically incorrect or not conform the PDU structure for Action.
 	PropertyConstraintViolation   ocpp.ErrorCode = "PropertyConstraintViolation"   // Payload is syntactically correct but at least one field contains an invalid value.
 	OccurrenceConstraintViolation ocpp.ErrorCode = "OccurrenceConstraintViolation" // Payload for Action is syntactically correct but at least one of the fields violates occurrence constraints.
 	TypeConstraintViolation       ocpp.ErrorCode = "TypeConstraintViolation"       // Payload for Action is syntactically correct but at least one of the fields violates data type constraints (e.g. “somestring”: 12).
 	GenericError                  ocpp.ErrorCode = "GenericError"                  // Any other error not covered by the previous ones.
+	FormatViolationV2             ocpp.ErrorCode = "FormatViolation"               // Payload for Action is syntactically incorrect. This is only valid for OCPP 2.0.1
+	FormatViolationV16            ocpp.ErrorCode = "FormationViolation"            // Payload for Action is syntactically incorrect or not conform the PDU structure for Action. This is only valid for OCPP 1.6
+)
+
+var (
+	FormationViolation = FormatViolationV16 // Used as constant, but can be overwritten depending on protocol version. Sett FormatViolationV16 and FormatViolationV2.
 )
 
 func IsErrorCodeValid(fl validator.FieldLevel) bool {


### PR DESCRIPTION
Makes the `ocppj.FormationViolation` error code a variable, which will be set dynamically by the respective protocol:
- `FormationViolation` for v1.6
- `FormatViolation` for v2.0.1