### PR TITLE
Fix GetCertificateStatusResponse.status type to Certificate15118EVStatus instead of genericStatus - ocpp2.0.1

### DIFF
--- a/ocpp2.0.1/iso15118/get_certificate_status.go
+++ b/ocpp2.0.1/iso15118/get_certificate_status.go
@@ -18,9 +18,9 @@ type GetCertificateStatusRequest struct {
 // This field definition of the GetCertificateStatus response payload, sent by the CSMS to the Charging Station in response to a GetCertificateStatusRequest.
 // In case the request was invalid, or couldn't be processed, an error will be sent instead.
 type GetCertificateStatusResponse struct {
-	Status     types.GenericStatus `json:"status" validate:"required,genericStatus"`
-	OcspResult string              `json:"ocspResult,omitempty" validate:"omitempty,max=5500"`
-	StatusInfo *types.StatusInfo   `json:"statusInfo,omitempty" validate:"omitempty"`
+	Status     types.Certificate15118EVStatus `json:"status" validate:"required,15118EVCertificate"`
+	OcspResult string                         `json:"ocspResult,omitempty" validate:"omitempty,max=5500"`
+	StatusInfo *types.StatusInfo              `json:"statusInfo,omitempty" validate:"omitempty"`
 }
 
 // For 15118 certificate installation on EVs, the Charging Station requests the CSMS to provide the OCSP certificate
@@ -56,6 +56,6 @@ func NewGetCertificateStatusRequest(ocspRequestData types.OCSPRequestDataType) *
 }
 
 // Creates a new GetCertificateStatusResponse, containing all required fields. Optional fields may be set afterwards.
