### PR TITLE
Fix OccurrenceConstraintViolation in v2.0.1

### DIFF
--- a/ocpp1.6_test/proto_test.go
+++ b/ocpp1.6_test/proto_test.go
@@ -51,7 +51,7 @@ func (suite *OcppV16TestSuite) TestChargePointSendResponseError() {
 		{
 			name:        "ocurrence validation",
 			confirmData: CustomData{Field1: "", Field2: 42},
-			expectedErr: &ocpp.Error{Code: ocppj.OccurrenceConstraintViolation, Description: "Field CallResult.Payload.Data.Field1 required but not found for feature DataTransfer"},
+			expectedErr: &ocpp.Error{Code: ocppj.OccurrenceConstraintViolationV16, Description: "Field CallResult.Payload.Data.Field1 required but not found for feature DataTransfer"},
 		},
 		{
 			name:        "marshaling error",
@@ -130,7 +130,7 @@ func (suite *OcppV16TestSuite) TestCentralSystemSendResponseError() {
 	require.Error(t, err)
 	require.IsType(t, &ocpp.Error{}, err)
 	ocppErr = err.(*ocpp.Error)
-	assert.Equal(t, ocppj.OccurrenceConstraintViolation, ocppErr.Code)
+	assert.Equal(t, ocppj.OccurrenceConstraintViolationV16, ocppErr.Code)
 	assert.Equal(t, "Field CallResult.Payload.Data.Field1 required but not found for feature DataTransfer", ocppErr.Description)
 	// Test 2: marshaling error
 	dataTransferConfirmation = core.NewDataTransferConfirmation(core.DataTransferStatusAccepted)
@@ -158,4 +158,5 @@ func (suite *OcppV16TestSuite) TestCentralSystemSendResponseError() {
 
 func (suite *OcppV16TestSuite) TestErrorCodes() {
 	suite.Equal(ocppj.FormatViolationV16, ocppj.FormatErrorType(suite.ocppjCentralSystem))
+	suite.Equal(ocppj.OccurrenceConstraintViolationV16, ocppj.OccurrenceConstraintErrorType(suite.ocppjCentralSystem))
 }

--- a/ocpp2.0.1_test/proto_test.go
+++ b/ocpp2.0.1_test/proto_test.go
@@ -57,7 +57,7 @@ func (suite *OcppV2TestSuite) TestChargePointSendResponseError() {
 	result := <-resultChannel
 	require.IsType(t, &ocpp.Error{}, result)
 	ocppErr = result.(*ocpp.Error)
-	assert.Equal(t, ocppj.OccurrenceConstraintViolation, ocppErr.Code)
+	assert.Equal(t, ocppj.OccurrenceConstraintViolationV2, ocppErr.Code)
 	assert.Equal(t, "Field CallResult.Payload.Data.Field1 required but not found for feature DataTransfer", ocppErr.Description)
 	// Test 2: marshaling error
 	dataTransferResponse = data.NewDataTransferResponse(data.DataTransferStatusAccepted)
@@ -132,7 +132,7 @@ func (suite *OcppV2TestSuite) TestCentralSystemSendResponseError() {
 	require.Error(t, err)
 	require.IsType(t, &ocpp.Error{}, err)
 	ocppErr = err.(*ocpp.Error)
-	assert.Equal(t, ocppj.OccurrenceConstraintViolation, ocppErr.Code)
+	assert.Equal(t, ocppj.OccurrenceConstraintViolationV2, ocppErr.Code)
 	assert.Equal(t, "Field CallResult.Payload.Data.Field1 required but not found for feature DataTransfer", ocppErr.Description)
 	// Test 2: marshaling error
 	dataTransferResponse = data.NewDataTransferResponse(data.DataTransferStatusAccepted)
@@ -160,4 +160,5 @@ func (suite *OcppV2TestSuite) TestCentralSystemSendResponseError() {
 
 func (suite *OcppV2TestSuite) TestErrorCodes() {
 	suite.Equal(ocppj.FormatViolationV2, ocppj.FormatErrorType(suite.ocppjServer))
+	suite.Equal(ocppj.OccurrenceConstraintViolationV2, ocppj.OccurrenceConstraintErrorType(suite.ocppjServer))
 }

--- a/ocppj/central_system_test.go
+++ b/ocppj/central_system_test.go
@@ -332,7 +332,7 @@ func (suite *OcppJTestSuite) TestCentralSystemHandleFailedResponse() {
 	require.Nil(t, callResult)
 	suite.centralSystem.HandleFailedResponseError(mockChargePointID, mockUniqueID, err, mockResponse.GetFeatureName())
 	rawResponse := <-msgC
-	expectedErr := fmt.Sprintf(`[4,"%v","%v","Field %s required but not found for feature %s",{}]`, mockUniqueID, ocppj.OccurrenceConstraintViolation, mockField, mockResponse.GetFeatureName())
+	expectedErr := fmt.Sprintf(`[4,"%v","%v","Field %s required but not found for feature %s",{}]`, mockUniqueID, ocppj.OccurrenceConstraintErrorType(suite.centralSystem), mockField, mockResponse.GetFeatureName())
 	assert.Equal(t, expectedErr, string(rawResponse))
 	// 2. property constraint validation error
 	val := "len4"

--- a/ocppj/charge_point_test.go
+++ b/ocppj/charge_point_test.go
@@ -306,7 +306,7 @@ func (suite *OcppJTestSuite) TestChargePointHandleFailedResponse() {
 	require.Nil(t, callResult)
 	suite.chargePoint.HandleFailedResponseError(mockUniqueID, err, mockResponse.GetFeatureName())
 	rawResponse := <-msgC
-	expectedErr := fmt.Sprintf(`[4,"%v","%v","Field %s required but not found for feature %s",{}]`, mockUniqueID, ocppj.OccurrenceConstraintViolation, mockField, mockResponse.GetFeatureName())
+	expectedErr := fmt.Sprintf(`[4,"%v","%v","Field %s required but not found for feature %s",{}]`, mockUniqueID, ocppj.OccurrenceConstraintErrorType(suite.chargePoint), mockField, mockResponse.GetFeatureName())
 	assert.Equal(t, expectedErr, string(rawResponse))
 	// 2. property constraint validation error
 	val := "len4"

--- a/ocppj/client.go
+++ b/ocppj/client.go
@@ -1,6 +1,7 @@
 package ocppj
 
 import (
+	"errors"
 	"fmt"
 
 	"gopkg.in/go-playground/validator.v9"
@@ -331,11 +332,12 @@ func (c *Client) HandleFailedResponseError(requestID string, err error, featureN
 	switch err.(type) {
 	case validator.ValidationErrors:
 		// Validation error
-		validationErr := err.(validator.ValidationErrors)
-		responseErr = errorFromValidation(validationErr, requestID, featureName)
+		var validationErr validator.ValidationErrors
+		errors.As(err, &validationErr)
+		responseErr = errorFromValidation(c, validationErr, requestID, featureName)
 	case *ocpp.Error:
 		// Internal OCPP error
-		responseErr = err.(*ocpp.Error)
+		errors.As(err, &responseErr)
 	case error:
 		// Unknown error
 		responseErr = ocpp.NewError(GenericError, err.Error(), requestID)

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -740,7 +740,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidRequest() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, messageId, protoErr.MessageId)
-	assert.Equal(t, ocppj.OccurrenceConstraintViolation, protoErr.Code)
+	assert.Equal(t, ocppj.OccurrenceConstraintErrorType(suite.chargePoint), protoErr.Code)
 	// Test invalid request -> max constraint wrong
 	mockRequest.MockValue = "somelongvalue"
 	message, err = suite.chargePoint.ParseMessage(mockMessage, suite.chargePoint.RequestState)
@@ -769,7 +769,7 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidConfirmation() {
 	protoErr := err.(*ocpp.Error)
 	require.NotNil(t, protoErr)
 	assert.Equal(t, messageId, protoErr.MessageId)
-	assert.Equal(t, ocppj.OccurrenceConstraintViolation, protoErr.Code)
+	assert.Equal(t, ocppj.OccurrenceConstraintErrorType(suite.chargePoint), protoErr.Code)
 	// Test invalid request -> max constraint wrong
 	mockConfirmation.MockValue = "min"
 	suite.chargePoint.RequestState.AddPendingRequest(messageId, pendingRequest) // Manually add a pending request, so that responses are not rejected

--- a/ocppj/server.go
+++ b/ocppj/server.go
@@ -1,6 +1,7 @@
 package ocppj
 
 import (
+	"errors"
 	"fmt"
 
 	"gopkg.in/go-playground/validator.v9"
@@ -304,11 +305,12 @@ func (s *Server) HandleFailedResponseError(clientID string, requestID string, er
 	switch err.(type) {
 	case validator.ValidationErrors:
 		// Validation error
-		validationErr := err.(validator.ValidationErrors)
-		responseErr = errorFromValidation(validationErr, requestID, featureName)
+		var validationErr validator.ValidationErrors
+		errors.As(err, &validationErr)
+		responseErr = errorFromValidation(s, validationErr, requestID, featureName)
 	case *ocpp.Error:
 		// Internal OCPP error
-		responseErr = err.(*ocpp.Error)
+		errors.As(err, &responseErr)
 	case error:
 		// Unknown error
 		responseErr = ocpp.NewError(GenericError, err.Error(), requestID)


### PR DESCRIPTION
## Proposed changes

Improves upon https://github.com/lorenzodonini/ocpp-go/pull/331 by:
- using `OccurenceConstraintViolation` with a typo for v1.6
- using `OccurrenceConstraintViolation` without typo for v2.0.1

The original `OccurrenceConstraintViolation` constant is now replaced by:
- `OccurrenceConstraintViolationV16`
- `OccurrenceConstraintViolationV2`

In theory this should have no effect on existing implementations, unless they manually accessed/returned this constant value.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...