### PR TITLE
The serialNumber of CertificateHashData's valiation shoulde be max 40 instead of 20

### DIFF
--- a/ocpp2.0.1/types/types.go
+++ b/ocpp2.0.1/types/types.go
@@ -142,7 +142,7 @@ type OCSPRequestDataType struct {
 	HashAlgorithm  HashAlgorithmType `json:"hashAlgorithm" validate:"required,hashAlgorithm"`
 	IssuerNameHash string            `json:"issuerNameHash" validate:"required,max=128"`
 	IssuerKeyHash  string            `json:"issuerKeyHash" validate:"required,max=128"`
-	SerialNumber   string            `json:"serialNumber" validate:"required,max=20"`
+	SerialNumber   string            `json:"serialNumber" validate:"required,max=40"`
 	ResponderURL   string            `json:"responderURL,omitempty" validate:"max=512"`
 }
 

--- a/ocpp2.0.1/types/types.go
+++ b/ocpp2.0.1/types/types.go
@@ -151,7 +151,7 @@ type CertificateHashData struct {
 	HashAlgorithm  HashAlgorithmType `json:"hashAlgorithm" validate:"required,hashAlgorithm"`
 	IssuerNameHash string            `json:"issuerNameHash" validate:"required,max=128"`
 	IssuerKeyHash  string            `json:"issuerKeyHash" validate:"required,max=128"`
-	SerialNumber   string            `json:"serialNumber" validate:"required,max=20"`
+	SerialNumber   string            `json:"serialNumber" validate:"required,max=40"`
 }
 
 // CertificateHashDataChain


### PR DESCRIPTION
According to the schema of OCPP, the maximum length of serialNumber in CertificateHashData should be 40, and here is the screenshot of schema.
![image](https://github.com/lorenzodonini/ocpp-go/assets/14171595/8fea461e-f899-40da-ad8d-4efb3542e22d)

