### PR TITLE
Fix bug error panic OCPP 1.6J security features (CentralSystem)

### DIFF
--- a/ocpp1.6/central_system.go
+++ b/ocpp1.6/central_system.go
@@ -352,8 +352,11 @@ func (cs *centralSystem) TriggerMessageExtended(clientId string, callback func(*
 		fn(request)
 	}
 	genericCallback := func(confirmation ocpp.Response, protoError error) {
-		confirmationCasted := confirmation.(*extendedtriggermessage.ExtendedTriggerMessageResponse)
-		callback(confirmationCasted, protoError)
+		if confirmation != nil {
+			callback(confirmation.(*extendedtriggermessage.ExtendedTriggerMessageResponse), protoError)
+		} else {
+			callback(nil, protoError)
+		}
 	}
 	return cs.SendRequestAsync(clientId, request, genericCallback)
 
@@ -365,8 +368,11 @@ func (cs *centralSystem) CertificateSigned(clientId string, callback func(*secur
 		fn(request)
 	}
 	genericCallback := func(confirmation ocpp.Response, protoError error) {
-		confirmationCasted := confirmation.(*security.CertificateSignedResponse)
-		callback(confirmationCasted, protoError)
+		if confirmation != nil {
+			callback(confirmation.(*security.CertificateSignedResponse), protoError)
+		} else {
+			callback(nil, protoError)
+		}
 	}
 	return cs.SendRequestAsync(clientId, request, genericCallback)
 }
@@ -377,8 +383,11 @@ func (cs *centralSystem) SignedUpdateFirmware(clientId string, callback func(*se
 		fn(request)
 	}
 	genericCallback := func(confirmation ocpp.Response, protoError error) {
-		confirmationCasted := confirmation.(*securefirmware.SignedUpdateFirmwareResponse)
-		callback(confirmationCasted, protoError)
+		if confirmation != nil {
+			callback(confirmation.(*securefirmware.SignedUpdateFirmwareResponse), protoError)
+		} else {
+			callback(nil, protoError)
+		}
 	}
 	return cs.SendRequestAsync(clientId, request, genericCallback)
 }
@@ -389,8 +398,11 @@ func (cs *centralSystem) GetInstalledCertificateIds(clientId string, callback fu
 		fn(request)
 	}
 	genericCallback := func(confirmation ocpp.Response, protoError error) {
-		confirmationCasted := confirmation.(*certificates.GetInstalledCertificateIdsResponse)
-		callback(confirmationCasted, protoError)
+		if confirmation != nil {
+			callback(confirmation.(*certificates.GetInstalledCertificateIdsResponse), protoError)
+		} else {
+			callback(nil, protoError)
+		}
 	}
 	return cs.SendRequestAsync(clientId, request, genericCallback)
 }
@@ -401,8 +413,11 @@ func (cs *centralSystem) InstallCertificate(clientId string, callback func(*cert
 		fn(request)
 	}
 	genericCallback := func(confirmation ocpp.Response, protoError error) {
-		confirmationCasted := confirmation.(*certificates.InstallCertificateResponse)
-		callback(confirmationCasted, protoError)
+		if confirmation != nil {
+			callback(confirmation.(*certificates.InstallCertificateResponse), protoError)
+		} else {
+			callback(nil, protoError)
+		}
 	}
 	return cs.SendRequestAsync(clientId, request, genericCallback)
 }
@@ -413,8 +428,11 @@ func (cs *centralSystem) DeleteCertificate(clientId string, callback func(*certi
 		fn(request)
 	}
 	genericCallback := func(confirmation ocpp.Response, protoError error) {
-		confirmationCasted := confirmation.(*certificates.DeleteCertificateResponse)
-		callback(confirmationCasted, protoError)
+		if confirmation != nil {
+			callback(confirmation.(*certificates.DeleteCertificateResponse), protoError)
+		} else {
+			callback(nil, protoError)
+		}
 	}
 	return cs.SendRequestAsync(clientId, request, genericCallback)
 }
@@ -425,8 +443,11 @@ func (cs *centralSystem) GetLog(clientId string, callback func(*logging.GetLogRe
 		fn(request)
 	}
 	genericCallback := func(confirmation ocpp.Response, protoError error) {
-		confirmationCasted := confirmation.(*logging.GetLogResponse)
-		callback(confirmationCasted, protoError)
+		if confirmation != nil {
+			callback(confirmation.(*logging.GetLogResponse), protoError)
+		} else {
+			callback(nil, protoError)
+		}
 	}
 	return cs.SendRequestAsync(clientId, request, genericCallback)
 }

--- a/ocpp1.6/extendedtriggermessage/extended_trigger_message.go
+++ b/ocpp1.6/extendedtriggermessage/extended_trigger_message.go
@@ -72,7 +72,7 @@ func isValidExtendedTriggerMessageStatus(fl validator.FieldLevel) bool {
 // The field definition of the LogStatusNotification request payload sent by a Charging Station to the CSMS.
 type ExtendedTriggerMessageRequest struct {
 	RequestedMessage ExtendedTriggerMessageType `json:"requestedMessage" validate:"required,extendedTriggerMessageType"`
-	ConnectorId      *int                       `json:"connectorId" validate:"gt=0,omitempty"`
+	ConnectorId      *int                       `json:"connectorId,omitempty" validate:"omitempty,gte=0"`
 }
 
 // This field definition of the LogStatusNotification response payload, sent by the CSMS to the Charging Station in response to a ExtendedTriggerMessageRequest.


### PR DESCRIPTION
## Proposed changes

(1)  Fix panic when get response proto-error on OCPP 1.6J Security features CentralSystem
(2)  Fix `connectorId` field validation on `ExtendedTriggerMessageRequest` feature base on OCPP 1.6J security extension specification

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/xBlaz3kx/ocppManager-go/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

**(1)** Example message to produce panic when get response proto-error on OCPP 1.6J Security features CentralSystem

Request message:
```json
[2,"1457709147","ExtendedTriggerMessage",{"requestedMessage":"SignChargePointCertificate"}]
```
Response message:
```json
[4,"1457709147","NotSupported","Feature not implemented",{}]
```
CentralSystem will get panic:
```
...
panic: interface conversion: ocpp.Response is nil, not *extendedtriggermessage.ExtendedTriggerMessageResponse
...
``` 

<br>
<br>

**(2)** Field `connectorId` of `ExtendedTriggerMessageRequest` on OCPP 1.6J Security specification

![image](https://github.com/user-attachments/assets/5e6cb1a2-2bc3-4494-b48b-9be28afc1b66)

<br>
