### PR TITLE
Move ocpp.FormationViolation to Endpoint (BC)

### DIFF
--- a/ocpp/ocpp.go
+++ b/ocpp/ocpp.go
@@ -112,3 +112,12 @@ func (p *Profile) ParseResponse(featureName string, rawResponse interface{}, res
 	responseType := feature.GetResponseType()
 	return responseParser(rawResponse, responseType)
 }
+
+// Dialect is the OCPP version the Endpoint supports
+type Dialect int
+
+const (
+	_ Dialect = iota
+	V16
+	V2
+)

--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -405,7 +405,7 @@ func (cs *centralSystem) SendRequestAsync(clientId string, request ocpp.Request,
 
 func (cs *centralSystem) Start(listenPort int, listenPath string) {
 	// Overriding some protocol-specific values in the lower layers globally
-	ocppj.FormationViolation = ocppj.FormatViolationV16
+	cs.server.Endpoint.FormatError = ocppj.FormatViolationV16
 	// Start server
 	cs.server.Start(listenPort, listenPath)
 }

--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -405,13 +405,13 @@ func (cs *centralSystem) SendRequestAsync(clientId string, request ocpp.Request,
 
 func (cs *centralSystem) Start(listenPort int, listenPath string) {
 	// Overriding some protocol-specific values in the lower layers globally
-	cs.server.Endpoint.FormatError = ocppj.FormatViolationV16
+	cs.server.Endpoint.Dialect = ocpp.V16
 	// Start server
 	cs.server.Start(listenPort, listenPath)
 }
 
-func (cs *centralSystem) FormatError() ocpp.ErrorCode {
-	return cs.server.Endpoint.FormatError
+func (cs *centralSystem) Dialect() ocpp.Dialect {
+	return cs.server.Endpoint.Dialect
 }
 
 func (cs *centralSystem) sendResponse(chargePointId string, confirmation ocpp.Response, err error, requestId string) {

--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -405,13 +405,13 @@ func (cs *centralSystem) SendRequestAsync(clientId string, request ocpp.Request,
 
 func (cs *centralSystem) Start(listenPort int, listenPath string) {
 	// Overriding some protocol-specific values in the lower layers globally
-	cs.server.Endpoint.Dialect = ocpp.V16
+	cs.server.Endpoint.SetDialect(ocpp.V16)
 	// Start server
 	cs.server.Start(listenPort, listenPath)
 }
 
 func (cs *centralSystem) Dialect() ocpp.Dialect {
-	return cs.server.Endpoint.Dialect
+	return cs.server.Endpoint.Dialect()
 }
 
 func (cs *centralSystem) sendResponse(chargePointId string, confirmation ocpp.Response, err error, requestId string) {

--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -33,6 +33,7 @@ func newCentralSystem(server *ocppj.Server) centralSystem {
 	if server == nil {
 		panic("server must not be nil")
 	}
+	server.SetDialect(ocpp.V16)
 	return centralSystem{
 		server:        server,
 		callbackQueue: callbackqueue.New(),
@@ -404,8 +405,6 @@ func (cs *centralSystem) SendRequestAsync(clientId string, request ocpp.Request,
 }
 
 func (cs *centralSystem) Start(listenPort int, listenPath string) {
-	// Overriding some protocol-specific values in the lower layers globally
-	cs.server.Endpoint.SetDialect(ocpp.V16)
 	// Start server
 	cs.server.Start(listenPort, listenPath)
 }

--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -409,10 +409,6 @@ func (cs *centralSystem) Start(listenPort int, listenPath string) {
 	cs.server.Start(listenPort, listenPath)
 }
 
-func (cs *centralSystem) Dialect() ocpp.Dialect {
-	return cs.server.Endpoint.Dialect()
-}
-
 func (cs *centralSystem) sendResponse(chargePointId string, confirmation ocpp.Response, err error, requestId string) {
 	if err != nil {
 		// Send error response

--- a/ocpp1.6/charge_point.go
+++ b/ocpp1.6/charge_point.go
@@ -333,8 +333,6 @@ func (cp *chargePoint) sendResponse(confirmation ocpp.Response, err error, reque
 }
 
 func (cp *chargePoint) Start(centralSystemUrl string) error {
-	// Overriding some protocol-specific values in the lower layers globally
-	cp.client.Endpoint.SetDialect(ocpp.V16)
 	// Start client
 	cp.stopC = make(chan struct{}, 1)
 	err := cp.client.Start(centralSystemUrl)

--- a/ocpp1.6/charge_point.go
+++ b/ocpp1.6/charge_point.go
@@ -334,7 +334,7 @@ func (cp *chargePoint) sendResponse(confirmation ocpp.Response, err error, reque
 
 func (cp *chargePoint) Start(centralSystemUrl string) error {
 	// Overriding some protocol-specific values in the lower layers globally
-	cp.client.Endpoint.Dialect = ocpp.V16
+	cp.client.Endpoint.SetDialect(ocpp.V16)
 	// Start client
 	cp.stopC = make(chan struct{}, 1)
 	err := cp.client.Start(centralSystemUrl)

--- a/ocpp1.6/charge_point.go
+++ b/ocpp1.6/charge_point.go
@@ -334,7 +334,7 @@ func (cp *chargePoint) sendResponse(confirmation ocpp.Response, err error, reque
 
 func (cp *chargePoint) Start(centralSystemUrl string) error {
 	// Overriding some protocol-specific values in the lower layers globally
-	cp.client.Endpoint.FormatError = ocppj.FormatViolationV16
+	cp.client.Endpoint.Dialect = ocpp.V16
 	// Start client
 	cp.stopC = make(chan struct{}, 1)
 	err := cp.client.Start(centralSystemUrl)

--- a/ocpp1.6/charge_point.go
+++ b/ocpp1.6/charge_point.go
@@ -334,7 +334,7 @@ func (cp *chargePoint) sendResponse(confirmation ocpp.Response, err error, reque
 
 func (cp *chargePoint) Start(centralSystemUrl string) error {
 	// Overriding some protocol-specific values in the lower layers globally
-	ocppj.FormationViolation = ocppj.FormatViolationV16
+	cp.client.Endpoint.FormatError = ocppj.FormatViolationV16
 	// Start client
 	cp.stopC = make(chan struct{}, 1)
 	err := cp.client.Start(centralSystemUrl)

--- a/ocpp1.6/v16.go
+++ b/ocpp1.6/v16.go
@@ -254,8 +254,8 @@ type CentralSystem interface {
 	Start(listenPort int, listenPath string)
 	// Errors returns a channel for error messages. If it doesn't exist it es created.
 	Errors() <-chan error
-	// FormatError returns a format-error error code.
-	FormatError() ocpp.ErrorCode
+	// Dialect returns the endpoint dialect.
+	Dialect() ocpp.Dialect
 }
 
 // Creates a new OCPP 1.6 central system.

--- a/ocpp1.6/v16.go
+++ b/ocpp1.6/v16.go
@@ -261,8 +261,6 @@ type CentralSystem interface {
 	Start(listenPort int, listenPath string)
 	// Errors returns a channel for error messages. If it doesn't exist it es created.
 	Errors() <-chan error
-	// Dialect returns the endpoint dialect.
-	Dialect() ocpp.Dialect
 }
 
 // Creates a new OCPP 1.6 central system.

--- a/ocpp1.6_test/ocpp16_test.go
+++ b/ocpp1.6_test/ocpp16_test.go
@@ -670,8 +670,8 @@ type OcppV16TestSuite struct {
 	ocppjCentralSystem *ocppj.Server
 	mockWsServer       *MockWebsocketServer
 	mockWsClient       *MockWebsocketClient
-	chargePoint        ocpp16.ChargePoint   // ocpp16.chargePoint
-	centralSystem      ocpp16.CentralSystem // ocpp16.centralSystem
+	chargePoint        ocpp16.ChargePoint
+	centralSystem      ocpp16.CentralSystem
 	messageIdGenerator TestRandomIdGenerator
 	clientDispatcher   ocppj.ClientDispatcher
 	serverDispatcher   ocppj.ServerDispatcher

--- a/ocpp1.6_test/ocpp16_test.go
+++ b/ocpp1.6_test/ocpp16_test.go
@@ -670,8 +670,8 @@ type OcppV16TestSuite struct {
 	ocppjCentralSystem *ocppj.Server
 	mockWsServer       *MockWebsocketServer
 	mockWsClient       *MockWebsocketClient
-	chargePoint        ocpp16.ChargePoint
-	centralSystem      ocpp16.CentralSystem
+	chargePoint        ocpp16.ChargePoint   // ocpp16.chargePoint
+	centralSystem      ocpp16.CentralSystem // ocpp16.centralSystem
 	messageIdGenerator TestRandomIdGenerator
 	clientDispatcher   ocppj.ClientDispatcher
 	serverDispatcher   ocppj.ServerDispatcher
@@ -720,8 +720,7 @@ func (suite *OcppV16TestSuite) TestIsConnected() {
 	assert.False(t, suite.chargePoint.IsConnected())
 }
 
-//TODO: implement generic protocol tests
-
+// TODO: implement generic protocol tests
 func TestOcpp16Protocol(t *testing.T) {
 	suite.Run(t, new(OcppV16TestSuite))
 }

--- a/ocpp1.6_test/proto_test.go
+++ b/ocpp1.6_test/proto_test.go
@@ -157,5 +157,5 @@ func (suite *OcppV16TestSuite) TestErrorCodes() {
 	t := suite.T()
 	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	suite.centralSystem.Start(8887, "somePath")
-	assert.Equal(t, ocppj.FormatViolationV16, suite.centralSystem.FormatError())
+	assert.Equal(t, ocppj.FormatViolationV16, ocppj.FormatErrorForDialect(suite.centralSystem.Dialect()))
 }

--- a/ocpp1.6_test/proto_test.go
+++ b/ocpp1.6_test/proto_test.go
@@ -154,8 +154,5 @@ func (suite *OcppV16TestSuite) TestCentralSystemSendResponseError() {
 }
 
 func (suite *OcppV16TestSuite) TestErrorCodes() {
-	t := suite.T()
-	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
-	suite.centralSystem.Start(8887, "somePath")
-	assert.Equal(t, ocppj.FormatViolationV16, ocppj.FormatErrorType(suite.centralSystem))
+	suite.Equal(ocppj.FormatViolationV16, ocppj.FormatErrorType(suite.ocppjCentralSystem))
 }

--- a/ocpp1.6_test/proto_test.go
+++ b/ocpp1.6_test/proto_test.go
@@ -157,5 +157,5 @@ func (suite *OcppV16TestSuite) TestErrorCodes() {
 	t := suite.T()
 	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	suite.centralSystem.Start(8887, "somePath")
-	assert.Equal(t, ocppj.FormatViolationV16, ocppj.FormatErrorForDialect(suite.centralSystem.Dialect()))
+	assert.Equal(t, ocppj.FormatViolationV16, ocppj.FormatErrorType(suite.centralSystem))
 }

--- a/ocpp2.0.1/charging_station.go
+++ b/ocpp2.0.1/charging_station.go
@@ -594,7 +594,7 @@ func (cs *chargingStation) sendResponse(response ocpp.Response, err error, reque
 
 func (cs *chargingStation) Start(csmsUrl string) error {
 	// Overriding some protocol-specific values in the lower layers globally
-	ocppj.FormationViolation = ocppj.FormatViolationV2
+	cs.client.Endpoint.FormatError = ocppj.FormatViolationV2
 	// Start client
 	cs.stopC = make(chan struct{}, 1)
 	err := cs.client.Start(csmsUrl)

--- a/ocpp2.0.1/charging_station.go
+++ b/ocpp2.0.1/charging_station.go
@@ -594,7 +594,7 @@ func (cs *chargingStation) sendResponse(response ocpp.Response, err error, reque
 
 func (cs *chargingStation) Start(csmsUrl string) error {
 	// Overriding some protocol-specific values in the lower layers globally
-	cs.client.Endpoint.Dialect = ocpp.V2
+	cs.client.Endpoint.SetDialect(ocpp.V2)
 	// Start client
 	cs.stopC = make(chan struct{}, 1)
 	err := cs.client.Start(csmsUrl)

--- a/ocpp2.0.1/charging_station.go
+++ b/ocpp2.0.1/charging_station.go
@@ -594,7 +594,7 @@ func (cs *chargingStation) sendResponse(response ocpp.Response, err error, reque
 
 func (cs *chargingStation) Start(csmsUrl string) error {
 	// Overriding some protocol-specific values in the lower layers globally
-	cs.client.Endpoint.FormatError = ocppj.FormatViolationV2
+	cs.client.Endpoint.Dialect = ocpp.V2
 	// Start client
 	cs.stopC = make(chan struct{}, 1)
 	err := cs.client.Start(csmsUrl)

--- a/ocpp2.0.1/charging_station.go
+++ b/ocpp2.0.1/charging_station.go
@@ -593,8 +593,6 @@ func (cs *chargingStation) sendResponse(response ocpp.Response, err error, reque
 }
 
 func (cs *chargingStation) Start(csmsUrl string) error {
-	// Overriding some protocol-specific values in the lower layers globally
-	cs.client.Endpoint.SetDialect(ocpp.V2)
 	// Start client
 	cs.stopC = make(chan struct{}, 1)
 	err := cs.client.Start(csmsUrl)

--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -811,13 +811,13 @@ func (cs *csms) SendRequestAsync(clientId string, request ocpp.Request, callback
 
 func (cs *csms) Start(listenPort int, listenPath string) {
 	// Overriding some protocol-specific values in the lower layers globally
-	cs.server.Endpoint.Dialect = ocpp.V2
+	cs.server.Endpoint.SetDialect(ocpp.V2)
 	// Start server
 	cs.server.Start(listenPort, listenPath)
 }
 
 func (cs *csms) Dialect() ocpp.Dialect {
-	return cs.server.Endpoint.Dialect
+	return cs.server.Endpoint.Dialect()
 }
 
 func (cs *csms) sendResponse(chargingStationID string, response ocpp.Response, err error, requestId string) {

--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -815,10 +815,6 @@ func (cs *csms) Start(listenPort int, listenPath string) {
 	cs.server.Start(listenPort, listenPath)
 }
 
-func (cs *csms) Dialect() ocpp.Dialect {
-	return cs.server.Endpoint.Dialect()
-}
-
 func (cs *csms) sendResponse(chargingStationID string, response ocpp.Response, err error, requestId string) {
 	if err != nil {
 		// Send error response

--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -811,13 +811,13 @@ func (cs *csms) SendRequestAsync(clientId string, request ocpp.Request, callback
 
 func (cs *csms) Start(listenPort int, listenPath string) {
 	// Overriding some protocol-specific values in the lower layers globally
-	cs.server.Endpoint.FormatError = ocppj.FormatViolationV2
+	cs.server.Endpoint.Dialect = ocpp.V16
 	// Start server
 	cs.server.Start(listenPort, listenPath)
 }
 
-func (cs *csms) FormatError() ocpp.ErrorCode {
-	return cs.server.Endpoint.FormatError
+func (cs *csms) Dialect() ocpp.Dialect {
+	return cs.server.Endpoint.Dialect
 }
 
 func (cs *csms) sendResponse(chargingStationID string, response ocpp.Response, err error, requestId string) {

--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -811,7 +811,7 @@ func (cs *csms) SendRequestAsync(clientId string, request ocpp.Request, callback
 
 func (cs *csms) Start(listenPort int, listenPath string) {
 	// Overriding some protocol-specific values in the lower layers globally
-	ocppj.FormationViolation = ocppj.FormatViolationV2
+	cs.server.Endpoint.FormatError = ocppj.FormatViolationV2
 	// Start server
 	cs.server.Start(listenPort, listenPath)
 }

--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -53,6 +53,7 @@ func newCSMS(server *ocppj.Server) csms {
 	if server == nil {
 		panic("server must not be nil")
 	}
+	server.SetDialect(ocpp.V2)
 	return csms{
 		server:        server,
 		callbackQueue: callbackqueue.New(),
@@ -810,8 +811,6 @@ func (cs *csms) SendRequestAsync(clientId string, request ocpp.Request, callback
 }
 
 func (cs *csms) Start(listenPort int, listenPath string) {
-	// Overriding some protocol-specific values in the lower layers globally
-	cs.server.Endpoint.SetDialect(ocpp.V2)
 	// Start server
 	cs.server.Start(listenPort, listenPath)
 }

--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -811,7 +811,7 @@ func (cs *csms) SendRequestAsync(clientId string, request ocpp.Request, callback
 
 func (cs *csms) Start(listenPort int, listenPath string) {
 	// Overriding some protocol-specific values in the lower layers globally
-	cs.server.Endpoint.Dialect = ocpp.V16
+	cs.server.Endpoint.Dialect = ocpp.V2
 	// Start server
 	cs.server.Start(listenPort, listenPath)
 }

--- a/ocpp2.0.1/v2.go
+++ b/ocpp2.0.1/v2.go
@@ -34,8 +34,10 @@ type ChargingStationConnection interface {
 	TLSConnectionState() *tls.ConnectionState
 }
 
-type ChargingStationValidationHandler ws.CheckClientHandler
-type ChargingStationConnectionHandler func(chargePoint ChargingStationConnection)
+type (
+	ChargingStationValidationHandler ws.CheckClientHandler
+	ChargingStationConnectionHandler func(chargePoint ChargingStationConnection)
+)
 
 // -------------------- v2.0 Charging Station --------------------
 
@@ -384,8 +386,8 @@ type CSMS interface {
 	Start(listenPort int, listenPath string)
 	// Errors returns a channel for error messages. If it doesn't exist it es created.
 	Errors() <-chan error
-	// FormatError returns a format-error error code.
-	FormatError() ocpp.ErrorCode
+	// Dialect returns the endpoint dialect.
+	Dialect() ocpp.Dialect
 }
 
 // Creates a new OCPP 2.0 CSMS.

--- a/ocpp2.0.1/v2.go
+++ b/ocpp2.0.1/v2.go
@@ -392,8 +392,6 @@ type CSMS interface {
 	Start(listenPort int, listenPath string)
 	// Errors returns a channel for error messages. If it doesn't exist it es created.
 	Errors() <-chan error
-	// Dialect returns the endpoint dialect.
-	Dialect() ocpp.Dialect
 }
 
 // Creates a new OCPP 2.0 CSMS.

--- a/ocpp2.0.1_test/proto_test.go
+++ b/ocpp2.0.1_test/proto_test.go
@@ -159,8 +159,5 @@ func (suite *OcppV2TestSuite) TestCentralSystemSendResponseError() {
 }
 
 func (suite *OcppV2TestSuite) TestErrorCodes() {
-	t := suite.T()
-	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
-	suite.csms.Start(8887, "somePath")
-	assert.Equal(t, ocppj.FormatViolationV2, ocppj.FormatErrorType(suite.csms))
+	suite.Equal(ocppj.FormatViolationV2, ocppj.FormatErrorType(suite.ocppjServer))
 }

--- a/ocpp2.0.1_test/proto_test.go
+++ b/ocpp2.0.1_test/proto_test.go
@@ -162,5 +162,5 @@ func (suite *OcppV2TestSuite) TestErrorCodes() {
 	t := suite.T()
 	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	suite.csms.Start(8887, "somePath")
-	assert.Equal(t, ocppj.FormatViolationV2, suite.csms.FormatError())
+	assert.Equal(t, ocppj.FormatViolationV2, ocppj.FormatErrorForDialect(suite.csms.Dialect()))
 }

--- a/ocpp2.0.1_test/proto_test.go
+++ b/ocpp2.0.1_test/proto_test.go
@@ -162,5 +162,5 @@ func (suite *OcppV2TestSuite) TestErrorCodes() {
 	t := suite.T()
 	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(nil)
 	suite.csms.Start(8887, "somePath")
-	assert.Equal(t, ocppj.FormatViolationV2, ocppj.FormatErrorForDialect(suite.csms.Dialect()))
+	assert.Equal(t, ocppj.FormatViolationV2, ocppj.FormatErrorType(suite.csms))
 }

--- a/ocppj/central_system_test.go
+++ b/ocppj/central_system_test.go
@@ -117,7 +117,7 @@ func (suite *OcppJTestSuite) TestCentralSystemInvalidMessageHook() {
 	serializedPayload, err := json.Marshal(mockPayload)
 	require.NoError(t, err)
 	invalidMessage := fmt.Sprintf("[2,\"%v\",\"%s\",%v]", mockID, MockFeatureName, string(serializedPayload))
-	expectedError := fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockID, ocppj.FormationViolation, "json: cannot unmarshal number into Go struct field MockRequest.mockValue of type string")
+	expectedError := fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockID, suite.centralSystem.Endpoint.FormatError, "json: cannot unmarshal number into Go struct field MockRequest.mockValue of type string")
 	writeHook := suite.mockServer.On("Write", mockChargePointId, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		data := args.Get(1).([]byte)
 		assert.Equal(t, expectedError, string(data))
@@ -138,7 +138,7 @@ func (suite *OcppJTestSuite) TestCentralSystemInvalidMessageHook() {
 	err = suite.mockServer.MessageHandler(mockChargePoint, []byte(invalidMessage))
 	ocppErr, ok := err.(*ocpp.Error)
 	require.True(t, ok)
-	assert.Equal(t, ocppj.FormationViolation, ocppErr.Code)
+	assert.Equal(t, suite.centralSystem.Endpoint.FormatError, ocppErr.Code)
 	// Setup hook 2
 	mockError := ocpp.NewError(ocppj.InternalError, "custom error", mockID)
 	expectedError = fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockError.MessageId, mockError.Code, mockError.Description)
@@ -197,7 +197,7 @@ func (suite *OcppJTestSuite) TestCentralSystemSendRequestFailed() {
 	suite.serverDispatcher.CreateClient(mockChargePointId)
 	mockRequest := newMockRequest("mockValue")
 	err := suite.centralSystem.SendRequest(mockChargePointId, mockRequest)
-	//TODO: currently the network error is not returned by SendRequest, but is only generated internally
+	// TODO: currently the network error is not returned by SendRequest, but is only generated internally
 	assert.Nil(t, err)
 	// Assert that pending request was removed
 	time.Sleep(500 * time.Millisecond)
@@ -578,7 +578,7 @@ func (suite *OcppJTestSuite) TestEnqueueMultipleRequests() {
 	assert.False(t, q.IsEmpty())
 	assert.Equal(t, messagesToQueue, q.Size())
 	// Analyze enqueued bundle
-	var i = 0
+	var i int
 	for !q.IsEmpty() {
 		popped := q.Pop()
 		require.NotNil(t, popped)

--- a/ocppj/central_system_test.go
+++ b/ocppj/central_system_test.go
@@ -117,7 +117,7 @@ func (suite *OcppJTestSuite) TestCentralSystemInvalidMessageHook() {
 	serializedPayload, err := json.Marshal(mockPayload)
 	require.NoError(t, err)
 	invalidMessage := fmt.Sprintf("[2,\"%v\",\"%s\",%v]", mockID, MockFeatureName, string(serializedPayload))
-	expectedError := fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockID, suite.centralSystem.Endpoint.FormatError, "json: cannot unmarshal number into Go struct field MockRequest.mockValue of type string")
+	expectedError := fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockID, ocppj.FormatErrorForDialect(suite.centralSystem.Endpoint.Dialect), "json: cannot unmarshal number into Go struct field MockRequest.mockValue of type string")
 	writeHook := suite.mockServer.On("Write", mockChargePointId, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		data := args.Get(1).([]byte)
 		assert.Equal(t, expectedError, string(data))
@@ -138,7 +138,7 @@ func (suite *OcppJTestSuite) TestCentralSystemInvalidMessageHook() {
 	err = suite.mockServer.MessageHandler(mockChargePoint, []byte(invalidMessage))
 	ocppErr, ok := err.(*ocpp.Error)
 	require.True(t, ok)
-	assert.Equal(t, suite.centralSystem.Endpoint.FormatError, ocppErr.Code)
+	assert.Equal(t, ocppj.FormatErrorForDialect(suite.centralSystem.Endpoint.Dialect), ocppErr.Code)
 	// Setup hook 2
 	mockError := ocpp.NewError(ocppj.InternalError, "custom error", mockID)
 	expectedError = fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockError.MessageId, mockError.Code, mockError.Description)

--- a/ocppj/central_system_test.go
+++ b/ocppj/central_system_test.go
@@ -117,7 +117,7 @@ func (suite *OcppJTestSuite) TestCentralSystemInvalidMessageHook() {
 	serializedPayload, err := json.Marshal(mockPayload)
 	require.NoError(t, err)
 	invalidMessage := fmt.Sprintf("[2,\"%v\",\"%s\",%v]", mockID, MockFeatureName, string(serializedPayload))
-	expectedError := fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockID, ocppj.FormatErrorForDialect(suite.centralSystem.Endpoint.Dialect), "json: cannot unmarshal number into Go struct field MockRequest.mockValue of type string")
+	expectedError := fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockID, ocppj.FormatErrorType(suite.centralSystem), "json: cannot unmarshal number into Go struct field MockRequest.mockValue of type string")
 	writeHook := suite.mockServer.On("Write", mockChargePointId, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		data := args.Get(1).([]byte)
 		assert.Equal(t, expectedError, string(data))
@@ -138,7 +138,7 @@ func (suite *OcppJTestSuite) TestCentralSystemInvalidMessageHook() {
 	err = suite.mockServer.MessageHandler(mockChargePoint, []byte(invalidMessage))
 	ocppErr, ok := err.(*ocpp.Error)
 	require.True(t, ok)
-	assert.Equal(t, ocppj.FormatErrorForDialect(suite.centralSystem.Endpoint.Dialect), ocppErr.Code)
+	assert.Equal(t, ocppj.FormatErrorType(suite.centralSystem), ocppErr.Code)
 	// Setup hook 2
 	mockError := ocpp.NewError(ocppj.InternalError, "custom error", mockID)
 	expectedError = fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockError.MessageId, mockError.Code, mockError.Description)

--- a/ocppj/charge_point_test.go
+++ b/ocppj/charge_point_test.go
@@ -122,7 +122,7 @@ func (suite *OcppJTestSuite) TestChargePointInvalidMessageHook() {
 	serializedPayload, err := json.Marshal(mockPayload)
 	require.NoError(t, err)
 	invalidMessage := fmt.Sprintf("[2,\"%v\",\"%s\",%v]", mockID, MockFeatureName, string(serializedPayload))
-	expectedError := fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockID, ocppj.FormationViolation, "json: cannot unmarshal number into Go struct field MockRequest.mockValue of type string")
+	expectedError := fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockID, suite.chargePoint.Endpoint.FormatError, "json: cannot unmarshal number into Go struct field MockRequest.mockValue of type string")
 	writeHook := suite.mockClient.On("Write", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		data := args.Get(0).([]byte)
 		assert.Equal(t, expectedError, string(data))
@@ -142,7 +142,7 @@ func (suite *OcppJTestSuite) TestChargePointInvalidMessageHook() {
 	err = suite.mockClient.MessageHandler([]byte(invalidMessage))
 	ocppErr, ok := err.(*ocpp.Error)
 	require.True(t, ok)
-	assert.Equal(t, ocppj.FormationViolation, ocppErr.Code)
+	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, ocppErr.Code)
 	// Setup hook 2
 	mockError := ocpp.NewError(ocppj.InternalError, "custom error", mockID)
 	expectedError = fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockError.MessageId, mockError.Code, mockError.Description)
@@ -193,7 +193,7 @@ func (suite *OcppJTestSuite) TestChargePointSendRequestFailed() {
 	_ = suite.chargePoint.Start("someUrl")
 	mockRequest := newMockRequest("mockValue")
 	err := suite.chargePoint.SendRequest(mockRequest)
-	//TODO: currently the network error is not returned by SendRequest, but is only generated internally
+	// TODO: currently the network error is not returned by SendRequest, but is only generated internally
 	assert.Nil(t, err)
 	// Assert that pending request was removed
 	time.Sleep(500 * time.Millisecond)
@@ -472,7 +472,7 @@ func (suite *OcppJTestSuite) TestClientEnqueueMultipleRequests() {
 	require.False(t, suite.clientRequestQueue.IsEmpty())
 	assert.Equal(t, messagesToQueue, suite.clientRequestQueue.Size())
 	// Analyze enqueued bundle
-	var i = 0
+	var i int
 	for !suite.clientRequestQueue.IsEmpty() {
 		popped := suite.clientRequestQueue.Pop()
 		require.NotNil(t, popped)

--- a/ocppj/charge_point_test.go
+++ b/ocppj/charge_point_test.go
@@ -122,7 +122,7 @@ func (suite *OcppJTestSuite) TestChargePointInvalidMessageHook() {
 	serializedPayload, err := json.Marshal(mockPayload)
 	require.NoError(t, err)
 	invalidMessage := fmt.Sprintf("[2,\"%v\",\"%s\",%v]", mockID, MockFeatureName, string(serializedPayload))
-	expectedError := fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockID, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), "json: cannot unmarshal number into Go struct field MockRequest.mockValue of type string")
+	expectedError := fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockID, ocppj.FormatErrorType(suite.chargePoint), "json: cannot unmarshal number into Go struct field MockRequest.mockValue of type string")
 	writeHook := suite.mockClient.On("Write", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		data := args.Get(0).([]byte)
 		assert.Equal(t, expectedError, string(data))
@@ -142,7 +142,7 @@ func (suite *OcppJTestSuite) TestChargePointInvalidMessageHook() {
 	err = suite.mockClient.MessageHandler([]byte(invalidMessage))
 	ocppErr, ok := err.(*ocpp.Error)
 	require.True(t, ok)
-	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), ocppErr.Code)
+	assert.Equal(t, ocppj.FormatErrorType(suite.chargePoint), ocppErr.Code)
 	// Setup hook 2
 	mockError := ocpp.NewError(ocppj.InternalError, "custom error", mockID)
 	expectedError = fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockError.MessageId, mockError.Code, mockError.Description)

--- a/ocppj/charge_point_test.go
+++ b/ocppj/charge_point_test.go
@@ -122,7 +122,7 @@ func (suite *OcppJTestSuite) TestChargePointInvalidMessageHook() {
 	serializedPayload, err := json.Marshal(mockPayload)
 	require.NoError(t, err)
 	invalidMessage := fmt.Sprintf("[2,\"%v\",\"%s\",%v]", mockID, MockFeatureName, string(serializedPayload))
-	expectedError := fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockID, suite.chargePoint.Endpoint.FormatError, "json: cannot unmarshal number into Go struct field MockRequest.mockValue of type string")
+	expectedError := fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockID, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), "json: cannot unmarshal number into Go struct field MockRequest.mockValue of type string")
 	writeHook := suite.mockClient.On("Write", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		data := args.Get(0).([]byte)
 		assert.Equal(t, expectedError, string(data))
@@ -142,7 +142,7 @@ func (suite *OcppJTestSuite) TestChargePointInvalidMessageHook() {
 	err = suite.mockClient.MessageHandler([]byte(invalidMessage))
 	ocppErr, ok := err.(*ocpp.Error)
 	require.True(t, ok)
-	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, ocppErr.Code)
+	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), ocppErr.Code)
 	// Setup hook 2
 	mockError := ocpp.NewError(ocppj.InternalError, "custom error", mockID)
 	expectedError = fmt.Sprintf("[4,\"%v\",\"%v\",\"%v\",{}]", mockError.MessageId, mockError.Code, mockError.Description)

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -198,6 +198,17 @@ const (
 	FormatViolationV16            ocpp.ErrorCode = "FormationViolation"            // Payload for Action is syntactically incorrect or not conform the PDU structure for Action. This is only valid for OCPP 1.6
 )
 
+func FormatErrorForDialect(d ocpp.Dialect) ocpp.ErrorCode {
+	switch d {
+	case ocpp.V16:
+		return FormatViolationV16
+	case ocpp.V2:
+		return FormatViolationV2
+	default:
+		panic(fmt.Sprintf("invalid dialect: %v", d))
+	}
+}
+
 func IsErrorCodeValid(fl validator.FieldLevel) bool {
 	code := ocpp.ErrorCode(fl.Field().String())
 	switch code {
@@ -304,8 +315,8 @@ func jsonMarshal(t interface{}) ([]byte, error) {
 // An OCPP-J endpoint is one of the two entities taking part in the communication.
 // The endpoint keeps state for supported OCPP profiles and current pending requests.
 type Endpoint struct {
-	FormatError ocpp.ErrorCode
-	Profiles    []*ocpp.Profile
+	Dialect  ocpp.Dialect
+	Profiles []*ocpp.Profile
 }
 
 // Adds support for a new profile on the endpoint.
@@ -375,25 +386,25 @@ func parseRawJsonConfirmation(raw interface{}, confirmationType reflect.Type) (o
 func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState ClientState) (Message, error) {
 	// Checking message fields
 	if len(arr) < 3 {
-		return nil, ocpp.NewError(endpoint.FormatError, "Invalid message. Expected array length >= 3", "")
+		return nil, ocpp.NewError(FormatErrorForDialect(endpoint.Dialect), "Invalid message. Expected array length >= 3", "")
 	}
 	rawTypeId, ok := arr[0].(float64)
 	if !ok {
-		return nil, ocpp.NewError(endpoint.FormatError, fmt.Sprintf("Invalid element %v at 0, expected message type (int)", arr[0]), "")
+		return nil, ocpp.NewError(FormatErrorForDialect(endpoint.Dialect), fmt.Sprintf("Invalid element %v at 0, expected message type (int)", arr[0]), "")
 	}
 	typeId := MessageType(rawTypeId)
 	uniqueId, ok := arr[1].(string)
 	if !ok {
-		return nil, ocpp.NewError(endpoint.FormatError, fmt.Sprintf("Invalid element %v at 1, expected unique ID (string)", arr[1]), uniqueId)
+		return nil, ocpp.NewError(FormatErrorForDialect(endpoint.Dialect), fmt.Sprintf("Invalid element %v at 1, expected unique ID (string)", arr[1]), uniqueId)
 	}
 	// Parse message
 	if typeId == CALL {
 		if len(arr) != 4 {
-			return nil, ocpp.NewError(endpoint.FormatError, "Invalid Call message. Expected array length 4", uniqueId)
+			return nil, ocpp.NewError(FormatErrorForDialect(endpoint.Dialect), "Invalid Call message. Expected array length 4", uniqueId)
 		}
 		action, ok := arr[2].(string)
 		if !ok {
-			return nil, ocpp.NewError(endpoint.FormatError, fmt.Sprintf("Invalid element %v at 2, expected action (string)", arr[2]), uniqueId)
+			return nil, ocpp.NewError(FormatErrorForDialect(endpoint.Dialect), fmt.Sprintf("Invalid element %v at 2, expected action (string)", arr[2]), uniqueId)
 		}
 
 		profile, ok := endpoint.GetProfileForFeature(action)
@@ -402,7 +413,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 		}
 		request, err := profile.ParseRequest(action, arr[3], parseRawJsonRequest)
 		if err != nil {
-			return nil, ocpp.NewError(endpoint.FormatError, err.Error(), uniqueId)
+			return nil, ocpp.NewError(FormatErrorForDialect(endpoint.Dialect), err.Error(), uniqueId)
 		}
 		call := Call{
 			MessageTypeId: CALL,
@@ -424,7 +435,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 		profile, _ := endpoint.GetProfileForFeature(request.GetFeatureName())
 		confirmation, err := profile.ParseResponse(request.GetFeatureName(), arr[2], parseRawJsonConfirmation)
 		if err != nil {
-			return nil, ocpp.NewError(endpoint.FormatError, err.Error(), uniqueId)
+			return nil, ocpp.NewError(FormatErrorForDialect(endpoint.Dialect), err.Error(), uniqueId)
 		}
 		callResult := CallResult{
 			MessageTypeId: CALL_RESULT,
@@ -443,7 +454,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 			return nil, nil
 		}
 		if len(arr) < 4 {
-			return nil, ocpp.NewError(endpoint.FormatError, "Invalid Call Error message. Expected array length >= 4", uniqueId)
+			return nil, ocpp.NewError(FormatErrorForDialect(endpoint.Dialect), "Invalid Call Error message. Expected array length >= 4", uniqueId)
 		}
 		var details interface{}
 		if len(arr) > 4 {
@@ -451,7 +462,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 		}
 		rawErrorCode, ok := arr[2].(string)
 		if !ok {
-			return nil, ocpp.NewError(endpoint.FormatError, fmt.Sprintf("Invalid element %v at 2, expected rawErrorCode (string)", arr[2]), rawErrorCode)
+			return nil, ocpp.NewError(FormatErrorForDialect(endpoint.Dialect), fmt.Sprintf("Invalid element %v at 2, expected rawErrorCode (string)", arr[2]), rawErrorCode)
 		}
 		errorCode := ocpp.ErrorCode(rawErrorCode)
 		errorDescription := ""

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -201,7 +201,7 @@ const (
 func IsErrorCodeValid(fl validator.FieldLevel) bool {
 	code := ocpp.ErrorCode(fl.Field().String())
 	switch code {
-	case NotImplemented, NotSupported, InternalError, MessageTypeNotSupported, ProtocolError, SecurityError, FormationViolation, PropertyConstraintViolation, OccurrenceConstraintViolation, TypeConstraintViolation, GenericError:
+	case NotImplemented, NotSupported, InternalError, MessageTypeNotSupported, ProtocolError, SecurityError, FormatViolationV16, FormatViolationV2, PropertyConstraintViolation, OccurrenceConstraintViolation, TypeConstraintViolation, GenericError:
 		return true
 	}
 	return false

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -198,10 +198,6 @@ const (
 	FormatViolationV16            ocpp.ErrorCode = "FormationViolation"            // Payload for Action is syntactically incorrect or not conform the PDU structure for Action. This is only valid for OCPP 1.6
 )
 
-var (
-	FormationViolation = FormatViolationV16 // Used as constant, but can be overwritten depending on protocol version. Sett FormatViolationV16 and FormatViolationV2.
-)
-
 func IsErrorCodeValid(fl validator.FieldLevel) bool {
 	code := ocpp.ErrorCode(fl.Field().String())
 	switch code {
@@ -308,7 +304,8 @@ func jsonMarshal(t interface{}) ([]byte, error) {
 // An OCPP-J endpoint is one of the two entities taking part in the communication.
 // The endpoint keeps state for supported OCPP profiles and current pending requests.
 type Endpoint struct {
-	Profiles []*ocpp.Profile
+	FormatError ocpp.ErrorCode
+	Profiles    []*ocpp.Profile
 }
 
 // Adds support for a new profile on the endpoint.
@@ -378,25 +375,25 @@ func parseRawJsonConfirmation(raw interface{}, confirmationType reflect.Type) (o
 func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState ClientState) (Message, error) {
 	// Checking message fields
 	if len(arr) < 3 {
-		return nil, ocpp.NewError(FormationViolation, "Invalid message. Expected array length >= 3", "")
+		return nil, ocpp.NewError(endpoint.FormatError, "Invalid message. Expected array length >= 3", "")
 	}
 	rawTypeId, ok := arr[0].(float64)
 	if !ok {
-		return nil, ocpp.NewError(FormationViolation, fmt.Sprintf("Invalid element %v at 0, expected message type (int)", arr[0]), "")
+		return nil, ocpp.NewError(endpoint.FormatError, fmt.Sprintf("Invalid element %v at 0, expected message type (int)", arr[0]), "")
 	}
 	typeId := MessageType(rawTypeId)
 	uniqueId, ok := arr[1].(string)
 	if !ok {
-		return nil, ocpp.NewError(FormationViolation, fmt.Sprintf("Invalid element %v at 1, expected unique ID (string)", arr[1]), "")
+		return nil, ocpp.NewError(endpoint.FormatError, fmt.Sprintf("Invalid element %v at 1, expected unique ID (string)", arr[1]), uniqueId)
 	}
 	// Parse message
 	if typeId == CALL {
 		if len(arr) != 4 {
-			return nil, ocpp.NewError(FormationViolation, "Invalid Call message. Expected array length 4", uniqueId)
+			return nil, ocpp.NewError(endpoint.FormatError, "Invalid Call message. Expected array length 4", uniqueId)
 		}
 		action, ok := arr[2].(string)
 		if !ok {
-			return nil, ocpp.NewError(FormationViolation, fmt.Sprintf("Invalid element %v at 2, expected action (string)", arr[2]), uniqueId)
+			return nil, ocpp.NewError(endpoint.FormatError, fmt.Sprintf("Invalid element %v at 2, expected action (string)", arr[2]), "")
 		}
 
 		profile, ok := endpoint.GetProfileForFeature(action)
@@ -405,7 +402,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 		}
 		request, err := profile.ParseRequest(action, arr[3], parseRawJsonRequest)
 		if err != nil {
-			return nil, ocpp.NewError(FormationViolation, err.Error(), uniqueId)
+			return nil, ocpp.NewError(endpoint.FormatError, err.Error(), uniqueId)
 		}
 		call := Call{
 			MessageTypeId: CALL,
@@ -427,7 +424,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 		profile, _ := endpoint.GetProfileForFeature(request.GetFeatureName())
 		confirmation, err := profile.ParseResponse(request.GetFeatureName(), arr[2], parseRawJsonConfirmation)
 		if err != nil {
-			return nil, ocpp.NewError(FormationViolation, err.Error(), uniqueId)
+			return nil, ocpp.NewError(endpoint.FormatError, err.Error(), uniqueId)
 		}
 		callResult := CallResult{
 			MessageTypeId: CALL_RESULT,
@@ -446,7 +443,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 			return nil, nil
 		}
 		if len(arr) < 4 {
-			return nil, ocpp.NewError(FormationViolation, "Invalid Call Error message. Expected array length >= 4", uniqueId)
+			return nil, ocpp.NewError(endpoint.FormatError, "Invalid Call Error message. Expected array length >= 4", uniqueId)
 		}
 		var details interface{}
 		if len(arr) > 4 {
@@ -454,7 +451,7 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 		}
 		rawErrorCode, ok := arr[2].(string)
 		if !ok {
-			return nil, ocpp.NewError(FormationViolation, fmt.Sprintf("Invalid element %v at 2, expected rawErrorCode (string)", arr[2]), rawErrorCode)
+			return nil, ocpp.NewError(endpoint.FormatError, fmt.Sprintf("Invalid element %v at 2, expected rawErrorCode (string)", arr[2]), rawErrorCode)
 		}
 		errorCode := ocpp.ErrorCode(rawErrorCode)
 		errorDescription := ""

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -363,7 +363,6 @@ type OcppJTestSuite struct {
 }
 
 func (suite *OcppJTestSuite) SetupTest() {
-	defaultDialect := ocpp.V16 // set default to version 1.6 format error *for test only
 	mockProfile := ocpp.NewProfile("mock", &MockFeature{})
 	mockClient := MockWebsocketClient{}
 	mockServer := MockWebsocketServer{}
@@ -375,8 +374,9 @@ func (suite *OcppJTestSuite) SetupTest() {
 	suite.serverRequestMap = ocppj.NewFIFOQueueMap(queueCapacity)
 	suite.serverDispatcher = ocppj.NewDefaultServerDispatcher(suite.serverRequestMap)
 	suite.centralSystem = ocppj.NewServer(suite.mockServer, suite.serverDispatcher, nil, mockProfile)
-	suite.centralSystem.Dialect = defaultDialect
-	suite.chargePoint.Dialect = defaultDialect
+	defaultDialect := ocpp.V16 // set default to version 1.6 format error *for test only
+	suite.centralSystem.SetDialect(defaultDialect)
+	suite.chargePoint.SetDialect(defaultDialect)
 }
 
 func (suite *OcppJTestSuite) TearDownTest() {
@@ -535,7 +535,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidLength() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, "", protoErr.MessageId)
-	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), protoErr.Code)
+	assert.Equal(t, ocppj.FormatErrorType(suite.chargePoint), protoErr.Code)
 	assert.Equal(t, "Invalid message. Expected array length >= 3", protoErr.Description)
 }
 
@@ -553,7 +553,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidTypeId() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, "", protoErr.MessageId)
-	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), protoErr.Code)
+	assert.Equal(t, ocppj.FormatErrorType(suite.chargePoint), protoErr.Code)
 	assert.Equal(t, fmt.Sprintf("Invalid element %v at 0, expected message type (int)", invalidTypeId), protoErr.Description)
 }
 
@@ -570,7 +570,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidMessageId() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, "", protoErr.MessageId)
-	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), protoErr.Code)
+	assert.Equal(t, ocppj.FormatErrorType(suite.chargePoint), protoErr.Code)
 	assert.Equal(t, fmt.Sprintf("Invalid element %v at 1, expected unique ID (string)", invalidMessageId), protoErr.Description)
 }
 
@@ -625,7 +625,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidCall() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, messageId, protoErr.MessageId)
-	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), protoErr.Code)
+	assert.Equal(t, ocppj.FormatErrorType(suite.chargePoint), protoErr.Code)
 	assert.Equal(t, "Invalid Call message. Expected array length 4", protoErr.Description)
 }
 
@@ -645,7 +645,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidActionCall() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, protoErr.MessageId, messageId) // unique id is returned even after invalid type cast error
-	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), protoErr.Code)
+	assert.Equal(t, ocppj.FormatErrorType(suite.chargePoint), protoErr.Code)
 	assert.Equal(t, "Invalid element 42 at 2, expected action (string)", protoErr.Description)
 }
 
@@ -680,7 +680,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidCallError() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, messageId, protoErr.MessageId)
-	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), protoErr.Code)
+	assert.Equal(t, ocppj.FormatErrorType(suite.chargePoint), protoErr.Code)
 	assert.Equal(t, "Invalid Call Error message. Expected array length >= 4", protoErr.Description)
 }
 
@@ -701,7 +701,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidRawErrorCode() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, protoErr.MessageId, "") // unique id is never set after invalid type cast return
-	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), protoErr.Code)
+	assert.Equal(t, ocppj.FormatErrorType(suite.chargePoint), protoErr.Code)
 	assert.Equal(t, "Invalid element 42 at 2, expected rawErrorCode (string)", protoErr.Description)
 }
 

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -363,7 +363,7 @@ type OcppJTestSuite struct {
 }
 
 func (suite *OcppJTestSuite) SetupTest() {
-	defaultFormatError := ocppj.FormatViolationV16 // set default to version 1.6 format error *for test only
+	// defaultDialect := ocpp.V16 // set default to version 1.6 format error *for test only
 	mockProfile := ocpp.NewProfile("mock", &MockFeature{})
 	mockClient := MockWebsocketClient{}
 	mockServer := MockWebsocketServer{}
@@ -375,8 +375,8 @@ func (suite *OcppJTestSuite) SetupTest() {
 	suite.serverRequestMap = ocppj.NewFIFOQueueMap(queueCapacity)
 	suite.serverDispatcher = ocppj.NewDefaultServerDispatcher(suite.serverRequestMap)
 	suite.centralSystem = ocppj.NewServer(suite.mockServer, suite.serverDispatcher, nil, mockProfile)
-	suite.centralSystem.FormatError = defaultFormatError
-	suite.chargePoint.FormatError = defaultFormatError
+	// suite.centralSystem.Dialect = defaultDialect
+	// suite.chargePoint.Dialect = defaultDialect
 }
 
 func (suite *OcppJTestSuite) TearDownTest() {
@@ -535,7 +535,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidLength() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, "", protoErr.MessageId)
-	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, protoErr.Code)
+	assert.Equal(t, suite.chargePoint.Endpoint.Dialect, protoErr.Code)
 	assert.Equal(t, "Invalid message. Expected array length >= 3", protoErr.Description)
 }
 
@@ -553,7 +553,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidTypeId() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, "", protoErr.MessageId)
-	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, protoErr.Code)
+	assert.Equal(t, suite.chargePoint.Endpoint.Dialect, protoErr.Code)
 	assert.Equal(t, fmt.Sprintf("Invalid element %v at 0, expected message type (int)", invalidTypeId), protoErr.Description)
 }
 
@@ -570,7 +570,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidMessageId() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, "", protoErr.MessageId)
-	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, protoErr.Code)
+	assert.Equal(t, suite.chargePoint.Endpoint.Dialect, protoErr.Code)
 	assert.Equal(t, fmt.Sprintf("Invalid element %v at 1, expected unique ID (string)", invalidMessageId), protoErr.Description)
 }
 
@@ -625,7 +625,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidCall() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, messageId, protoErr.MessageId)
-	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, protoErr.Code)
+	assert.Equal(t, suite.chargePoint.Endpoint.Dialect, protoErr.Code)
 	assert.Equal(t, "Invalid Call message. Expected array length 4", protoErr.Description)
 }
 
@@ -645,7 +645,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidActionCall() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, protoErr.MessageId, messageId) // unique id is returned even after invalid type cast error
-	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, protoErr.Code)
+	assert.Equal(t, suite.chargePoint.Endpoint.Dialect, protoErr.Code)
 	assert.Equal(t, "Invalid element 42 at 2, expected action (string)", protoErr.Description)
 }
 
@@ -680,7 +680,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidCallError() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, messageId, protoErr.MessageId)
-	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, protoErr.Code)
+	assert.Equal(t, suite.chargePoint.Endpoint.Dialect, protoErr.Code)
 	assert.Equal(t, "Invalid Call Error message. Expected array length >= 4", protoErr.Description)
 }
 
@@ -701,7 +701,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidRawErrorCode() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, protoErr.MessageId, "") // unique id is never set after invalid type cast return
-	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, protoErr.Code)
+	assert.Equal(t, suite.chargePoint.Endpoint.Dialect, protoErr.Code)
 	assert.Equal(t, "Invalid element 42 at 2, expected rawErrorCode (string)", protoErr.Description)
 }
 

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -29,7 +29,6 @@ type MockWebSocket struct {
 
 func (websocket MockWebSocket) ID() string {
 	return websocket.id
-
 }
 
 func (websocket MockWebSocket) RemoteAddr() net.Addr {
@@ -405,8 +404,6 @@ func (suite *OcppJTestSuite) TestGetProfileForFeature() {
 	assert.Equal(t, "mock", profile.Name)
 }
 
-//func (suite *OcppJTestSuite) TestAddFeature
-
 func (suite *OcppJTestSuite) TestGetProfileForInvalidFeature() {
 	t := suite.T()
 	profile, ok := suite.chargePoint.GetProfileForFeature("test")
@@ -535,7 +532,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidLength() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, "", protoErr.MessageId)
-	assert.Equal(t, ocppj.FormationViolation, protoErr.Code)
+	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, protoErr.Code)
 	assert.Equal(t, "Invalid message. Expected array length >= 3", protoErr.Description)
 }
 
@@ -553,7 +550,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidTypeId() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, "", protoErr.MessageId)
-	assert.Equal(t, ocppj.FormationViolation, protoErr.Code)
+	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, protoErr.Code)
 	assert.Equal(t, fmt.Sprintf("Invalid element %v at 0, expected message type (int)", invalidTypeId), protoErr.Description)
 }
 
