### PR TITLE
Add Stop to CSMS and CentralSystem

### DIFF
--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -409,6 +409,10 @@ func (cs *centralSystem) Start(listenPort int, listenPath string) {
 	cs.server.Start(listenPort, listenPath)
 }
 
+func (cs *centralSystem) Stop() {
+	cs.server.Stop()
+}
+
 func (cs *centralSystem) sendResponse(chargePointId string, confirmation ocpp.Response, err error, requestId string) {
 	if err != nil {
 		// Send error response

--- a/ocpp1.6/v16.go
+++ b/ocpp1.6/v16.go
@@ -259,6 +259,8 @@ type CentralSystem interface {
 
 	// The function blocks forever, so it is suggested to wrap it in a goroutine, in case other functionality needs to be executed on the main program thread.
 	Start(listenPort int, listenPath string)
+	// Stops the central system, clearing all pending requests.
+	Stop()
 	// Errors returns a channel for error messages. If it doesn't exist it es created.
 	Errors() <-chan error
 }

--- a/ocpp1.6_test/ocpp16_test.go
+++ b/ocpp1.6_test/ocpp16_test.go
@@ -511,6 +511,7 @@ func setupDefaultCentralSystemHandlers(suite *OcppV16TestSuite, coreListener cor
 	})
 	suite.centralSystem.SetCoreHandler(coreListener)
 	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(options.startReturnArgument)
+	suite.mockWsServer.On("Stop").Return()
 	suite.mockWsServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Return(options.writeReturnArgument).Run(func(args mock.Arguments) {
 		clientId := args.String(0)
 		data := args.Get(1)
@@ -595,6 +596,8 @@ func testUnsupportedRequestFromChargePoint(suite *OcppV16TestSuite, request ocpp
 	assert.Nil(t, err)
 	_, ok := <-resultChannel
 	assert.True(t, ok)
+	// Stop the central system
+	suite.centralSystem.Stop()
 }
 
 func testUnsupportedRequestFromCentralSystem(suite *OcppV16TestSuite, request ocpp.Request, requestJson string, messageId string) {
@@ -635,6 +638,8 @@ func testUnsupportedRequestFromCentralSystem(suite *OcppV16TestSuite, request oc
 	assert.Nil(t, err)
 	_, ok := <-resultChannel
 	assert.True(t, ok)
+	// Stop the central system
+	suite.centralSystem.Stop()
 }
 
 type GenericTestEntry struct {

--- a/ocpp2.0.1/csms.go
+++ b/ocpp2.0.1/csms.go
@@ -815,6 +815,10 @@ func (cs *csms) Start(listenPort int, listenPath string) {
 	cs.server.Start(listenPort, listenPath)
 }
 
+func (cs *csms) Stop() {
+	cs.server.Stop()
+}
+
 func (cs *csms) sendResponse(chargingStationID string, response ocpp.Response, err error, requestId string) {
 	if err != nil {
 		// Send error response

--- a/ocpp2.0.1/v2.go
+++ b/ocpp2.0.1/v2.go
@@ -390,6 +390,8 @@ type CSMS interface {
 
 	// The function blocks forever, so it is suggested to wrap it in a goroutine, in case other functionality needs to be executed on the main program thread.
 	Start(listenPort int, listenPath string)
+	// Stops the CSMS, clearing all pending requests.
+	Stop()
 	// Errors returns a channel for error messages. If it doesn't exist it es created.
 	Errors() <-chan error
 }

--- a/ocpp2.0.1_test/ocpp2_test.go
+++ b/ocpp2.0.1_test/ocpp2_test.go
@@ -909,6 +909,7 @@ func setupDefaultCSMSHandlers(suite *OcppV2TestSuite, options expectedCSMSOption
 		assert.Equal(t, options.clientId, chargingStation.ID())
 	})
 	suite.mockWsServer.On("Start", mock.AnythingOfType("int"), mock.AnythingOfType("string")).Return(options.startReturnArgument)
+	suite.mockWsServer.On("Stop").Return()
 	suite.mockWsServer.On("Write", mock.AnythingOfType("string"), mock.Anything).Return(options.writeReturnArgument).Run(func(args mock.Arguments) {
 		clientId := args.String(0)
 		data := args.Get(1)
@@ -1027,6 +1028,8 @@ func testUnsupportedRequestFromChargingStation(suite *OcppV2TestSuite, request o
 	require.Nil(t, err)
 	result := <-resultChannel
 	assert.True(t, result)
+	// Stop the CSMS
+	suite.csms.Stop()
 }
 
 func testUnsupportedRequestFromCentralSystem(suite *OcppV2TestSuite, request ocpp.Request, requestJson string, messageId string, handlers ...interface{}) {
@@ -1067,6 +1070,8 @@ func testUnsupportedRequestFromCentralSystem(suite *OcppV2TestSuite, request ocp
 	assert.Nil(t, err)
 	_, ok := <-resultChannel
 	assert.True(t, ok)
+	// Stop the CSMS
+	suite.csms.Stop()
 }
 
 type GenericTestEntry struct {


### PR DESCRIPTION
While implementing the server and client in my own application, I realized that only the `ChargePoint` and `ChargingStation` interfaces exposed a `Stop` function. As I'd like for the `CentralSystem` and `CSMS` to be capable of graceful shutdown when the application stops, I've exposed `Stop` on those interfaces as well.