### PR TITLE
add log debug when send error message from server to client

### DIFF
--- a/ocppj/server.go
+++ b/ocppj/server.go
@@ -226,6 +226,7 @@ func (s *Server) SendError(clientID string, requestId string, errorCode ocpp.Err
 		return ocpp.NewError(GenericError, err.Error(), requestId)
 	}
 	log.Debugf("sent CALL ERROR [%s] for %s", callError.UniqueId, clientID)
+	log.Debugf("sent JSON message to %s: %s", clientID, string(jsonMessage))
 	return nil
 }
 


### PR DESCRIPTION
Add log debug when send error message from server to client, the same as was added in `ocppj/client.go` :
https://github.com/lorenzodonini/ocpp-go/blob/9b4800337eaee4dddd4996396942fec6191dd8b3/ocppj/client.go#L245