### PR TITLE
Check for empty unique ID

### DIFF
--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -411,6 +411,9 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 	if !ok {
 		return nil, ocpp.NewError(FormatErrorType(endpoint), fmt.Sprintf("Invalid element %v at 1, expected unique ID (string)", arr[1]), uniqueId)
 	}
+	if uniqueId == "" {
+		return nil, ocpp.NewError(FormatErrorType(endpoint), "Invalid unique ID, cannot be empty", uniqueId)
+	}
 	// Parse message
 	if typeId == CALL {
 		if len(arr) != 4 {

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -574,6 +574,22 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidMessageId() {
 	assert.Equal(t, fmt.Sprintf("Invalid element %v at 1, expected unique ID (string)", invalidMessageId), protoErr.Description)
 }
 
+func (suite *OcppJTestSuite) TestParseMessageEmptyMessageID() {
+	t := suite.T()
+	mockMessage := make([]interface{}, 3)
+	// Test invalid message length
+	mockMessage[0] = float64(ocppj.CALL_RESULT) // Message Type ID
+	mockMessage[1] = ""                         // Empty ID
+	message, err := suite.chargePoint.ParseMessage(mockMessage, suite.chargePoint.RequestState)
+	require.Nil(t, message)
+	require.Error(t, err)
+	protoErr := err.(*ocpp.Error)
+	require.NotNil(t, protoErr)
+	suite.Equal("", protoErr.MessageId)
+	suite.Equal(ocppj.FormatErrorType(suite.chargePoint), protoErr.Code)
+	suite.Errorf(protoErr, "Invalid unique ID, cannot be empty")
+}
+
 func (suite *OcppJTestSuite) TestParseMessageUnknownTypeId() {
 	t := suite.T()
 	mockMessage := make([]interface{}, 3)


### PR DESCRIPTION
Fixes a bug that would lead to a crash when a `CALL_RESULT` message with an empty unique identifier would be received.