@@ -570,7 +567,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidMessageId() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, "", protoErr.MessageId)
-	assert.Equal(t, ocppj.FormationViolation, protoErr.Code)
+	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, protoErr.Code)
 	assert.Equal(t, fmt.Sprintf("Invalid element %v at 1, expected unique ID (string)", invalidMessageId), protoErr.Description)
 }
 
@@ -625,7 +622,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidCall() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, messageId, protoErr.MessageId)
-	assert.Equal(t, ocppj.FormationViolation, protoErr.Code)
+	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, protoErr.Code)
 	assert.Equal(t, "Invalid Call message. Expected array length 4", protoErr.Description)
 }
 
@@ -645,7 +642,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidActionCall() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, protoErr.MessageId, messageId) // unique id is returned even after invalid type cast error
-	assert.Equal(t, ocppj.FormationViolation, protoErr.Code)
+	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, protoErr.Code)
 	assert.Equal(t, "Invalid element 42 at 2, expected action (string)", protoErr.Description)
 }
 
@@ -680,7 +677,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidCallError() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, messageId, protoErr.MessageId)
-	assert.Equal(t, ocppj.FormationViolation, protoErr.Code)
+	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, protoErr.Code)
 	assert.Equal(t, "Invalid Call Error message. Expected array length >= 4", protoErr.Description)
 }
 
