### PR TITLE
Add Now datetime utility function

### DIFF
--- a/ocpp1.6/types/datetime.go
+++ b/ocpp1.6/types/datetime.go
@@ -24,6 +24,11 @@ func NewDateTime(time time.Time) *DateTime {
 	return &DateTime{Time: time}
 }
 
+// Creates a new DateTime struct, containing a time.Now() value.
+func Now() *DateTime {
+	return &DateTime{Time: time.Now()}
+}
+
 func null(b []byte) bool {
 	if len(b) != 4 {
 		return false

--- a/ocpp1.6_test/common_test.go
+++ b/ocpp1.6_test/common_test.go
@@ -176,3 +176,9 @@ func (suite *OcppV16TestSuite) TestMarshalDateTime() {
 		suite.Equal(dt.ExpectedFormattedString, formatted)
 	}
 }
+
+func (suite *OcppV16TestSuite) TestNowDateTime() {
+	now := types.Now()
+	suite.NotNil(now)
+	suite.True(time.Now().Sub(now.Time) < 1*time.Second)
+}

--- a/ocpp2.0.1/types/datetime.go
+++ b/ocpp2.0.1/types/datetime.go
@@ -24,6 +24,11 @@ func NewDateTime(time time.Time) *DateTime {
 	return &DateTime{Time: time}
 }
 
+// Creates a new DateTime struct, containing a time.Now() value.
+func Now() *DateTime {
+	return &DateTime{Time: time.Now()}
+}
+
 func null(b []byte) bool {
 	if len(b) != 4 {
 		return false

--- a/ocpp2.0.1_test/common_test.go
+++ b/ocpp2.0.1_test/common_test.go
@@ -338,3 +338,9 @@ func (suite *OcppV2TestSuite) TestMarshalDateTime() {
 		suite.Equal(dt.ExpectedFormattedString, formatted)
 	}
 }
+
+func (suite *OcppV2TestSuite) TestNowDateTime() {
+	now := types.Now()
+	suite.NotNil(now)
+	suite.True(time.Now().Sub(now.Time) < 1*time.Second)
+}


### PR DESCRIPTION
- Added the `Now()` function to automatically generate a `DateTime` struct containing a `time.Now()` timestamps
- Fixes examples and CI