### PR TITLE
Be more lenient towards bad OCPP implementations

### DIFF
--- a/ocpp1.6/core/get_configuration.go
+++ b/ocpp1.6/core/get_configuration.go
@@ -2,17 +2,27 @@ package core
 
 import (
 	"reflect"
+	"strings"
 )
 
 // -------------------- Get Configuration (CS -> CP) --------------------
 
 const GetConfigurationFeatureName = "GetConfiguration"
 
+// Be more lenient about boolean values
+type BooleanOrString bool
+
+func (bit *BooleanOrString) UnmarshalJSON(data []byte) error {
+	asString := strings.Trim(string(data), `"`)
+	*bit = BooleanOrString(asString == "true")
+	return nil
+}
+
 // Contains information about a specific configuration key. It is returned in GetConfigurationConfirmation
 type ConfigurationKey struct {
-	Key      string  `json:"key" validate:"required,max=50"`
-	Readonly bool    `json:"readonly"`
-	Value    *string `json:"value,omitempty" validate:"omitempty,max=500"`
+	Key      string          `json:"key" validate:"required,max=50"`
+	Readonly BooleanOrString `json:"readonly"`
+	Value    *string         `json:"value,omitempty" validate:"omitempty,max=500"`
 }
 
 // The field definition of the GetConfiguration request payload sent by the Central System to the Charge Point.

--- a/ocpp1.6_test/get_configuration_test.go
+++ b/ocpp1.6_test/get_configuration_test.go
@@ -3,7 +3,12 @@ package ocpp16_test
 import (
 	"fmt"
 
+	"encoding/json"
+	"reflect"
+
+	"github.com/lorenzodonini/ocpp-go/ocpp"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
+	"github.com/lorenzodonini/ocpp-go/ocppj"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -98,4 +103,44 @@ func (suite *OcppV16TestSuite) TestGetConfigurationInvalidEndpoint() {
 	getConfigurationRequest := core.NewGetConfigurationRequest(requestKeys)
 	requestJson := fmt.Sprintf(`[2,"%v","%v",{"key":["%v","%v"]}]`, messageId, core.GetConfigurationFeatureName, key1, key2)
 	testUnsupportedRequestFromChargePoint(suite, getConfigurationRequest, requestJson, messageId)
+}
+
+func parseRawJsonConfirmation(raw interface{}, confirmationType reflect.Type) (ocpp.Response, error) {
+	if raw == nil {
+		raw = &struct{}{}
+	}
+	bytes, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	confirmation := reflect.New(confirmationType).Interface()
+	err = json.Unmarshal(bytes, &confirmation)
+	if err != nil {
+		return nil, err
+	}
+	result := confirmation.(ocpp.Response)
+	return result, nil
+}
+
+func (suite *OcppV16TestSuite) TestGetConfigurationLenientParseJSON() {
+	t := suite.T()
+	key1 := "key1"
+	key2 := "key2"
+	someValue := "someValue"
+	someOtherValue := "someOtherValue"
+	resultKey1 := core.ConfigurationKey{Key: key1, Readonly: true, Value: &someValue}
+	resultKey2 := core.ConfigurationKey{Key: key2, Readonly: false, Value: &someOtherValue}
+	resultKeys := []core.ConfigurationKey{resultKey1, resultKey2}
+	responseJson := fmt.Sprintf(`[3,"%v",{"configurationKey":[{"key":"%v","readonly":%v,"value":"%v"},{"key":"%v","readonly":"%v","value":"%v"}]}]`, defaultMessageId, resultKey1.Key, resultKey1.Readonly, *resultKey1.Value, resultKey2.Key, resultKey2.Readonly, *resultKey2.Value)
+	parsedData, err := ocppj.ParseJsonMessage(responseJson)
+	require.NoError(t, err)
+	require.NotNil(t, parsedData)
+	profile := ocpp.NewProfile(
+		"test",
+		core.GetConfigurationFeature{},
+	)
+	confirmation, err := profile.ParseResponse(core.GetConfigurationFeatureName, parsedData[2], parseRawJsonConfirmation)
+	require.NoError(t, err)
+	require.NotNil(t, confirmation)
+	assert.Equal(t, core.NewGetConfigurationConfirmation(resultKeys), confirmation)
 }


### PR DESCRIPTION
In the analysis for https://github.com/lorenzodonini/ocpp-go/issues/234 we found that the JSON parser throws an error if the attribute type in GetConfigurationKey is not exactly boolean. In my case, my charge box happens to use strings there.

I thought I could make an attempt to be more lenient towards violations of the standard. Would you please consider including this small fix? The test shows that it does no harm and works as expected.