@@ -701,7 +698,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidRawErrorCode() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, protoErr.MessageId, "") // unique id is never set after invalid type cast return
-	assert.Equal(t, ocppj.FormationViolation, protoErr.Code)
+	assert.Equal(t, suite.chargePoint.Endpoint.FormatError, protoErr.Code)
 	assert.Equal(t, "Invalid element 42 at 2, expected rawErrorCode (string)", protoErr.Description)
 }
 
@@ -787,8 +784,7 @@ func (suite *OcppJTestSuite) TestParseCall() {
 	assert.Equal(t, mockValue, mockRequest.MockValue)
 }
 
-//TODO: implement further ocpp-j protocol tests
-
+// TODO: implement further ocpp-j protocol tests
 type testLogger struct {
 	c chan string
 }
@@ -796,18 +792,23 @@ type testLogger struct {
 func (l *testLogger) Debug(args ...interface{}) {
 	l.c <- "debug"
 }
+
 func (l *testLogger) Debugf(format string, args ...interface{}) {
 	l.c <- "debugf"
 }
+
 func (l *testLogger) Info(args ...interface{}) {
 	l.c <- "info"
 }
+
 func (l *testLogger) Infof(format string, args ...interface{}) {
 	l.c <- "infof"
 }
+
 func (l *testLogger) Error(args ...interface{}) {
 	l.c <- "error"
 }
+
 func (l *testLogger) Errorf(format string, args ...interface{}) {
 	l.c <- "errorf"
 }

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -363,7 +363,7 @@ type OcppJTestSuite struct {
 }
 
 func (suite *OcppJTestSuite) SetupTest() {
-	// defaultDialect := ocpp.V16 // set default to version 1.6 format error *for test only
+	defaultDialect := ocpp.V16 // set default to version 1.6 format error *for test only
 	mockProfile := ocpp.NewProfile("mock", &MockFeature{})
 	mockClient := MockWebsocketClient{}
 	mockServer := MockWebsocketServer{}
@@ -375,8 +375,8 @@ func (suite *OcppJTestSuite) SetupTest() {
 	suite.serverRequestMap = ocppj.NewFIFOQueueMap(queueCapacity)
 	suite.serverDispatcher = ocppj.NewDefaultServerDispatcher(suite.serverRequestMap)
 	suite.centralSystem = ocppj.NewServer(suite.mockServer, suite.serverDispatcher, nil, mockProfile)
-	// suite.centralSystem.Dialect = defaultDialect
-	// suite.chargePoint.Dialect = defaultDialect
+	suite.centralSystem.Dialect = defaultDialect
+	suite.chargePoint.Dialect = defaultDialect
 }
 
 func (suite *OcppJTestSuite) TearDownTest() {
@@ -535,7 +535,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidLength() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, "", protoErr.MessageId)
-	assert.Equal(t, suite.chargePoint.Endpoint.Dialect, protoErr.Code)
+	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), protoErr.Code)
 	assert.Equal(t, "Invalid message. Expected array length >= 3", protoErr.Description)
 }
 
