### PR TITLE
Use positive numbers as transactionId

### DIFF
--- a/example/1.6/cs/handler.go
+++ b/example/1.6/cs/handler.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	nextTransactionId = 0
+	nextTransactionId = 1
 )
 
 // TransactionInfo contains info about a transaction


### PR DESCRIPTION
According to the description in section 3.54 of the "OCPP 1.6 Errata sheet: v4.0 Release, 2019-10-23" document, it is recommended to use a unique positive number as the value of the transactionId.