### PR TITLE
fix typo field 15118CertificateHashData to iso15118CertificateHashData on AuthorizeRequest

### DIFF
--- a/ocpp2.0.1/authorization/authorize.go
+++ b/ocpp2.0.1/authorization/authorize.go
@@ -39,7 +39,7 @@ func isValidAuthorizeCertificateStatus(fl validator.FieldLevel) bool {
 type AuthorizeRequest struct {
 	Certificate         string                      `json:"certificate,omitempty" validate:"max=5500"`
 	IdToken             types.IdToken               `json:"idToken" validate:"required"`
-	CertificateHashData []types.OCSPRequestDataType `json:"15118CertificateHashData,omitempty" validate:"max=4,dive"`
+	CertificateHashData []types.OCSPRequestDataType `json:"iso15118CertificateHashData,omitempty" validate:"max=4,dive"`
 }
 
 // This field definition of the Authorize response payload, sent by the Charging Station to the CSMS in response to an AuthorizeRequest.

--- a/ocpp2.0.1_test/authorize_test.go
+++ b/ocpp2.0.1_test/authorize_test.go
@@ -53,7 +53,7 @@ func (suite *OcppV2TestSuite) TestAuthorizeE2EMocked() {
 	certHashData := types.OCSPRequestDataType{HashAlgorithm: types.SHA256, IssuerNameHash: "h0", IssuerKeyHash: "h0.1", SerialNumber: "s0", ResponderURL: "http://www.test.org"}
 	status := types.AuthorizationStatusAccepted
 	certificateStatus := authorization.CertificateStatusAccepted
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificate":"%v","idToken":{"idToken":"%v","type":"%v","additionalInfo":[{"additionalIdToken":"%v","type":"%v"}]},"15118CertificateHashData":[{"hashAlgorithm":"%v","issuerNameHash":"%v","issuerKeyHash":"%v","serialNumber":"%v","responderURL":"%v"}]}]`,
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificate":"%v","idToken":{"idToken":"%v","type":"%v","additionalInfo":[{"additionalIdToken":"%v","type":"%v"}]},"iso15118CertificateHashData":[{"hashAlgorithm":"%v","issuerNameHash":"%v","issuerKeyHash":"%v","serialNumber":"%v","responderURL":"%v"}]}]`,
 		messageId, authorization.AuthorizeFeatureName, certificate, idToken.IdToken, idToken.Type, additionalInfo.AdditionalIdToken, additionalInfo.Type, certHashData.HashAlgorithm, certHashData.IssuerNameHash, certHashData.IssuerKeyHash, certHashData.SerialNumber, certHashData.ResponderURL)
 	responseJson := fmt.Sprintf(`[3,"%v",{"certificateStatus":"%v","idTokenInfo":{"status":"%v"}}]`,
 		messageId, certificateStatus, status)
@@ -103,7 +103,7 @@ func (suite *OcppV2TestSuite) TestAuthorizeInvalidEndpoint() {
 	idToken := types.IdToken{IdToken: "tok1", Type: types.IdTokenTypeKeyCode, AdditionalInfo: []types.AdditionalInfo{additionalInfo}}
 	certHashData := types.OCSPRequestDataType{HashAlgorithm: types.SHA256, IssuerNameHash: "h0", IssuerKeyHash: "h0.1", SerialNumber: "s0", ResponderURL: "http://www.test.org"}
 	authorizeRequest := authorization.NewAuthorizationRequest(idToken.IdToken, idToken.Type)
-	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificate":"%v","idToken":{"idToken":"%v","type":"%v","additionalInfo":[{"additionalIdToken":"%v","type":"%v"}]},"15118CertificateHashData":[{"hashAlgorithm":"%v","issuerNameHash":"%v","issuerKeyHash":"%v","serialNumber":"%v","responderURL":"%v"}]}]`,
+	requestJson := fmt.Sprintf(`[2,"%v","%v",{"certificate":"%v","idToken":{"idToken":"%v","type":"%v","additionalInfo":[{"additionalIdToken":"%v","type":"%v"}]},"iso15118CertificateHashData":[{"hashAlgorithm":"%v","issuerNameHash":"%v","issuerKeyHash":"%v","serialNumber":"%v","responderURL":"%v"}]}]`,
 		messageId, authorization.AuthorizeFeatureName, certificate, idToken.IdToken, idToken.Type, additionalInfo.AdditionalIdToken, additionalInfo.Type, certHashData.HashAlgorithm, certHashData.IssuerNameHash, certHashData.IssuerKeyHash, certHashData.SerialNumber, certHashData.ResponderURL)
 	testUnsupportedRequestFromCentralSystem(suite, authorizeRequest, requestJson, messageId)
 }


### PR DESCRIPTION
Hello, I just fix typo `15118CertificateHashData`  to `iso15118CertificateHashData` on `AuthorizeRequest`

![image](https://github.com/lorenzodonini/ocpp-go/assets/21311440/e41dfba9-2167-4269-80a7-15b53f85dc01)
