### PR TITLE
Allow connectorID 0 for trigger message

### DIFF
--- a/ocpp1.6/remotetrigger/trigger_message.go
+++ b/ocpp1.6/remotetrigger/trigger_message.go
@@ -1,11 +1,12 @@
 package remotetrigger
 
 import (
+	"reflect"
+
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/firmware"
 	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"gopkg.in/go-playground/validator.v9"
-	"reflect"
 )
 
 // -------------------- Trigger Message (CS -> CP) --------------------
@@ -47,7 +48,7 @@ func isValidMessageTrigger(fl validator.FieldLevel) bool {
 // The field definition of the TriggerMessage request payload sent by the Central System to the Charge Point.
 type TriggerMessageRequest struct {
 	RequestedMessage MessageTrigger `json:"requestedMessage" validate:"required,messageTrigger16"`
-	ConnectorId      *int           `json:"connectorId,omitempty" validate:"omitempty,gt=0"`
+	ConnectorId      *int           `json:"connectorId,omitempty" validate:"omitempty,gte=0"`
 }
 
 // This field definition of the TriggerMessage confirmation payload, sent by the Charge Point to the Central System in response to a TriggerMessageRequest.

--- a/ocpp1.6_test/trigger_message_test.go
+++ b/ocpp1.6_test/trigger_message_test.go
@@ -17,7 +17,8 @@ func (suite *OcppV16TestSuite) TestTriggerMessageRequestValidation() {
 		{remotetrigger.TriggerMessageRequest{RequestedMessage: core.StatusNotificationFeatureName, ConnectorId: newInt(1)}, true},
 		{remotetrigger.TriggerMessageRequest{RequestedMessage: core.StatusNotificationFeatureName}, true},
 		{remotetrigger.TriggerMessageRequest{}, false},
-		{remotetrigger.TriggerMessageRequest{RequestedMessage: core.StatusNotificationFeatureName, ConnectorId: newInt(0)}, false},
+		{remotetrigger.TriggerMessageRequest{RequestedMessage: core.StatusNotificationFeatureName, ConnectorId: newInt(0)}, true},
+		{remotetrigger.TriggerMessageRequest{RequestedMessage: core.StatusNotificationFeatureName, ConnectorId: newInt(-1)}, false},
 		{remotetrigger.TriggerMessageRequest{RequestedMessage: core.StartTransactionFeatureName}, false},
 	}
 	ExecuteGenericTestTable(t, requestTable)


### PR DESCRIPTION
Fixes a validation bug caused by inconsistency in the spec. To prevent misinterpretation, the validation was changed from:
`connectorId > 0` to `connectorId >= 0` for `TriggerMessage.Req`.

Closes #244 