@@ -553,7 +553,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidTypeId() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, "", protoErr.MessageId)
-	assert.Equal(t, suite.chargePoint.Endpoint.Dialect, protoErr.Code)
+	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), protoErr.Code)
 	assert.Equal(t, fmt.Sprintf("Invalid element %v at 0, expected message type (int)", invalidTypeId), protoErr.Description)
 }
 
@@ -570,7 +570,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidMessageId() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, "", protoErr.MessageId)
-	assert.Equal(t, suite.chargePoint.Endpoint.Dialect, protoErr.Code)
+	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), protoErr.Code)
 	assert.Equal(t, fmt.Sprintf("Invalid element %v at 1, expected unique ID (string)", invalidMessageId), protoErr.Description)
 }
 
@@ -625,7 +625,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidCall() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, messageId, protoErr.MessageId)
-	assert.Equal(t, suite.chargePoint.Endpoint.Dialect, protoErr.Code)
+	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), protoErr.Code)
 	assert.Equal(t, "Invalid Call message. Expected array length 4", protoErr.Description)
 }
 
@@ -645,7 +645,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidActionCall() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, protoErr.MessageId, messageId) // unique id is returned even after invalid type cast error
-	assert.Equal(t, suite.chargePoint.Endpoint.Dialect, protoErr.Code)
+	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), protoErr.Code)
 	assert.Equal(t, "Invalid element 42 at 2, expected action (string)", protoErr.Description)
 }
 
@@ -680,7 +680,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidCallError() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, messageId, protoErr.MessageId)
-	assert.Equal(t, suite.chargePoint.Endpoint.Dialect, protoErr.Code)
+	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), protoErr.Code)
 	assert.Equal(t, "Invalid Call Error message. Expected array length >= 4", protoErr.Description)
 }
 
@@ -701,7 +701,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidRawErrorCode() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, protoErr.MessageId, "") // unique id is never set after invalid type cast return
-	assert.Equal(t, suite.chargePoint.Endpoint.Dialect, protoErr.Code)
+	assert.Equal(t, ocppj.FormatErrorForDialect(suite.chargePoint.Endpoint.Dialect), protoErr.Code)
 	assert.Equal(t, "Invalid element 42 at 2, expected rawErrorCode (string)", protoErr.Description)
 }
 


### PR DESCRIPTION
Fix https://github.com/lorenzodonini/ocpp-go/issues/227

TODO

- [x] fix tests