### PR TITLE
Don't call onDisconnected with nil error

### DIFF
--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -900,7 +900,7 @@ func (client *Client) writePump() {
 		ticker.Stop()
 		client.cleanup()
 		// Invoke callback
-		if client.onDisconnected != nil {
+		if err != nil && client.onDisconnected != nil {
 			client.onDisconnected(err)
 		}
 	}


### PR DESCRIPTION
This fixes some unexpected panics when logging errors in onDisconnected with err.Error().

Is called with nil here https://github.com/lorenzodonini/ocpp-go/blob/f63dc40405ccd2bba03b818f3f428ef56a82134b/ws/websocket.go#L944
