### PR TITLE
Altered auto-reconnection attempt logic to comply with part 4 of the OCPP2.0.1 standard

### DIFF
--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -985,7 +985,7 @@ func (client *Client) cleanup() {
 
 func (client *Client) handleReconnection() {
 	log.Info("started automatic reconnection handler")
-	delay := client.timeoutConfig.RetryBackOffWaitMinimum + time.Duration(rand.Intn(client.timeoutConfig.RetryBackOffRandomRange+1))
+	delay := client.timeoutConfig.RetryBackOffWaitMinimum + time.Duration(rand.Intn(client.timeoutConfig.RetryBackOffRandomRange+1))*time.Second
 	reconnectionAttempts := 1
 	for {
 		// Wait before reconnecting
@@ -1009,6 +1009,7 @@ func (client *Client) handleReconnection() {
 		if reconnectionAttempts < client.timeoutConfig.RetryBackOffRepeatTimes {
 			// Re-connection failed, double the delay
 			delay *= 2
+			delay += time.Duration(rand.Intn(client.timeoutConfig.RetryBackOffRandomRange+1)) * time.Second
 		}
 		reconnectionAttempts += 1
 	}

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -1006,7 +1006,7 @@ func (client *Client) handleReconnection() {
 		}
 		client.error(fmt.Errorf("reconnection failed: %w", err))
 
-		if reconnectionAttempts > client.timeoutConfig.RetryBackOffRepeatTimes {
+		if reconnectionAttempts < client.timeoutConfig.RetryBackOffRepeatTimes {
 			// Re-connection failed, double the delay
 			delay *= 2
 		}


### PR DESCRIPTION
According to part 4 of the OCPP2.0.1 standard: *JSON over WebSockets implementation guide*, section **5.3. Reconnecting**,  there are some configuration variables, specifically:

- RetryBackOffRepeatTimes
- RetryBackOffRandomRange
- RetryBackOffWaitMinimum

which dictate auto reconnection behaviour of the charge point. I have done my best to implement these changes and update the corresponding network test accordingly.

While the websocket code is shared between both OCPP versions, since OCPP1.6J (to my understanding) doesn't specify auto reconnection behaviour, it shouldn't be incompatible.