### PR TITLE
Allow ConfigurationKey values up to 1000 chars

### DIFF
--- a/ocpp1.6/core/get_configuration.go
+++ b/ocpp1.6/core/get_configuration.go
@@ -12,7 +12,7 @@ const GetConfigurationFeatureName = "GetConfiguration"
 type ConfigurationKey struct {
 	Key      string  `json:"key" validate:"required,max=50"`
 	Readonly bool    `json:"readonly"`
-	Value    *string `json:"value,omitempty" validate:"omitempty,max=500"`
+	Value    *string `json:"value,omitempty" validate:"omitempty,max=1000"`
 }
 
 // The field definition of the GetConfiguration request payload sent by the Central System to the Charge Point.


### PR DESCRIPTION
Fix https://github.com/evcc-io/evcc/issues/12901

Seems there are boxes sending >500 characters...