### PR TITLE
allow overriding charge point id resolution

### DIFF
--- a/ws/mocks/mock_Server.go
+++ b/ws/mocks/mock_Server.go
@@ -244,6 +244,39 @@ func (_c *MockServer_SetBasicAuthHandler_Call) RunAndReturn(run func(func(string
 	return _c
 }
 
+// SetChargePointIdResolver provides a mock function with given fields: resolver
+func (_m *MockServer) SetChargePointIdResolver(resolver func(*http.Request) (string, error)) {
+	_m.Called(resolver)
+}
+
+// MockServer_SetChargePointIdResolver_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetChargePointIdResolver'
+type MockServer_SetChargePointIdResolver_Call struct {
+	*mock.Call
+}
+
+// SetChargePointIdResolver is a helper method to define mock.On call
+//   - resolver func(*http.Request)(string , error)
+func (_e *MockServer_Expecter) SetChargePointIdResolver(resolver interface{}) *MockServer_SetChargePointIdResolver_Call {
+	return &MockServer_SetChargePointIdResolver_Call{Call: _e.mock.On("SetChargePointIdResolver", resolver)}
+}
+
+func (_c *MockServer_SetChargePointIdResolver_Call) Run(run func(resolver func(*http.Request) (string, error))) *MockServer_SetChargePointIdResolver_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(func(*http.Request) (string, error)))
+	})
+	return _c
+}
+
+func (_c *MockServer_SetChargePointIdResolver_Call) Return() *MockServer_SetChargePointIdResolver_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockServer_SetChargePointIdResolver_Call) RunAndReturn(run func(func(*http.Request) (string, error))) *MockServer_SetChargePointIdResolver_Call {
+	_c.Run(run)
+	return _c
+}
+
 // SetCheckClientHandler provides a mock function with given fields: handler
 func (_m *MockServer) SetCheckClientHandler(handler ws.CheckClientHandler) {
 	_m.Called(handler)


### PR DESCRIPTION
## Proposed changes

This introduces a new `SetChargePointIdResolver` function to the `WsServer` that allows providing a custom hook for determining the charge point ID of a new charger connecting to the server. By default, this keeps the current behavior that uses the path of the request as the charge point ID, but it will allow this to be overridden if needed. My own use case for this is that I also need to merge in part of the HTTP Host into the charge point ID to be able to propagate certain states downstream, and this felt like a non-intrusive way to support that.

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/xBlaz3kx/ocppManager-go/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

While evaluating this library for our OCPP needs I opened #315 to explore potential solutions to this issue. That can consider closed as far as I am concerned if this change is accepted and merged.