-func NewGetCertificateStatusResponse(status types.GenericStatus) *GetCertificateStatusResponse {
+func NewGetCertificateStatusResponse(status types.Certificate15118EVStatus) *GetCertificateStatusResponse {
 	return &GetCertificateStatusResponse{Status: status}
 }

--- a/ocpp2.0.1/iso15118/get_installed_certificate_ids.go
+++ b/ocpp2.0.1/iso15118/get_installed_certificate_ids.go
@@ -31,7 +31,7 @@ func isValidGetInstalledCertificateStatus(fl validator.FieldLevel) bool {
 
 // The field definition of the GetInstalledCertificateIdsRequest PDU sent by the CSMS to the Charging Station.
 type GetInstalledCertificateIdsRequest struct {
-	CertificateTypes []types.CertificateUse `json:"certificateType" validate:"omitempty,dive,certificateUse"`
+	CertificateTypes []types.CertificateUse `json:"certificateType,omitempty" validate:"omitempty,dive,certificateUse"`
 }
 
 // The field definition of the GetInstalledCertificateIds response payload sent by the Charging Station to the CSMS in response to a GetInstalledCertificateIdsRequest.

--- a/ocpp2.0.1_test/get_certificate_status_test.go
+++ b/ocpp2.0.1_test/get_certificate_status_test.go
@@ -25,11 +25,11 @@ func (suite *OcppV2TestSuite) TestGetCertificateStatusRequestValidation() {
 func (suite *OcppV2TestSuite) TestGetCertificateStatusConfirmationValidation() {
 	t := suite.T()
 	var confirmationTable = []GenericTestEntry{
-		{iso15118.GetCertificateStatusResponse{Status: types.GenericStatusAccepted, OcspResult: "deadbeef"}, true},
-		{iso15118.GetCertificateStatusResponse{Status: types.GenericStatusAccepted}, true},
-		{iso15118.GetCertificateStatusResponse{Status: types.GenericStatusRejected}, true},
+		{iso15118.GetCertificateStatusResponse{Status: types.Certificate15188EVStatusAccepted, OcspResult: "deadbeef"}, true},
+		{iso15118.GetCertificateStatusResponse{Status: types.Certificate15188EVStatusAccepted}, true},
+		{iso15118.GetCertificateStatusResponse{Status: types.Certificate15118EVStatusFailed}, true},
 		{iso15118.GetCertificateStatusResponse{Status: "invalidGenericStatus"}, false},
-		{iso15118.GetCertificateStatusResponse{Status: types.GenericStatusAccepted, OcspResult: newLongString(5501)}, false},
+		{iso15118.GetCertificateStatusResponse{Status: types.Certificate15188EVStatusAccepted, OcspResult: newLongString(5501)}, false},
 		{iso15118.GetCertificateStatusResponse{}, false},
 	}
 	ExecuteGenericTestTable(t, confirmationTable)
@@ -42,7 +42,7 @@ func (suite *OcppV2TestSuite) TestGetCertificateStatusE2EMocked() {
 	wsUrl := "someUrl"
 	ocspData := types.OCSPRequestDataType{HashAlgorithm: types.SHA256, IssuerNameHash: "hash00", IssuerKeyHash: "hash01", SerialNumber: "serial0", ResponderURL: "http://someUrl"}
 	ocspResult := "deadbeef"
-	status := types.GenericStatusAccepted
+	status := types.Certificate15188EVStatusAccepted
 	requestJson := fmt.Sprintf(`[2,"%v","%v",{"ocspRequestData":{"hashAlgorithm":"%v","issuerNameHash":"%v","issuerKeyHash":"%v","serialNumber":"%v","responderURL":"%v"}}]`,
 		messageId, iso15118.GetCertificateStatusFeatureName, ocspData.HashAlgorithm, ocspData.IssuerNameHash, ocspData.IssuerKeyHash, ocspData.SerialNumber, ocspData.ResponderURL)
 	responseJson := fmt.Sprintf(`[3,"%v",{"status":"%v","ocspResult":"%v"}]`, messageId, status, ocspResult)

--- a/ocpp2.0.1_test/get_composite_schedule_test.go
+++ b/ocpp2.0.1_test/get_composite_schedule_test.go
@@ -73,6 +73,7 @@ func (suite *OcppV2TestSuite) TestGetCompositeScheduleE2EMocked() {
 	responseJson := fmt.Sprintf(`[3,"%v",{"status":"%v","statusInfo":{"reasonCode":"%v"},"schedule":{"startDateTime":"%v","chargingSchedule":{"id":%v,"startSchedule":"%v","duration":%v,"chargingRateUnit":"%v","minChargingRate":%v,"chargingSchedulePeriod":[{"startPeriod":%v,"limit":%v,"numberPhases":%v}]}}}]`,
 		messageId, status, statusInfo.ReasonCode, compositeSchedule.StartDateTime.FormatTimestamp(), chargingSchedule.ID, chargingSchedule.StartSchedule.FormatTimestamp(), *chargingSchedule.Duration, chargingSchedule.ChargingRateUnit, *chargingSchedule.MinChargingRate, chargingSchedulePeriod.StartPeriod, chargingSchedulePeriod.Limit, *chargingSchedulePeriod.NumberPhases)
 	getCompositeScheduleConfirmation := smartcharging.NewGetCompositeScheduleResponse(status)
+	getCompositeScheduleConfirmation.StatusInfo = statusInfo
 	getCompositeScheduleConfirmation.Schedule = &compositeSchedule
 	channel := NewMockWebSocket(wsId)
 


### PR DESCRIPTION
## Proposed changes

- Fix  type of field  `GetCertificateStatusResponse.Status` to `types.Certificate15118EVStatus` instead of `types.GenericStatus`
- Add omitempty to `certificateType` field base on doc. spec requirement
- Also fix panic  nil pointer `confirmation.StatusInfo.ReasonCode` in unit test `TestGetCompositeScheduleE2EMocked`

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/xBlaz3kx/ocppManager-go/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Fix  type of field  `GetCertificateStatusResponse.Status` to `types.Certificate15118EVStatus` instead of `types.GenericStatus`:
<img width="1257" height="318" alt="image" src="https://github.com/user-attachments/assets/4cbd79d5-b113-4266-8720-ffb0e39b53e8" />

  
  
Add omitempty to `certificateType` field on `GetInstalledCertificateIdsRequest` base on doc. spec:
<img width="1238" height="308" alt="image" src="https://github.com/user-attachments/assets/16b458a5-a4ee-4829-b6f1-d8dd1034ceb7" />
