### PR TITLE
Handle incoming invalid messages

### DIFF
--- a/ocppj/central_system_test.go
+++ b/ocppj/central_system_test.go
@@ -92,7 +92,7 @@ func (suite *OcppJTestSuite) TestCentralSystemSendRequestNoValidation() {
 	assert.Nil(suite.T(), err)
 }
 
-func (suite *OcppJTestSuite) TestServerSendInvalidJsonRequest() {
+func (suite *OcppJTestSuite) TestCentralSystemSendInvalidJsonRequest() {
 	mockChargePointId := "1234"
 	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	suite.mockServer.On("Write", mockChargePointId, mock.Anything).Return(nil)
@@ -103,6 +103,65 @@ func (suite *OcppJTestSuite) TestServerSendInvalidJsonRequest() {
 	err := suite.centralSystem.SendRequest(mockChargePointId, mockRequest)
 	require.Error(suite.T(), err)
 	assert.IsType(suite.T(), &json.UnsupportedTypeError{}, err)
+}
+
+func (suite *OcppJTestSuite) TestCentralSystemInvalidMessageHook() {
+	t := suite.T()
+	mockChargePointId := "1234"
+	mockChargePoint := NewMockWebSocket(mockChargePointId)
+	// Prepare invalid payload
+	mockID := "1234"
+	mockPayload := map[string]interface{}{
+		"mockValue": float64(1234),
+	}
+	serializedPayload, err := json.Marshal(mockPayload)
+	require.NoError(t, err)
+	invalidMessage := fmt.Sprintf("[2,\"%v\",\"%s\",%v]", mockID, MockFeatureName, string(serializedPayload))
+	expectedError := fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockID, ocppj.FormationViolation, "json: cannot unmarshal number into Go struct field MockRequest.mockValue of type string")
+	writeHook := suite.mockServer.On("Write", mockChargePointId, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		data := args.Get(1).([]byte)
+		assert.Equal(t, expectedError, string(data))
+	})
+	suite.mockServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
+	// Setup hook 1
+	suite.centralSystem.SetInvalidMessageHook(func(client ws.Channel, err *ocpp.Error, rawMessage string, parsedFields []interface{}) *ocpp.Error {
+		assert.Equal(t, mockChargePoint.ID(), client.ID())
+		// Verify the correct fields are passed to the hook. Content is very low-level, since parsing failed
+		assert.Equal(t, float64(ocppj.CALL), parsedFields[0])
+		assert.Equal(t, mockID, parsedFields[1])
+		assert.Equal(t, MockFeatureName, parsedFields[2])
+		assert.Equal(t, mockPayload, parsedFields[3])
+		return nil
+	})
+	suite.centralSystem.Start(8887, "/{ws}")
+	// Trigger incoming invalid CALL
+	err = suite.mockServer.MessageHandler(mockChargePoint, []byte(invalidMessage))
+	ocppErr, ok := err.(*ocpp.Error)
+	require.True(t, ok)
+	assert.Equal(t, ocppj.FormationViolation, ocppErr.Code)
+	// Setup hook 2
+	mockError := ocpp.NewError(ocppj.InternalError, "custom error", mockID)
+	expectedError = fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockError.MessageId, mockError.Code, mockError.Description)
+	writeHook.Run(func(args mock.Arguments) {
+		data := args.Get(1).([]byte)
+		assert.Equal(t, expectedError, string(data))
+	})
+	suite.centralSystem.SetInvalidMessageHook(func(client ws.Channel, err *ocpp.Error, rawMessage string, parsedFields []interface{}) *ocpp.Error {
+		assert.Equal(t, mockChargePoint.ID(), client.ID())
+		// Verify the correct fields are passed to the hook. Content is very low-level, since parsing failed
+		assert.Equal(t, float64(ocppj.CALL), parsedFields[0])
+		assert.Equal(t, mockID, parsedFields[1])
+		assert.Equal(t, MockFeatureName, parsedFields[2])
+		assert.Equal(t, mockPayload, parsedFields[3])
+		return mockError
+	})
+	// Trigger incoming invalid CALL that returns custom error
+	err = suite.mockServer.MessageHandler(mockChargePoint, []byte(invalidMessage))
+	ocppErr, ok = err.(*ocpp.Error)
+	require.True(t, ok)
+	assert.Equal(t, mockError.Code, ocppErr.Code)
+	assert.Equal(t, mockError.Description, ocppErr.Description)
+	assert.Equal(t, mockError.MessageId, ocppErr.MessageId)
 }
 
 func (suite *OcppJTestSuite) TestServerSendInvalidCall() {

--- a/ocppj/server.go
+++ b/ocppj/server.go
@@ -20,6 +20,7 @@ type Server struct {
 	requestHandler            RequestHandler
 	responseHandler           ResponseHandler
 	errorHandler              ErrorHandler
+	invalidMessageHook        InvalidMessageHook
 	dispatcher                ServerDispatcher
 	RequestState              ServerState
 }
@@ -28,6 +29,7 @@ type ClientHandler func(client ws.Channel)
 type RequestHandler func(client ws.Channel, request ocpp.Request, requestId string, action string)
 type ResponseHandler func(client ws.Channel, response ocpp.Response, requestId string)
 type ErrorHandler func(client ws.Channel, err *ocpp.Error, details interface{})
+type InvalidMessageHook func(client ws.Channel, err *ocpp.Error, rawJson string, parsedFields []interface{}) *ocpp.Error
 
 // Creates a new Server endpoint.
 // Requires a a websocket server. Optionally a structure for queueing/dispatching requests,
@@ -77,6 +79,24 @@ func (s *Server) SetResponseHandler(handler ResponseHandler) {
 // Registers a handler for incoming error messages.
 func (s *Server) SetErrorHandler(handler ErrorHandler) {
 	s.errorHandler = handler
+}
+
+// SetInvalidMessageHook registers an optional hook for incoming messages that couldn't be parsed.
+// This hook is called when a message is received but cannot be parsed to the target OCPP message struct.
+//
+// The application is notified synchronously of the error.
+// The callback provides the raw JSON string, along with the parsed fields.
+// The application MUST return as soon as possible, since the hook is called synchronously and awaits a return value.
+//
+// The hook does not allow responding to the message directly,
+// but the return value will be used to send an OCPP error to the other endpoint.
+//
+// If no handler is registered (or no error is returned by the hook),
+// the internal error message is sent to the client without further processing.
+//
+// Note: Failing to return from the hook will cause the handler for this client to block indefinitely.
+func (s *Server) SetInvalidMessageHook(hook InvalidMessageHook) {
+	s.invalidMessageHook = hook
 }
 
 // Registers a handler for canceled request messages.
@@ -221,6 +241,18 @@ func (s *Server) ocppMessageHandler(wsChannel ws.Channel, data []byte) error {
 	message, err := s.ParseMessage(parsedJson, pending)
 	if err != nil {
 		ocppErr := err.(*ocpp.Error)
+		messageID := ocppErr.MessageId
+		// Support ad-hoc callback for invalid message handling
+		if s.invalidMessageHook != nil {
+			err2 := s.invalidMessageHook(wsChannel, ocppErr, string(data), parsedJson)
+			// If the hook returns an error, use it as output error. If not, use the original error.
+			if err2 != nil {
+				ocppErr = err2
+				ocppErr.MessageId = messageID
+			}
+		}
+		err = ocppErr
+		// Send error to other endpoint if a message ID is available
 		if ocppErr.MessageId != "" {
 			err2 := s.SendError(wsChannel.ID(), ocppErr.MessageId, ocppErr.Code, ocppErr.Description, nil)
 			if err2 != nil {
@@ -235,7 +267,9 @@ func (s *Server) ocppMessageHandler(wsChannel ws.Channel, data []byte) error {
 		case CALL:
 			call := message.(*Call)
 			log.Debugf("handling incoming CALL [%s, %s] from %s", call.UniqueId, call.Action, wsChannel.ID())
-			s.requestHandler(wsChannel, call.Payload, call.UniqueId, call.Action)
+			if s.requestHandler != nil {
+				s.requestHandler(wsChannel, call.Payload, call.UniqueId, call.Action)
+			}
 		case CALL_RESULT:
 			callResult := message.(*CallResult)
 			log.Debugf("handling incoming CALL RESULT [%s] from %s", callResult.UniqueId, wsChannel.ID())


### PR DESCRIPTION
Adds a hook for client and servers to support custom handling of incoming invalid messages. 

This refers to invalid payloads only:
- if the message is malformed, the hook won't be invoked
- if the payload is not conform to the specified feature name, the hook will be invoked

The hooks are completely optional and may be set as follows:
```go
// Client
ocppjClient.SetInvalidMessageHook(func(err *ocpp.Error, rawMessage string, parsedFields []interface{}) *ocpp.Error {
     // custom handling
     return ocpp.NewError(...) // if no error override is necessary, nil can be returned
})

// Server
ocppjServer.SetInvalidMessageHook(func(client ws.Channel, err *ocpp.Error, rawMessage string, parsedFields []interface{}) *ocpp.Error {
     // custom handling
     return ocpp.NewError(...) // if no error override is necessary, nil can be returned
}
```

If set, a hook MUST return a value as soon as possible, as the function call blocks the main routine from receiving any other messages.

If the returned value is `nil` the internal error will be sent back to the other endpoint.
If the returned value is actually a valid error, it will be sent back to the other endpoint instead of the internally generated error.

Addresses the issue described [here](https://github.com/lorenzodonini/ocpp-go/issues/188#issuecomment-1533427383).