### PR TITLE
Fix validation for connectorId of GetCompositeSchedule.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,5 @@ Or you may build requests manually and send them using either the synchronous or
 If you're contributing a code change, you'll want to be sure the tests are passing first; here are the steps to check that:
 
 -   Install [toxiproxy](https://github.com/Shopify/toxiproxy) for your platform
--   Shell 1 - `cd example/1.6 && ./create-test-certificates.sh ; cd ../..`
--   Shell 1 - `cd example/2.0.1 && ./create-test-certificates.sh ; cd ../..`
 -   Shell 1 - `toxiproxy-server -port 8474 -host localhost`
 -   Shell 2 - `go fmt ./... && go vet ./... && go test -v -count=1 -failfast ./...`

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ There are currently no plans of supporting OCPP-S.
 
 Planned milestones and features:
 
-- [x] OCPP 1.6
-- [x] OCPP 2.0.1 (examples working, but will need more real-world testing)
-- [ ] Dedicated package for configuration management
+-   [x] OCPP 1.6
+-   [x] OCPP 2.0.1 (examples working, but will need more real-world testing)
+-   [ ] Dedicated package for configuration management
 
 ## OCPP 1.6 Usage
 
@@ -31,6 +31,7 @@ go get github.com/lorenzodonini/ocpp-go
 ```
 
 You will also need to fetch some dependencies:
+
 ```sh
 cd <path-to-ocpp-go>
 export GO111MODULE=on
@@ -42,6 +43,7 @@ Your application may either act as a [Central System](#central-system) (server) 
 ### Central System
 
 If you want to integrate the library into your custom Central System, you must implement the callbacks defined in the profile interfaces, e.g.:
+
 ```go
 import (
     "github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
@@ -65,7 +67,7 @@ func (handler *CentralSystemHandler) OnBootNotification(chargePointId string, re
 	return core.NewBootNotificationConfirmation(types.NewDateTime(time.Now()), defaultHeartbeatInterval, core.RegistrationStatusAccepted), nil
 }
 
-// further callbacks... 
+// further callbacks...
 ```
 
 Every time a request from the charge point comes in, the respective callback function is called.
@@ -77,6 +79,7 @@ You need to implement at least all other callbacks defined in the `core.CentralS
 Depending on which OCPP profiles you want to support in your application, you will need to implement additional callbacks as well.
 
 To start a central system instance, simply run the following:
+
 ```go
 centralSystem := ocpp16.NewCentralSystem(nil, nil)
 
@@ -102,6 +105,7 @@ log.Println("stopped central system")
 #### Sending requests
 
 To send requests to the charge point, you may either use the simplified API:
+
 ```go
 err := centralSystem.ChangeAvailability("1234", myCallback, 1, core.AvailabilityTypeInoperative)
 if err != nil {
@@ -110,6 +114,7 @@ if err != nil {
 ```
 
 or create a message manually:
+
 ```go
 request := core.NewChangeAvailabilityRequest(1, core.AvailabilityTypeInoperative)
 err := centralSystem.SendRequestAsync("clientId", request, callbackFunction)
@@ -118,8 +123,9 @@ if err != nil {
 }
 ```
 
-In both cases, the request is sent asynchronously and the function returns right away. 
+In both cases, the request is sent asynchronously and the function returns right away.
 You need to write the callback function to check for errors and handle the confirmation on your own:
+
 ```go
 myCallback := func(confirmation *core.ChangeAvailabilityConfirmation, e error) {
 	if e != nil {
@@ -137,6 +143,7 @@ Since the initial `centralSystem.Start` call blocks forever, you may want to wra
 
 You can take a look at the [full example](./example/1.6/cs/central_system_sim.go).
 To run it, simply execute:
+
 ```bash
 go run ./example/1.6/cs/*.go
 ```
@@ -144,12 +151,14 @@ go run ./example/1.6/cs/*.go
 #### Docker
 
 A containerized version of the central system example is available:
+
 ```bash
 docker pull ldonini/ocpp1.6-central-system:latest
 docker run -it -p 8887:8887 --rm --name central-system ldonini/ocpp1.6-central-system:latest
 ```
 
 You can also run it directly using docker-compose:
+
 ```sh
 docker-compose -f example/1.6/docker-compose.yml up central-system
 ```
@@ -158,9 +167,10 @@ docker-compose -f example/1.6/docker-compose.yml up central-system
 
 If you wish to test the central system using TLS, make sure you put your self-signed certificates inside the `example/1.6/certs` folder.
 
-Feel free to use the utility script `cd example/1.6 && ./create-test-certificates.sh` for generating test certificates. 
+Feel free to use the utility script `cd example/1.6 && ./create-test-certificates.sh` for generating test certificates.
 
 Then run the following:
+
 ```
 docker-compose -f example/1.6/docker-compose.tls.yml up central-system
 ```
@@ -168,6 +178,7 @@ docker-compose -f example/1.6/docker-compose.tls.yml up central-system
 ### Charge Point
 
 If you want to integrate the library into your custom Charge Point, you must implement the callbacks defined in the profile interfaces, e.g.:
+
 ```go
 import (
     "github.com/lorenzodonini/ocpp-go/ocpp1.6/core"
@@ -199,6 +210,7 @@ You need to implement at least all other callbacks defined in the `core.ChargePo
 Depending on which OCPP profiles you want to support in your application, you will need to implement additional callbacks as well.
 
 To start a charge point instance, simply run the following:
+
 ```go
 chargePointId := "cp0001"
 csUrl = "ws://localhost:8887"
@@ -213,7 +225,7 @@ err := chargePoint.Start(csUrl)
 if err != nil {
 	log.Println(err)
 } else {
-	log.Printf("connected to central system at %v", csUrl) 
+	log.Printf("connected to central system at %v", csUrl)
 	mainRoutine() // ... your program logic goes here
 }
 
@@ -225,6 +237,7 @@ log.Printf("disconnected from central system")
 #### Sending requests
 
 To send requests to the central station, you have two options. You may either use the simplified synchronous blocking API (recommended):
+
 ```go
 bootConf, err := chargePoint.BootNotification("model1", "vendor1")
 if err != nil {
@@ -236,11 +249,13 @@ if err != nil {
 ```
 
 or create a message manually:
+
 ```go
 request := core.NewBootNotificationRequest("model1", "vendor1")
 ```
 
 You can then decide to send the message using a synchronous blocking call:
+
 ```go
 // Synchronous call
 confirmation, err := chargePoint.SendRequest(request)
@@ -250,7 +265,9 @@ if err != nil {
 bootConf := confirmation.(*core.BootNotificationConfirmation)
 // ... do something with the confirmation
 ```
+
 or an asynchronous call:
+
 ```go
 // Asynchronous call
 err := chargePoint.SendRequestAsync(request, callbackFunction)
@@ -260,6 +277,7 @@ if err != nil {
 ```
 
 In the latter case, you need to write the callback function and check for errors on your own:
+
 ```go
 callback := func(confirmation ocpp.Response, e error) {
 	bootConf := confirmation.(*core.BootNotificationConfirmation)
@@ -275,8 +293,10 @@ callback := func(confirmation ocpp.Response, e error) {
 When creating a message manually, you always need to perform type assertion yourself, as the `SendRequest` and `SendRequestAsync` APIs use generic `Request` and `Confirmation` interfaces.
 
 #### Example
+
 You can take a look at the [full example](./example/1.6/cp/charge_point_sim.go).
 To run it, simply execute:
+
 ```bash
 CLIENT_ID=chargePointSim CENTRAL_SYSTEM_URL=ws://<host>:8887 go run example/1.6/cp/*.go
 ```
@@ -286,6 +306,7 @@ You need to specify the URL of a running central station server via environment 
 #### Docker
 
 A containerized version of the charge point example is available:
+
 ```bash
 docker pull ldonini/ocpp1.6-charge-point:latest
 docker run -e CLIENT_ID=chargePointSim -e CENTRAL_SYSTEM_URL=ws://<host>:8887 -it --rm --name charge-point ldonini/ocpp1.6-charge-point:latest
@@ -294,6 +315,7 @@ docker run -e CLIENT_ID=chargePointSim -e CENTRAL_SYSTEM_URL=ws://<host>:8887 -i
 You need to specify the host, on which the central system is running, in order for the charge point to connect to it.
 
 You can also run it directly using docker-compose:
+
 ```sh
 docker-compose -f example/1.6/docker-compose.yml up charge-point
 ```
@@ -302,9 +324,10 @@ docker-compose -f example/1.6/docker-compose.yml up charge-point
 
 If you wish to test the charge point using TLS, make sure you put your self-signed certificates inside the `example/1.6/certs` folder.
 
-Feel free to use the utility script `cd example/1.6 && ./create-test-certificates.sh` for generating test certificates. 
+Feel free to use the utility script `cd example/1.6 && ./create-test-certificates.sh` for generating test certificates.
 
 Then run the following:
+
 ```
 docker-compose -f example/1.6/docker-compose.tls.yml up charge-point
 ```
@@ -319,18 +342,20 @@ All incoming and outgoing messages are validated by default, using the [validato
 Constraints are defined on every request/response struct, as per OCPP specs.
 
 Validation may be disabled at a package level if needed:
+
 ```go
 ocppj.SetMessageValidation(false)
-``` 
+```
 
 Use at your own risk, as this will disable validation for all messages!
 
-> I will be evaluating the possibility to selectively disable validation for a specific message, 
+> I will be evaluating the possibility to selectively disable validation for a specific message,
 > e.g. by passing message options.
 
 ### Verbose logging
 
 The `ws` and `ocppj` packages offer the possibility to enable verbose logs, via your logger of choice, e.g.:
+
 ```go
 // Setup your own logger
 log = logrus.New()
@@ -340,6 +365,7 @@ log.SetLevel(logrus.DebugLevel) // Debug level needed to see all logs
 ws.SetLogger(log.WithField("logger", "websocket"))
 ocppj.SetLogger(log.WithField("logger", "ocppj"))
 ```
+
 The logger you pass needs to conform to the `logging.Logger` interface.
 Commonly used logging libraries, such as zap or logrus, adhere to this interface out-of-the-box.
 
@@ -347,10 +373,11 @@ If you are using a logger, that isn't conform, you can simply write an adapter b
 
 ### Websocket ping-pong
 
-The websocket package currently supports client-initiated pings only. 
+The websocket package currently supports client-initiated pings only.
 
 If your setup requires the server to be the initiator of a ping-pong (e.g. for web-based charge points),
 you may disable ping-pong entirely and just rely on the heartbeat mechanism:
+
 ```go
 cfg := ws.NewServerTimeoutConfig()
 cfg.PingWait = 0 // this instructs the server to wait forever
@@ -366,7 +393,7 @@ Experimental support for version 2.0.1 is now supported!
 > Version 2.0 was skipped entirely, since it is considered obsolete.
 
 Requests and responses in OCPP 2.0.1 are handled the same way they were in v1.6.
-The notable change is that there are now significantly more supported messages and profiles (feature sets), 
+The notable change is that there are now significantly more supported messages and profiles (feature sets),
 which also require their own handlers to be implemented.
 
 The library API to the lower websocket and ocpp-j layers remains unchanged.
@@ -383,6 +410,7 @@ More in-depth documentation for v2.0.1 will follow.
 ### CSMS
 
 To start a CSMS instance, run the following:
+
 ```go
 import "github.com/lorenzodonini/ocpp-go/ocpp2.0.1"
 
@@ -420,6 +448,7 @@ log.Println("stopped CSMS")
 #### Sending requests
 
 Similarly to v1.6, you may send requests using the simplified API, e.g.
+
 ```go
 err := csms.GetLocalListVersion(chargingStationID, myCallback)
 if err != nil {
@@ -432,11 +461,12 @@ Or you may build requests manually and send them using the asynchronous API.
 #### Docker image
 
 There is a Dockerfile and a docker image available upstream.
-Feel free 
+Feel free
 
 ### Charging Station
 
 To start a charging station instance, simply run the following:
+
 ```go
 chargingStationID := "cs0001"
 csmsUrl = "ws://localhost:8887"
@@ -464,7 +494,7 @@ err := chargingStation.Start(csmsUrl)
 if err != nil {
 	log.Println(err)
 } else {
-	log.Printf("connected to CSMS at %v", csmsUrl) 
+	log.Printf("connected to CSMS at %v", csmsUrl)
 	mainRoutine() // ... your program logic goes here
 }
 
@@ -476,6 +506,7 @@ log.Println("disconnected from CSMS")
 #### Sending requests
 
 Similarly to v1.6 you may send requests using the simplified API (recommended), e.g.
+
 ```go
 bootResp, err := chargingStation.BootNotification(provisioning.BootReasonPowerUp, "model1", "vendor1")
 if err != nil {
@@ -486,3 +517,13 @@ if err != nil {
 ```
 
 Or you may build requests manually and send them using either the synchronous or asynchronous API.
+
+#### Contributing
+
+If you're contributing a code change, you'll want to be sure the tests are passing first; here are the steps to check that:
+
+-   Install [toxiproxy](https://github.com/Shopify/toxiproxy) for your platform
+-   Shell 1 - `cd example/1.6 && ./create-test-certificates.sh ; cd ../..`
+-   Shell 1 - `cd example/2.0.1 && ./create-test-certificates.sh ; cd ../..`
+-   Shell 1 - `toxiproxy-server -port 8474 -host localhost`
+-   Shell 2 - `go fmt ./... && go vet ./... && go test -v -count=1 -failfast ./...`

--- a/ocpp1.6/core/stop_transaction.go
+++ b/ocpp1.6/core/stop_transaction.go
@@ -107,7 +107,7 @@ func NewStopTransactionConfirmation() *StopTransactionConfirmation {
 	return &StopTransactionConfirmation{}
 }
 
-//TODO: advanced validation
+// TODO: advanced validation
 func init() {
 	_ = types.Validate.RegisterValidation("reason", isValidReason)
 }

--- a/ocpp1.6/smartcharging/get_composite_schedule.go
+++ b/ocpp1.6/smartcharging/get_composite_schedule.go
@@ -40,7 +40,7 @@ type GetCompositeScheduleRequest struct {
 // In case the request was invalid, or couldn't be processed, an error will be sent instead.
 type GetCompositeScheduleConfirmation struct {
 	Status           GetCompositeScheduleStatus `json:"status" validate:"required,compositeScheduleStatus"`
-	ConnectorId      *int                       `json:"connectorId,omitempty" validate:"omitempty,gt=0"`
+	ConnectorId      *int                       `json:"connectorId,omitempty" validate:"omitempty,gte=0"`
 	ScheduleStart    *types.DateTime            `json:"scheduleStart,omitempty"`
 	ChargingSchedule *types.ChargingSchedule    `json:"chargingSchedule,omitempty" validate:"omitempty"`
 }

--- a/ocpp1.6_test/cancel_reservation_test.go
+++ b/ocpp1.6_test/cancel_reservation_test.go
@@ -42,7 +42,7 @@ func (suite *OcppV16TestSuite) TestCancelReservationE2EMocked() {
 	cancelReservationConfirmation := reservation.NewCancelReservationConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 
-	reservationListener := MockChargePointReservationListener{}
+	reservationListener := &MockChargePointReservationListener{}
 	reservationListener.On("OnCancelReservation", mock.Anything).Return(cancelReservationConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*reservation.CancelReservationRequest)
 		require.NotNil(t, request)
@@ -51,7 +51,7 @@ func (suite *OcppV16TestSuite) TestCancelReservationE2EMocked() {
 	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
-	suite.chargePoint.SetReservationHandler(&reservationListener)
+	suite.chargePoint.SetReservationHandler(reservationListener)
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)

--- a/ocpp1.6_test/clear_charging_profile_test.go
+++ b/ocpp1.6_test/clear_charging_profile_test.go
@@ -53,7 +53,7 @@ func (suite *OcppV16TestSuite) TestClearChargingProfileE2EMocked() {
 	ClearChargingProfileConfirmation := smartcharging.NewClearChargingProfileConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 
-	smartChargingListener := MockChargePointSmartChargingListener{}
+	smartChargingListener := &MockChargePointSmartChargingListener{}
 	smartChargingListener.On("OnClearChargingProfile", mock.Anything).Return(ClearChargingProfileConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*smartcharging.ClearChargingProfileRequest)
 		require.True(t, ok)
@@ -65,7 +65,7 @@ func (suite *OcppV16TestSuite) TestClearChargingProfileE2EMocked() {
 	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
-	suite.chargePoint.SetSmartChargingHandler(&smartChargingListener)
+	suite.chargePoint.SetSmartChargingHandler(smartChargingListener)
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)

--- a/ocpp1.6_test/diagnostics_status_notification_test.go
+++ b/ocpp1.6_test/diagnostics_status_notification_test.go
@@ -39,7 +39,7 @@ func (suite *OcppV16TestSuite) TestDiagnosticsStatusNotificationE2EMocked() {
 	diagnosticsStatusNotificationConfirmation := firmware.NewDiagnosticsStatusNotificationConfirmation()
 	channel := NewMockWebSocket(wsId)
 
-	firmwareListener := MockCentralSystemFirmwareManagementListener{}
+	firmwareListener := &MockCentralSystemFirmwareManagementListener{}
 	firmwareListener.On("OnDiagnosticsStatusNotification", mock.AnythingOfType("string"), mock.Anything).Return(diagnosticsStatusNotificationConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(1).(*firmware.DiagnosticsStatusNotificationRequest)
 		require.True(t, ok)
@@ -47,7 +47,7 @@ func (suite *OcppV16TestSuite) TestDiagnosticsStatusNotificationE2EMocked() {
 		assert.Equal(t, status, request.Status)
 	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
-	suite.centralSystem.SetFirmwareManagementHandler(&firmwareListener)
+	suite.centralSystem.SetFirmwareManagementHandler(firmwareListener)
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")

--- a/ocpp1.6_test/firmware_status_notification_test.go
+++ b/ocpp1.6_test/firmware_status_notification_test.go
@@ -39,7 +39,7 @@ func (suite *OcppV16TestSuite) TestFirmwareStatusNotificationE2EMocked() {
 	firmwareStatusNotificationConfirmation := firmware.NewFirmwareStatusNotificationConfirmation()
 	channel := NewMockWebSocket(wsId)
 
-	firmwareListener := MockCentralSystemFirmwareManagementListener{}
+	firmwareListener := &MockCentralSystemFirmwareManagementListener{}
 	firmwareListener.On("OnFirmwareStatusNotification", mock.AnythingOfType("string"), mock.Anything).Return(firmwareStatusNotificationConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(1).(*firmware.FirmwareStatusNotificationRequest)
 		require.True(t, ok)
@@ -47,7 +47,7 @@ func (suite *OcppV16TestSuite) TestFirmwareStatusNotificationE2EMocked() {
 		assert.Equal(t, status, request.Status)
 	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
-	suite.centralSystem.SetFirmwareManagementHandler(&firmwareListener)
+	suite.centralSystem.SetFirmwareManagementHandler(firmwareListener)
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")

--- a/ocpp1.6_test/get_diagnostics_test.go
+++ b/ocpp1.6_test/get_diagnostics_test.go
@@ -57,7 +57,7 @@ func (suite *OcppV16TestSuite) TestGetDiagnosticsE2EMocked() {
 	getDiagnosticsConfirmation.FileName = fileName
 	channel := NewMockWebSocket(wsId)
 
-	firmwareListener := MockChargePointFirmwareManagementListener{}
+	firmwareListener := &MockChargePointFirmwareManagementListener{}
 	firmwareListener.On("OnGetDiagnostics", mock.Anything).Return(getDiagnosticsConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*firmware.GetDiagnosticsRequest)
 		require.NotNil(t, request)
@@ -71,7 +71,7 @@ func (suite *OcppV16TestSuite) TestGetDiagnosticsE2EMocked() {
 		assertDateTimeEquality(t, *stopTime, *request.StopTime)
 	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
-	suite.chargePoint.SetFirmwareManagementHandler(&firmwareListener)
+	suite.chargePoint.SetFirmwareManagementHandler(firmwareListener)
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")

--- a/ocpp1.6_test/get_local_list_version_test.go
+++ b/ocpp1.6_test/get_local_list_version_test.go
@@ -41,14 +41,14 @@ func (suite *OcppV16TestSuite) TestGetLocalListVersionE2EMocked() {
 	localListVersionConfirmation := localauth.NewGetLocalListVersionConfirmation(listVersion)
 	channel := NewMockWebSocket(wsId)
 
-	localAuthListListener := MockChargePointLocalAuthListListener{}
+	localAuthListListener := &MockChargePointLocalAuthListListener{}
 	localAuthListListener.On("OnGetLocalListVersion", mock.Anything).Return(localListVersionConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*localauth.GetLocalListVersionRequest)
 		require.NotNil(t, request)
 		require.True(t, ok)
 	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
-	suite.chargePoint.SetLocalAuthListHandler(&localAuthListListener)
+	suite.chargePoint.SetLocalAuthListHandler(localAuthListListener)
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")

--- a/ocpp1.6_test/reserve_now_test.go
+++ b/ocpp1.6_test/reserve_now_test.go
@@ -56,7 +56,7 @@ func (suite *OcppV16TestSuite) TestReserveNowE2EMocked() {
 	ReserveNowConfirmation := reservation.NewReserveNowConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 
-	reservationListener := MockChargePointReservationListener{}
+	reservationListener := &MockChargePointReservationListener{}
 	reservationListener.On("OnReserveNow", mock.Anything).Return(ReserveNowConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*reservation.ReserveNowRequest)
 		require.True(t, ok)
@@ -70,7 +70,7 @@ func (suite *OcppV16TestSuite) TestReserveNowE2EMocked() {
 	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
-	suite.chargePoint.SetReservationHandler(&reservationListener)
+	suite.chargePoint.SetReservationHandler(reservationListener)
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)

--- a/ocpp1.6_test/send_local_list_test.go
+++ b/ocpp1.6_test/send_local_list_test.go
@@ -68,7 +68,7 @@ func (suite *OcppV16TestSuite) TestSendLocalListE2EMocked() {
 	sendLocalListConfirmation := localauth.NewSendLocalListConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 
-	localAuthListListener := MockChargePointLocalAuthListListener{}
+	localAuthListListener := &MockChargePointLocalAuthListListener{}
 	localAuthListListener.On("OnSendLocalList", mock.Anything).Return(sendLocalListConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*localauth.SendLocalListRequest)
 		require.NotNil(t, request)
@@ -83,7 +83,7 @@ func (suite *OcppV16TestSuite) TestSendLocalListE2EMocked() {
 		assertDateTimeEquality(t, *localAuthEntry.IdTagInfo.ExpiryDate, *request.LocalAuthorizationList[0].IdTagInfo.ExpiryDate)
 	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
-	suite.chargePoint.SetLocalAuthListHandler(&localAuthListListener)
+	suite.chargePoint.SetLocalAuthListHandler(localAuthListListener)
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")

--- a/ocpp1.6_test/set_charging_profile_test.go
+++ b/ocpp1.6_test/set_charging_profile_test.go
@@ -66,7 +66,7 @@ func (suite *OcppV16TestSuite) TestSetChargingProfileE2EMocked() {
 	SetChargingProfileConfirmation := smartcharging.NewSetChargingProfileConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 
-	smartChargingListener := MockChargePointSmartChargingListener{}
+	smartChargingListener := &MockChargePointSmartChargingListener{}
 	smartChargingListener.On("OnSetChargingProfile", mock.Anything).Return(SetChargingProfileConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*smartcharging.SetChargingProfileRequest)
 		require.True(t, ok)
@@ -91,7 +91,7 @@ func (suite *OcppV16TestSuite) TestSetChargingProfileE2EMocked() {
 	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
-	suite.chargePoint.SetSmartChargingHandler(&smartChargingListener)
+	suite.chargePoint.SetSmartChargingHandler(smartChargingListener)
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)

--- a/ocpp1.6_test/trigger_message_test.go
+++ b/ocpp1.6_test/trigger_message_test.go
@@ -47,7 +47,7 @@ func (suite *OcppV16TestSuite) TestTriggerMessageE2EMocked() {
 	TriggerMessageConfirmation := remotetrigger.NewTriggerMessageConfirmation(status)
 	channel := NewMockWebSocket(wsId)
 
-	remoteTriggerListener := MockChargePointRemoteTriggerListener{}
+	remoteTriggerListener := &MockChargePointRemoteTriggerListener{}
 	remoteTriggerListener.On("OnTriggerMessage", mock.Anything).Return(TriggerMessageConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*remotetrigger.TriggerMessageRequest)
 		require.True(t, ok)
@@ -57,7 +57,7 @@ func (suite *OcppV16TestSuite) TestTriggerMessageE2EMocked() {
 	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
-	suite.chargePoint.SetRemoteTriggerHandler(&remoteTriggerListener)
+	suite.chargePoint.SetRemoteTriggerHandler(remoteTriggerListener)
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")
 	err := suite.chargePoint.Start(wsUrl)

--- a/ocpp1.6_test/update_firmware_test.go
+++ b/ocpp1.6_test/update_firmware_test.go
@@ -50,7 +50,7 @@ func (suite *OcppV16TestSuite) TestUpdateFirmwareE2EMocked() {
 	updateFirmwareConfirmation := firmware.NewUpdateFirmwareConfirmation()
 	channel := NewMockWebSocket(wsId)
 
-	firmwareListener := MockChargePointFirmwareManagementListener{}
+	firmwareListener := &MockChargePointFirmwareManagementListener{}
 	firmwareListener.On("OnUpdateFirmware", mock.Anything).Return(updateFirmwareConfirmation, nil).Run(func(args mock.Arguments) {
 		request, ok := args.Get(0).(*firmware.UpdateFirmwareRequest)
 		require.NotNil(t, request)
@@ -63,7 +63,7 @@ func (suite *OcppV16TestSuite) TestUpdateFirmwareE2EMocked() {
 		assertDateTimeEquality(t, *retrieveDate, *request.RetrieveDate)
 	})
 	setupDefaultCentralSystemHandlers(suite, nil, expectedCentralSystemOptions{clientId: wsId, rawWrittenMessage: []byte(requestJson), forwardWrittenMessage: true})
-	suite.chargePoint.SetFirmwareManagementHandler(&firmwareListener)
+	suite.chargePoint.SetFirmwareManagementHandler(firmwareListener)
 	setupDefaultChargePointHandlers(suite, nil, expectedChargePointOptions{serverUrl: wsUrl, clientId: wsId, createChannelOnStart: true, channel: channel, rawWrittenMessage: []byte(responseJson), forwardWrittenMessage: true})
 	// Run Test
 	suite.centralSystem.Start(8887, "somePath")

--- a/ocpp2.0.1/availability/status_notification.go
+++ b/ocpp2.0.1/availability/status_notification.go
@@ -46,12 +46,12 @@ type StatusNotificationResponse struct {
 
 // The Charging Station notifies the CSMS about a connector status change.
 // This may typically be after on of the following events:
-//  - (re)boot
-//  - reset
-//  - any transaction event (start/stop/authorization)
-//  - reservation events
-//  - change availability operations
-//  - remote triggers
+//   - (re)boot
+//   - reset
+//   - any transaction event (start/stop/authorization)
+//   - reservation events
+//   - change availability operations
+//   - remote triggers
 //
 // The charging station sends a StatusNotificationRequest to the CSMS with information about the new status.
 // The CSMS responds with a StatusNotificationResponse.

--- a/ocpp2.0.1/remotecontrol/request_start_transaction.go
+++ b/ocpp2.0.1/remotecontrol/request_start_transaction.go
@@ -48,9 +48,9 @@ type RequestStartTransactionResponse struct {
 
 // The CSMS may remotely start a transaction for a user.
 // This functionality may be triggered by:
-//	- a CSO, to help out a user, that is having trouble starting a transaction
-//	- a third-party event (e.g. mobile app)
-//  - a previously set ChargingProfile
+//   - a CSO, to help out a user, that is having trouble starting a transaction
+//   - a third-party event (e.g. mobile app)
+//   - a previously set ChargingProfile
 //
 // The CSMS sends a RequestStartTransactionRequest to the Charging Station.
 // The Charging Stations will reply with a RequestStartTransactionResponse.

--- a/ocpp2.0.1/remotecontrol/request_stop_transaction.go
+++ b/ocpp2.0.1/remotecontrol/request_stop_transaction.go
@@ -24,9 +24,9 @@ type RequestStopTransactionResponse struct {
 
 // The CSMS may remotely stop an ongoing transaction for a user.
 // This functionality may be triggered by:
-//	- a CSO, to help out a user, that is having trouble stopping a transaction
-//	- a third-party event (e.g. mobile app)
-//  - the ISO15118-1 use-case F2
+//   - a CSO, to help out a user, that is having trouble stopping a transaction
+//   - a third-party event (e.g. mobile app)
+//   - the ISO15118-1 use-case F2
 //
 // The CSMS sends a RequestStopTransactionRequest to the Charging Station.
 // The Charging Stations will reply with a RequestStopTransactionResponse.

--- a/ocpp2.0.1/reservation/reservation_status_update.go
+++ b/ocpp2.0.1/reservation/reservation_status_update.go
@@ -41,8 +41,9 @@ type ReservationStatusUpdateResponse struct {
 }
 
 // A Charging Station shall cancel an existing reservation when:
-//  - the status of a targeted EVSE changes to either Faulted or Unavailable
-//  - the reservation has expired, before the EV driver started using the Charging Station
+//   - the status of a targeted EVSE changes to either Faulted or Unavailable
+//   - the reservation has expired, before the EV driver started using the Charging Station
+//
 // This message is not triggered, if a reservation is explicitly canceled by the user or the CSMS.
 //
 // The Charging Station sends a ReservationStatusUpdateRequest to the CSMS, with the according status set.

--- a/ocpp2.0.1_test/notify_report_test.go
+++ b/ocpp2.0.1_test/notify_report_test.go
@@ -123,7 +123,6 @@ func (suite *OcppV2TestSuite) TestNotifyReportE2EMocked() {
 	requestJson := fmt.Sprintf(`[2,"%v","%v",{"requestId":%v,"generatedAt":"%v","tbc":%v,"seqNo":%v,"reportData":[{"component":{"name":"%v"},"variable":{"name":"%v"},"variableAttribute":[{"type":"%v","value":"%v","mutability":"%v"}],"variableCharacteristics":{"unit":"%v","dataType":"%v","maxLimit":%v,"supportsMonitoring":%v}}]}]`,
 		messageId, provisioning.NotifyReportFeatureName, requestID, generatedAt.FormatTimestamp(), tbc, seqNo, reportData.Component.Name, reportData.Variable.Name, variableAttribute.Type, variableAttribute.Value, variableAttribute.Mutability, variableCharacteristics.Unit, variableCharacteristics.DataType, *variableCharacteristics.MaxLimit, variableCharacteristics.SupportsMonitoring)
 	responseJson := fmt.Sprintf(`[3,"%v",{}]`, messageId)
-	fmt.Println(responseJson)
 	notifyReportResponse := provisioning.NewNotifyReportResponse()
 	channel := NewMockWebSocket(wsId)
 


### PR DESCRIPTION
Hi,

This lib is awesome, we've built a production OCPP server around it and it's going great!

This PR fixes the validation of the `connectorId` field of `GetCompositeSchedule.conf` (https://github.com/lorenzodonini/ocpp-go/issues/276); I believe this fix is in keeping w/ OCPP 1.6:

<img width="1251" alt="image" src="https://github.com/lorenzodonini/ocpp-go/assets/5491690/066f0d89-6c02-4b57-a79b-e46de32b4b16">

An excerpt re: `GetCompositeSchedule`:

> If the ConnectorId in the request is set to '0', the Charge Point SHALL report the total expected power or current the Charge Point expects to consume from the grid during the requested time period.

While I was in the code I also ran `go fmt` and tidied up a couple of (probably unimportant) `go vet` failures around copied locks in test code.