### PR TITLE
Allow returning of CallErrors

### DIFF
--- a/example/2.0.1/chargingstation/firmware_handler.go
+++ b/example/2.0.1/chargingstation/firmware_handler.go
@@ -13,12 +13,12 @@ import (
 
 func (handler *ChargingStationHandler) OnPublishFirmware(request *firmware.PublishFirmwareRequest) (response *firmware.PublishFirmwareResponse, err error) {
 	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (handler *ChargingStationHandler) OnUnpublishFirmware(request *firmware.UnpublishFirmwareRequest) (response *firmware.UnpublishFirmwareResponse, err error) {
 	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (handler *ChargingStationHandler) OnUpdateFirmware(request *firmware.UpdateFirmwareRequest) (response *firmware.UpdateFirmwareResponse, err error) {

--- a/example/2.0.1/chargingstation/iso15118_handler.go
+++ b/example/2.0.1/chargingstation/iso15118_handler.go
@@ -8,15 +8,15 @@ import (
 
 func (handler *ChargingStationHandler) OnDeleteCertificate(request *iso15118.DeleteCertificateRequest) (response *iso15118.DeleteCertificateResponse, err error) {
 	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (handler *ChargingStationHandler) OnGetInstalledCertificateIds(request *iso15118.GetInstalledCertificateIdsRequest) (response *iso15118.GetInstalledCertificateIdsResponse, err error) {
 	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (handler *ChargingStationHandler) OnInstallCertificate(request *iso15118.InstallCertificateRequest) (response *iso15118.InstallCertificateResponse, err error) {
 	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }

--- a/example/2.0.1/chargingstation/provisioning_handler.go
+++ b/example/2.0.1/chargingstation/provisioning_handler.go
@@ -8,17 +8,17 @@ import (
 
 func (handler *ChargingStationHandler) OnGetBaseReport(request *provisioning.GetBaseReportRequest) (response *provisioning.GetBaseReportResponse, err error) {
 	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (handler *ChargingStationHandler) OnGetReport(request *provisioning.GetReportRequest) (response *provisioning.GetReportResponse, err error) {
 	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (handler *ChargingStationHandler) OnGetVariables(request *provisioning.GetVariablesRequest) (response *provisioning.GetVariablesResponse, err error) {
 	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (handler *ChargingStationHandler) OnReset(request *provisioning.ResetRequest) (response *provisioning.ResetResponse, err error) {
@@ -29,12 +29,12 @@ func (handler *ChargingStationHandler) OnReset(request *provisioning.ResetReques
 
 func (handler *ChargingStationHandler) OnSetNetworkProfile(request *provisioning.SetNetworkProfileRequest) (response *provisioning.SetNetworkProfileResponse, err error) {
 	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (handler *ChargingStationHandler) OnSetVariables(request *provisioning.SetVariablesRequest) (response *provisioning.SetVariablesResponse, err error) {
 	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 //func (handler *ChargingStationHandler) OnChangeConfiguration(request *core.ChangeConfigurationRequest) (confirmation *core.ChangeConfigurationConfirmation, err error) {

--- a/example/2.0.1/chargingstation/smartcharging_handler.go
+++ b/example/2.0.1/chargingstation/smartcharging_handler.go
@@ -8,20 +8,20 @@ import (
 
 func (handler *ChargingStationHandler) OnClearChargingProfile(request *smartcharging.ClearChargingProfileRequest) (response *smartcharging.ClearChargingProfileResponse, err error) {
 	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (handler *ChargingStationHandler) OnGetChargingProfiles(request *smartcharging.GetChargingProfilesRequest) (response *smartcharging.GetChargingProfilesResponse, err error) {
 	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (handler *ChargingStationHandler) OnGetCompositeSchedule(request *smartcharging.GetCompositeScheduleRequest) (response *smartcharging.GetCompositeScheduleResponse, err error) {
 	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (handler *ChargingStationHandler) OnSetChargingProfile(request *smartcharging.SetChargingProfileRequest) (response *smartcharging.SetChargingProfileResponse, err error) {
 	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }

--- a/example/2.0.1/chargingstation/transactions_handler.go
+++ b/example/2.0.1/chargingstation/transactions_handler.go
@@ -8,5 +8,5 @@ import (
 
 func (handler *ChargingStationHandler) OnGetTransactionStatus(request *transactions.GetTransactionStatusRequest) (response *transactions.GetTransactionStatusResponse, err error) {
 	logDefault(request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }

--- a/example/2.0.1/csms/iso15118_handler.go
+++ b/example/2.0.1/csms/iso15118_handler.go
@@ -8,10 +8,10 @@ import (
 
 func (c *CSMSHandler) OnGet15118EVCertificate(chargingStationID string, request *iso15118.Get15118EVCertificateRequest) (response *iso15118.Get15118EVCertificateResponse, err error) {
 	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (c *CSMSHandler) OnGetCertificateStatus(chargingStationID string, request *iso15118.GetCertificateStatusRequest) (response *iso15118.GetCertificateStatusResponse, err error) {
 	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }

--- a/example/2.0.1/csms/security_handler.go
+++ b/example/2.0.1/csms/security_handler.go
@@ -14,5 +14,5 @@ func (c *CSMSHandler) OnSecurityEventNotification(chargingStationID string, requ
 
 func (c *CSMSHandler) OnSignCertificate(chargingStationID string, request *security.SignCertificateRequest) (response *security.SignCertificateResponse, err error) {
 	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }

--- a/example/2.0.1/csms/smartcharging_handler.go
+++ b/example/2.0.1/csms/smartcharging_handler.go
@@ -8,25 +8,25 @@ import (
 
 func (c *CSMSHandler) OnClearedChargingLimit(chargingStationID string, request *smartcharging.ClearedChargingLimitRequest) (response *smartcharging.ClearedChargingLimitResponse, err error) {
 	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (c *CSMSHandler) OnNotifyChargingLimit(chargingStationID string, request *smartcharging.NotifyChargingLimitRequest) (response *smartcharging.NotifyChargingLimitResponse, err error) {
 	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (c *CSMSHandler) OnNotifyEVChargingNeeds(chargingStationID string, request *smartcharging.NotifyEVChargingNeedsRequest) (response *smartcharging.NotifyEVChargingNeedsResponse, err error) {
 	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (c *CSMSHandler) OnNotifyEVChargingSchedule(chargingStationID string, request *smartcharging.NotifyEVChargingScheduleRequest) (response *smartcharging.NotifyEVChargingScheduleResponse, err error) {
 	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }
 
 func (c *CSMSHandler) OnReportChargingProfiles(chargingStationID string, request *smartcharging.ReportChargingProfilesRequest) (response *smartcharging.ReportChargingProfilesResponse, err error) {
 	logDefault(chargingStationID, request.GetFeatureName()).Warnf("Unsupported feature")
-	return nil, ocpp.NewError(ocppj.NotSupported, "Not supported", "")
+	return nil, ocpp.NewHandlerError(ocppj.NotSupported, "Not supported")
 }

--- a/ocpp/ocpp.go
+++ b/ocpp/ocpp.go
@@ -45,6 +45,11 @@ func NewError(errorCode ErrorCode, description string, messageId string) *Error 
 	return &Error{Code: errorCode, Description: description, MessageId: messageId}
 }
 
+// Creates a new OCPP Error without messageId, which is added by the handlers parent.
+func NewHandlerError(errorCode ErrorCode, description string) *Error {
+	return &Error{Code: errorCode, Description: description, MessageId: ""}
+}
+
 func (err *Error) Error() string {
 	return fmt.Sprintf("ocpp message (%s): %v - %v", err.MessageId, err.Code, err.Description)
 }

--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -413,7 +413,11 @@ func (cs *centralSystem) Start(listenPort int, listenPath string) {
 func (cs *centralSystem) sendResponse(chargePointId string, confirmation ocpp.Response, err error, requestId string) {
 	if err != nil {
 		// Send error response
-		err = cs.server.SendError(chargePointId, requestId, ocppj.InternalError, err.Error(), nil)
+		if callError, ok := err.(*ocppj.CallError); ok {
+			err = cs.server.SendError(chargePointId, requestId, callError.ErrorCode, callError.ErrorDescription, nil)
+		} else {
+			err = cs.server.SendError(chargePointId, requestId, ocppj.InternalError, err.Error(), nil)
+		}
 		if err != nil {
 			// Error while sending an error. Will attempt to send a default error instead
 			cs.server.HandleFailedResponseError(chargePointId, requestId, err, "")

--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -413,8 +413,8 @@ func (cs *centralSystem) Start(listenPort int, listenPath string) {
 func (cs *centralSystem) sendResponse(chargePointId string, confirmation ocpp.Response, err error, requestId string) {
 	if err != nil {
 		// Send error response
-		if callError, ok := err.(*ocppj.CallError); ok {
-			err = cs.server.SendError(chargePointId, requestId, callError.ErrorCode, callError.ErrorDescription, nil)
+		if ocppError, ok := err.(*ocpp.Error); ok {
+			err = cs.server.SendError(chargePointId, requestId, ocppError.Code, ocppError.Description, nil)
 		} else {
 			err = cs.server.SendError(chargePointId, requestId, ocppj.InternalError, err.Error(), nil)
 		}

--- a/ocpp1.6/charge_point.go
+++ b/ocpp1.6/charge_point.go
@@ -298,7 +298,11 @@ func (cp *chargePoint) clearCallbacks(invokeCallback bool) {
 func (cp *chargePoint) sendResponse(confirmation ocpp.Response, err error, requestId string) {
 	if err != nil {
 		// Send error response
-		err = cp.client.SendError(requestId, ocppj.InternalError, err.Error(), nil)
+		if callError, ok := err.(*ocppj.CallError); ok {
+			err = cp.client.SendError(requestId, callError.ErrorCode, callError.ErrorDescription, nil)
+		} else {
+			err = cp.client.SendError(requestId, ocppj.InternalError, err.Error(), nil)
+		}
 		if err != nil {
 			// Error while sending an error. Will attempt to send a default error instead
 			cp.client.HandleFailedResponseError(requestId, err, "")

--- a/ocpp1.6/charge_point.go
+++ b/ocpp1.6/charge_point.go
@@ -298,8 +298,8 @@ func (cp *chargePoint) clearCallbacks(invokeCallback bool) {
 func (cp *chargePoint) sendResponse(confirmation ocpp.Response, err error, requestId string) {
 	if err != nil {
 		// Send error response
-		if callError, ok := err.(*ocppj.CallError); ok {
-			err = cp.client.SendError(requestId, callError.ErrorCode, callError.ErrorDescription, nil)
+		if ocppError, ok := err.(*ocpp.Error); ok {
+			err = cp.client.SendError(requestId, ocppError.Code, ocppError.Description, nil)
 		} else {
 			err = cp.client.SendError(requestId, ocppj.InternalError, err.Error(), nil)
 		}

--- a/ocpp2.0.1/charging_station.go
+++ b/ocpp2.0.1/charging_station.go
@@ -558,7 +558,11 @@ func (cs *chargingStation) asyncCallbackHandler() {
 func (cs *chargingStation) sendResponse(response ocpp.Response, err error, requestId string) {
 	if err != nil {
 		// Send error response
-		err = cs.client.SendError(requestId, ocppj.InternalError, err.Error(), nil)
+		if callError, ok := err.(*ocppj.CallError); ok {
+			err = cs.client.SendError(requestId, callError.ErrorCode, callError.ErrorDescription, nil)
+		} else {
+			err = cs.client.SendError(requestId, ocppj.InternalError, err.Error(), nil)
+		}
 		if err != nil {
 			// Error while sending an error. Will attempt to send a default error instead
 			cs.client.HandleFailedResponseError(requestId, err, "")

--- a/ocpp2.0.1/charging_station.go
+++ b/ocpp2.0.1/charging_station.go
@@ -558,8 +558,8 @@ func (cs *chargingStation) asyncCallbackHandler() {
 func (cs *chargingStation) sendResponse(response ocpp.Response, err error, requestId string) {
 	if err != nil {
 		// Send error response
-		if callError, ok := err.(*ocppj.CallError); ok {
-			err = cs.client.SendError(requestId, callError.ErrorCode, callError.ErrorDescription, nil)
+		if ocppError, ok := err.(*ocpp.Error); ok {
+			err = cs.client.SendError(requestId, ocppError.Code, ocppError.Description, nil)
 		} else {
 			err = cs.client.SendError(requestId, ocppj.InternalError, err.Error(), nil)
 		}

--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -819,7 +819,11 @@ func (cs *csms) Start(listenPort int, listenPath string) {
 func (cs *csms) sendResponse(chargingStationID string, response ocpp.Response, err error, requestId string) {
 	if err != nil {
 		// Send error response
-		err = cs.server.SendError(chargingStationID, requestId, ocppj.InternalError, err.Error(), nil)
+		if callError, ok := err.(*ocppj.CallError); ok {
+			err = cs.server.SendError(chargingStationID, requestId, callError.ErrorCode, callError.ErrorDescription, nil)
+		} else {
+			err = cs.server.SendError(chargingStationID, requestId, ocppj.InternalError, err.Error(), nil)
+		}
 		if err != nil {
 			// Error while sending an error. Will attempt to send a default error instead
 			cs.server.HandleFailedResponseError(chargingStationID, requestId, err, "")

--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -819,8 +819,8 @@ func (cs *csms) Start(listenPort int, listenPath string) {
 func (cs *csms) sendResponse(chargingStationID string, response ocpp.Response, err error, requestId string) {
 	if err != nil {
 		// Send error response
-		if callError, ok := err.(*ocppj.CallError); ok {
-			err = cs.server.SendError(chargingStationID, requestId, callError.ErrorCode, callError.ErrorDescription, nil)
+		if ocppError, ok := err.(*ocpp.Error); ok {
+			err = cs.server.SendError(chargingStationID, requestId, ocppError.Code, ocppError.Description, nil)
 		} else {
 			err = cs.server.SendError(chargingStationID, requestId, ocppj.InternalError, err.Error(), nil)
 		}

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -161,17 +161,6 @@ type CallError struct {
 	ErrorDetails     interface{}    `json:"errorDetails" validate:"omitempty"`
 }
 
-func NewCallError(code ocpp.ErrorCode, description string) *CallError {
-	return &CallError{
-		ErrorCode:        code,
-		ErrorDescription: description,
-	}
-}
-
-func (callError *CallError) Error() string {
-	return callError.ErrorDescription
-}
-
 func (callError *CallError) GetMessageTypeId() MessageType {
 	return callError.MessageTypeId
 }

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -161,6 +161,17 @@ type CallError struct {
 	ErrorDetails     interface{}    `json:"errorDetails" validate:"omitempty"`
 }
 
+func NewCallError(code ocpp.ErrorCode, description string) *CallError {
+	return &CallError{
+		ErrorCode:        code,
+		ErrorDescription: description,
+	}
+}
+
+func (callError *CallError) Error() string {
+	return callError.ErrorDescription
+}
+
 func (callError *CallError) GetMessageTypeId() MessageType {
 	return callError.MessageTypeId
 }

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -398,7 +398,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 	typeId := MessageType(rawTypeId)
 	uniqueId, ok := arr[1].(string)
 	if !ok {
-		return nil, ocpp.NewError(FormationViolation, fmt.Sprintf("Invalid element %v at 1, expected unique ID (string)", arr[1]), uniqueId)
+		return nil, ocpp.NewError(FormationViolation, fmt.Sprintf("Invalid element %v at 1, expected unique ID (string)", arr[1]), "")
 	}
 	// Parse message
 	if typeId == CALL {
@@ -407,7 +407,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 		}
 		action, ok := arr[2].(string)
 		if !ok {
-			return nil, ocpp.NewError(FormationViolation, fmt.Sprintf("Invalid element %v at 2, expected action (string)", arr[2]), "")
+			return nil, ocpp.NewError(FormationViolation, fmt.Sprintf("Invalid element %v at 2, expected action (string)", arr[2]), uniqueId)
 		}
 
 		profile, ok := endpoint.GetProfileForFeature(action)

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -644,7 +644,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidActionCall() {
 	require.Error(t, err)
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
-	assert.Equal(t, protoErr.MessageId, "") // unique id is never set after invalid type cast return
+	assert.Equal(t, protoErr.MessageId, messageId) // unique id is returned even after invalid type cast error
 	assert.Equal(t, ocppj.FormationViolation, protoErr.Code)
 	assert.Equal(t, "Invalid element 42 at 2, expected action (string)", protoErr.Description)
 }


### PR DESCRIPTION
Based on #219 , this implements the `Error `interface for `CallError` and the corresponding type check for sending the error data.

This is done rather simple, so please feel free to suggest improvements.