### PR TITLE
FIXES TYPO IN OccurrenceConstraintViolation

### DIFF
--- a/ocpp1.6_test/proto_test.go
+++ b/ocpp1.6_test/proto_test.go
@@ -51,7 +51,7 @@ func (suite *OcppV16TestSuite) TestChargePointSendResponseError() {
 		{
 			name:        "ocurrence validation",
 			confirmData: CustomData{Field1: "", Field2: 42},
-			expectedErr: &ocpp.Error{Code: ocppj.OccurrenceConstraintViolation, Description: "Field CallResult.Payload.Data.Field1 required but not found for feature DataTransfer"},
+			expectedErr: &ocpp.Error{Code: ocppj.OccurenceConstraintViolation, Description: "Field CallResult.Payload.Data.Field1 required but not found for feature DataTransfer"},
 		},
 		{
 			name:        "marshaling error",
@@ -130,7 +130,7 @@ func (suite *OcppV16TestSuite) TestCentralSystemSendResponseError() {
 	require.Error(t, err)
 	require.IsType(t, &ocpp.Error{}, err)
 	ocppErr = err.(*ocpp.Error)
-	assert.Equal(t, ocppj.OccurrenceConstraintViolation, ocppErr.Code)
+	assert.Equal(t, ocppj.OccurenceConstraintViolation, ocppErr.Code)
 	assert.Equal(t, "Field CallResult.Payload.Data.Field1 required but not found for feature DataTransfer", ocppErr.Description)
 	// Test 2: marshaling error
 	dataTransferConfirmation = core.NewDataTransferConfirmation(core.DataTransferStatusAccepted)

--- a/ocpp2.0.1_test/proto_test.go
+++ b/ocpp2.0.1_test/proto_test.go
@@ -57,7 +57,7 @@ func (suite *OcppV2TestSuite) TestChargePointSendResponseError() {
 	result := <-resultChannel
 	require.IsType(t, &ocpp.Error{}, result)
 	ocppErr = result.(*ocpp.Error)
-	assert.Equal(t, ocppj.OccurrenceConstraintViolation, ocppErr.Code)
+	assert.Equal(t, ocppj.OccurenceConstraintViolation, ocppErr.Code)
 	assert.Equal(t, "Field CallResult.Payload.Data.Field1 required but not found for feature DataTransfer", ocppErr.Description)
 	// Test 2: marshaling error
 	dataTransferResponse = data.NewDataTransferResponse(data.DataTransferStatusAccepted)
@@ -132,7 +132,7 @@ func (suite *OcppV2TestSuite) TestCentralSystemSendResponseError() {
 	require.Error(t, err)
 	require.IsType(t, &ocpp.Error{}, err)
 	ocppErr = err.(*ocpp.Error)
-	assert.Equal(t, ocppj.OccurrenceConstraintViolation, ocppErr.Code)
+	assert.Equal(t, ocppj.OccurenceConstraintViolation, ocppErr.Code)
 	assert.Equal(t, "Field CallResult.Payload.Data.Field1 required but not found for feature DataTransfer", ocppErr.Description)
 	// Test 2: marshaling error
 	dataTransferResponse = data.NewDataTransferResponse(data.DataTransferStatusAccepted)

--- a/ocppj/central_system_test.go
+++ b/ocppj/central_system_test.go
@@ -332,7 +332,7 @@ func (suite *OcppJTestSuite) TestCentralSystemHandleFailedResponse() {
 	require.Nil(t, callResult)
 	suite.centralSystem.HandleFailedResponseError(mockChargePointID, mockUniqueID, err, mockResponse.GetFeatureName())
 	rawResponse := <-msgC
-	expectedErr := fmt.Sprintf(`[4,"%v","%v","Field %s required but not found for feature %s",{}]`, mockUniqueID, ocppj.OccurrenceConstraintViolation, mockField, mockResponse.GetFeatureName())
+	expectedErr := fmt.Sprintf(`[4,"%v","%v","Field %s required but not found for feature %s",{}]`, mockUniqueID, ocppj.OccurenceConstraintViolation, mockField, mockResponse.GetFeatureName())
 	assert.Equal(t, expectedErr, string(rawResponse))
 	// 2. property constraint validation error
 	val := "len4"

--- a/ocppj/charge_point_test.go
+++ b/ocppj/charge_point_test.go
@@ -306,7 +306,7 @@ func (suite *OcppJTestSuite) TestChargePointHandleFailedResponse() {
 	require.Nil(t, callResult)
 	suite.chargePoint.HandleFailedResponseError(mockUniqueID, err, mockResponse.GetFeatureName())
 	rawResponse := <-msgC
-	expectedErr := fmt.Sprintf(`[4,"%v","%v","Field %s required but not found for feature %s",{}]`, mockUniqueID, ocppj.OccurrenceConstraintViolation, mockField, mockResponse.GetFeatureName())
+	expectedErr := fmt.Sprintf(`[4,"%v","%v","Field %s required but not found for feature %s",{}]`, mockUniqueID, ocppj.OccurenceConstraintViolation, mockField, mockResponse.GetFeatureName())
 	assert.Equal(t, expectedErr, string(rawResponse))
 	// 2. property constraint validation error
 	val := "len4"

--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -184,18 +184,18 @@ func (callError *CallError) MarshalJSON() ([]byte, error) {
 }
 
 const (
-	NotImplemented                ocpp.ErrorCode = "NotImplemented"                // Requested Action is not known by receiver.
-	NotSupported                  ocpp.ErrorCode = "NotSupported"                  // Requested Action is recognized but not supported by the receiver.
-	InternalError                 ocpp.ErrorCode = "InternalError"                 // An internal error occurred and the receiver was not able to process the requested Action successfully.
-	MessageTypeNotSupported       ocpp.ErrorCode = "MessageTypeNotSupported"       // A message with an Message Type Number received that is not supported by this implementation.
-	ProtocolError                 ocpp.ErrorCode = "ProtocolError"                 // Payload for Action is incomplete.
-	SecurityError                 ocpp.ErrorCode = "SecurityError"                 // During the processing of Action a security issue occurred preventing receiver from completing the Action successfully.
-	PropertyConstraintViolation   ocpp.ErrorCode = "PropertyConstraintViolation"   // Payload is syntactically correct but at least one field contains an invalid value.
-	OccurrenceConstraintViolation ocpp.ErrorCode = "OccurrenceConstraintViolation" // Payload for Action is syntactically correct but at least one of the fields violates occurrence constraints.
-	TypeConstraintViolation       ocpp.ErrorCode = "TypeConstraintViolation"       // Payload for Action is syntactically correct but at least one of the fields violates data type constraints (e.g. “somestring”: 12).
-	GenericError                  ocpp.ErrorCode = "GenericError"                  // Any other error not covered by the previous ones.
-	FormatViolationV2             ocpp.ErrorCode = "FormatViolation"               // Payload for Action is syntactically incorrect. This is only valid for OCPP 2.0.1
-	FormatViolationV16            ocpp.ErrorCode = "FormationViolation"            // Payload for Action is syntactically incorrect or not conform the PDU structure for Action. This is only valid for OCPP 1.6
+	NotImplemented               ocpp.ErrorCode = "NotImplemented"               // Requested Action is not known by receiver.
+	NotSupported                 ocpp.ErrorCode = "NotSupported"                 // Requested Action is recognized but not supported by the receiver.
+	InternalError                ocpp.ErrorCode = "InternalError"                // An internal error occurred and the receiver was not able to process the requested Action successfully.
+	MessageTypeNotSupported      ocpp.ErrorCode = "MessageTypeNotSupported"      // A message with an Message Type Number received that is not supported by this implementation.
+	ProtocolError                ocpp.ErrorCode = "ProtocolError"                // Payload for Action is incomplete.
+	SecurityError                ocpp.ErrorCode = "SecurityError"                // During the processing of Action a security issue occurred preventing receiver from completing the Action successfully.
+	PropertyConstraintViolation  ocpp.ErrorCode = "PropertyConstraintViolation"  // Payload is syntactically correct but at least one field contains an invalid value.
+	OccurenceConstraintViolation ocpp.ErrorCode = "OccurenceConstraintViolation" // Payload for Action is syntactically correct but at least one of the fields violates occurrence constraints.
+	TypeConstraintViolation      ocpp.ErrorCode = "TypeConstraintViolation"      // Payload for Action is syntactically correct but at least one of the fields violates data type constraints (e.g. “somestring”: 12).
+	GenericError                 ocpp.ErrorCode = "GenericError"                 // Any other error not covered by the previous ones.
+	FormatViolationV2            ocpp.ErrorCode = "FormatViolation"              // Payload for Action is syntactically incorrect. This is only valid for OCPP 2.0.1
+	FormatViolationV16           ocpp.ErrorCode = "FormationViolation"           // Payload for Action is syntactically incorrect or not conform the PDU structure for Action. This is only valid for OCPP 1.6
 )
 
 type dialector interface {
@@ -216,7 +216,7 @@ func FormatErrorType(d dialector) ocpp.ErrorCode {
 func IsErrorCodeValid(fl validator.FieldLevel) bool {
 	code := ocpp.ErrorCode(fl.Field().String())
 	switch code {
-	case NotImplemented, NotSupported, InternalError, MessageTypeNotSupported, ProtocolError, SecurityError, FormatViolationV16, FormatViolationV2, PropertyConstraintViolation, OccurrenceConstraintViolation, TypeConstraintViolation, GenericError:
+	case NotImplemented, NotSupported, InternalError, MessageTypeNotSupported, ProtocolError, SecurityError, FormatViolationV16, FormatViolationV2, PropertyConstraintViolation, OccurenceConstraintViolation, TypeConstraintViolation, GenericError:
 		return true
 	}
 	return false
@@ -268,7 +268,7 @@ func occurenceViolation(fieldError validator.FieldError, messageId, feature stri
 	if feature != "" {
 		description = fmt.Sprintf("%s for feature %s", description, feature)
 	}
-	return ocpp.NewError(OccurrenceConstraintViolation, description, messageId)
+	return ocpp.NewError(OccurenceConstraintViolation, description, messageId)
 }
 
 func propertyConstraintViolation(fieldError validator.FieldError, details, messageId, feature string) *ocpp.Error {

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -737,7 +737,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidRequest() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, messageId, protoErr.MessageId)
-	assert.Equal(t, ocppj.OccurrenceConstraintViolation, protoErr.Code)
+	assert.Equal(t, ocppj.OccurenceConstraintViolation, protoErr.Code)
 	// Test invalid request -> max constraint wrong
 	mockRequest.MockValue = "somelongvalue"
 	message, err = suite.chargePoint.ParseMessage(mockMessage, suite.chargePoint.RequestState)
@@ -766,7 +766,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidConfirmation() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, messageId, protoErr.MessageId)
-	assert.Equal(t, ocppj.OccurrenceConstraintViolation, protoErr.Code)
+	assert.Equal(t, ocppj.OccurenceConstraintViolation, protoErr.Code)
 	// Test invalid request -> max constraint wrong
 	mockConfirmation.MockValue = "min"
 	suite.chargePoint.RequestState.AddPendingRequest(messageId, pendingRequest) // Manually add a pending request, so that responses are not rejected


### PR DESCRIPTION
## Proposed changes

Currently when there are errors in ocpp message central system responds to the chargers with OccurrenceConstraintViolation error code for example, a missing value for a measurand in the MeterValues.Req.

However, there is an extra "r" in the error code and is a deviation from the OCPP spec. This also causes few of the chargers to indefinitely send the same faulty OCPP message until its cache gets exhausted and needs to be fixed. 
Error code from the documentation - https://downloads.regulations.gov/FHWA-2022-0008-0403/attachment_6.pdf

As part of this change the type is fixed and the status has been changed from OccurrenceConstraintViolation to OccurenceConstraintViolation.

NOTE: OccurrenceConstraintViolation is a typo in both OCPP 1.6 and OCPP 2.0.1. The right error code for both the versions is OccurenceConstraintViolation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/xBlaz3kx/ocppManager-go/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
NA