### PR TITLE
pass the chargepoint id to basic auth handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Example central system:
 
 ```go
 server := ws.NewServer()
-server.SetBasicAuthHandler(func (username string, password string) bool {
+server.SetBasicAuthHandler(func (chargePointID string, username string, password string) bool {
 // todo Handle basic auth
 return true
 })

--- a/ws/mocks/mock_Server.go
+++ b/ws/mocks/mock_Server.go
@@ -212,7 +212,7 @@ func (_c *MockServer_GetChannel_Call) RunAndReturn(run func(string) (ws.Channel,
 }
 
 // SetBasicAuthHandler provides a mock function with given fields: handler
-func (_m *MockServer) SetBasicAuthHandler(handler func(string, string) bool) {
+func (_m *MockServer) SetBasicAuthHandler(handler func(string, string, string) bool) {
 	_m.Called(handler)
 }
 
@@ -222,14 +222,14 @@ type MockServer_SetBasicAuthHandler_Call struct {
 }
 
 // SetBasicAuthHandler is a helper method to define mock.On call
-//   - handler func(string , string) bool
+//   - handler func(string , string , string) bool
 func (_e *MockServer_Expecter) SetBasicAuthHandler(handler interface{}) *MockServer_SetBasicAuthHandler_Call {
 	return &MockServer_SetBasicAuthHandler_Call{Call: _e.mock.On("SetBasicAuthHandler", handler)}
 }
 
-func (_c *MockServer_SetBasicAuthHandler_Call) Run(run func(handler func(string, string) bool)) *MockServer_SetBasicAuthHandler_Call {
+func (_c *MockServer_SetBasicAuthHandler_Call) Run(run func(handler func(string, string, string) bool)) *MockServer_SetBasicAuthHandler_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(func(string, string) bool))
+		run(args[0].(func(string, string, string) bool))
 	})
 	return _c
 }
@@ -239,7 +239,7 @@ func (_c *MockServer_SetBasicAuthHandler_Call) Return() *MockServer_SetBasicAuth
 	return _c
 }
 
-func (_c *MockServer_SetBasicAuthHandler_Call) RunAndReturn(run func(func(string, string) bool)) *MockServer_SetBasicAuthHandler_Call {
+func (_c *MockServer_SetBasicAuthHandler_Call) RunAndReturn(run func(func(string, string, string) bool)) *MockServer_SetBasicAuthHandler_Call {
 	_c.Run(run)
 	return _c
 }

--- a/ws/server.go
+++ b/ws/server.go
@@ -100,7 +100,7 @@ type Server interface {
 	// SetBasicAuthHandler enables HTTP Basic Authentication and requires clients to pass credentials.
 	// The handler function is called whenever a new client attempts to connect, to check for credentials correctness.
 	// The handler must return true if the credentials were correct, false otherwise.
-	SetBasicAuthHandler(handler func(username string, password string) bool)
+	SetBasicAuthHandler(handler func(chargePointID string, username string, password string) bool)
 	// SetCheckOriginHandler sets a handler for incoming websocket connections, allowing to perform
 	// custom cross-origin checks.
 	//
@@ -133,7 +133,7 @@ type server struct {
 	checkClientHandler  CheckClientHandler
 	newClientHandler    func(ws Channel)
 	disconnectedHandler func(ws Channel)
-	basicAuthHandler    func(username string, password string) bool
+	basicAuthHandler    func(chargePointID string, username string, password string) bool
 	tlsCertificatePath  string
 	tlsCertificateKey   string
 	timeoutConfig       ServerTimeoutConfig
@@ -220,7 +220,7 @@ func (s *server) AddSupportedSubprotocol(subProto string) {
 	s.upgrader.Subprotocols = append(s.upgrader.Subprotocols, subProto)
 }
 
-func (s *server) SetBasicAuthHandler(handler func(username string, password string) bool) {
+func (s *server) SetBasicAuthHandler(handler func(chargePointID string, username string, password string) bool) {
 	s.basicAuthHandler = handler
 }
 
@@ -371,7 +371,7 @@ out:
 	if s.basicAuthHandler != nil {
 		username, password, ok := r.BasicAuth()
 		if ok {
-			ok = s.basicAuthHandler(username, password)
+			ok = s.basicAuthHandler(id, username, password)
 		}
 		if !ok {
 			s.error(fmt.Errorf("basic auth failed: credentials invalid"))

--- a/ws/websocket_test.go
+++ b/ws/websocket_test.go
@@ -691,7 +691,8 @@ func (s *WebSocketSuite) TestValidBasicAuth() {
 	s.server, ok = tlsServer.(*server)
 	s.True(ok)
 	// Add basic auth handler
-	s.server.SetBasicAuthHandler(func(username string, password string) bool {
+	s.server.SetBasicAuthHandler(func(chargePointID string, username string, password string) bool {
+		s.Equal(testPath, chargePointID)
 		s.Equal(authUsername, username)
 		s.Equal(authPassword, password)
 		return true
@@ -746,8 +747,8 @@ func (s *WebSocketSuite) TestInvalidBasicAuth() {
 	s.server, ok = tlsServer.(*server)
 	s.True(ok)
 	// Add basic auth handler
-	s.server.SetBasicAuthHandler(func(username string, password string) bool {
-		validCredentials := authUsername == username && authPassword == password
+	s.server.SetBasicAuthHandler(func(chargePointID string, username string, password string) bool {
+		validCredentials := testPath == chargePointID && authUsername == username && authPassword == password
 		s.False(validCredentials)
 		return validCredentials
 	})
@@ -1276,7 +1277,7 @@ func (s *WebSocketSuite) TestClientErrors() {
 	conn := s.server.connections[path.Base(testPath)]
 	s.NotNil(conn)
 	err = conn.WriteManual(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseUnsupportedData, ""))
-	//err = conn.connection.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseUnsupportedData, ""))
+	// err = conn.connection.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseUnsupportedData, ""))
 	s.NoError(err)
 	r = <-triggerC
 	s.NotNil(r)


### PR DESCRIPTION
## Proposed changes

This makes the chargepoint ID used by the charger when authenticating part of the context the basic auth handler receives when authenticating the connection.

This is a breaking change, as it changes the basic auth handler signature. An option would be to introduce this as a separate type of basic auth handler, which I can change if you would prefer that path instead.

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/xBlaz3kx/ocppManager-go/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The use case for this builds on #346. If you using that PR have some custom chargepoint ID resolution set up, that might contain context necessary to authenticate the charger. A specific use-case I have for this is that the host the charger uses in the `Host` header is a significant part of the internal charge point ID; without that information in the basic auth handler I cannot authenticate the chargers.