### PR TITLE
check type on action in call and add test

### DIFF
--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -394,7 +394,11 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 		if len(arr) != 4 {
 			return nil, ocpp.NewError(FormationViolation, "Invalid Call message. Expected array length 4", uniqueId)
 		}
-		action := arr[2].(string)
+		action, ok := arr[2].(string)
+		if !ok {
+			return nil, ocpp.NewError(FormationViolation, fmt.Sprintf("Invalid element %v at 2, expected action (string)", arr[2]), "")
+		}
+
 		profile, ok := endpoint.GetProfileForFeature(action)
 		if !ok {
 			return nil, ocpp.NewError(NotSupported, fmt.Sprintf("Unsupported feature %v", action), uniqueId)

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -629,6 +629,26 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidCall() {
 	assert.Equal(t, "Invalid Call message. Expected array length 4", protoErr.Description)
 }
 
+func (suite *OcppJTestSuite) TestParseMessageInvalidActionCall() {
+	t := suite.T()
+	mockMessage := make([]interface{}, 4)
+	messageId := "12345"
+	mockRequest := newMockRequest("")
+	// Test invalid message length
+	mockMessage[0] = float64(ocppj.CALL) // Message Type ID
+	mockMessage[1] = messageId           // Unique ID
+	mockMessage[2] = float64(42)         // Wrong type on action parameter
+	mockMessage[3] = mockRequest
+	message, err := suite.chargePoint.ParseMessage(mockMessage, suite.chargePoint.RequestState)
+	require.Nil(t, message)
+	require.Error(t, err)
+	protoErr := err.(*ocpp.Error)
+	require.NotNil(t, protoErr)
+	assert.Equal(t, protoErr.MessageId, "") // unique id is never set after invalid type cast return
+	assert.Equal(t, ocppj.FormationViolation, protoErr.Code)
+	assert.Equal(t, "Invalid element 42 at 2, expected action (string)", protoErr.Description)
+}
+
 func (suite *OcppJTestSuite) TestParseMessageInvalidCallResult() {
 	t := suite.T()
 	mockMessage := make([]interface{}, 3)


### PR DESCRIPTION
Check the type of the action parameter to prevent crashes from a bad call.