### PR TITLE
Format with "%v" instead of "%d"

### DIFF
--- a/example/1.6/cs/handler.go
+++ b/example/1.6/cs/handler.go
@@ -78,7 +78,7 @@ func (handler *CentralSystemHandler) OnBootNotification(chargePointId string, re
 }
 
 func (handler *CentralSystemHandler) OnDataTransfer(chargePointId string, request *core.DataTransferRequest) (confirmation *core.DataTransferConfirmation, err error) {
-	logDefault(chargePointId, request.GetFeatureName()).Infof("received data %d", request.Data)
+	logDefault(chargePointId, request.GetFeatureName()).Infof("received data %v", request.Data)
 	return core.NewDataTransferConfirmation(core.DataTransferStatusAccepted), nil
 }
 


### PR DESCRIPTION
The `Data` field of type `DataTransferRequest` is defined as `interface{}`. 

In addition, I see that the `data` keys in ocppj1.6's `DataTransfer.json` and `DataTransferResponse.json` are both `string` types. Do I need to change the `Data` fields of the `DataTransferRequest` and `DataTransferConfirmation` types to the `string` type?