### PR TITLE
fix: Make CompositeSchedule (2.0.1) type to comply with the schema

### DIFF
--- a/ocpp2.0.1/smartcharging/get_composite_schedule.go
+++ b/ocpp2.0.1/smartcharging/get_composite_schedule.go
@@ -30,8 +30,11 @@ func isValidGetCompositeScheduleStatus(fl validator.FieldLevel) bool {
 }
 
 type CompositeSchedule struct {
-	StartDateTime    *types.DateTime         `json:"startDateTime,omitempty" validate:"omitempty"`
-	ChargingSchedule *types.ChargingSchedule `json:"chargingSchedule,omitempty" validate:"omitempty"`
+	ChargingSchedulePeriod []types.ChargingSchedulePeriod `json:"chargingSchedulePeriod" validate:"required,min=1"`
+	EvseID                 int                            `json:"evseId" validate:"required,gte=0"`
+	Duration               int                            `json:"duration" validate:"required,gte=0"`
+	ScheduleStart          types.DateTime                 `json:"scheduleStart" validate:"required"`
+	ChargingRateUnit       types.ChargingRateUnitType     `json:"chargingRateUnit" validate:"required,chargingRateUnit201"`
 }
 
 // The field definition of the GetCompositeSchedule request payload sent by the CSMS to the Charging System.

--- a/ocpp2.0.1/types/types.go
+++ b/ocpp2.0.1/types/types.go
@@ -500,6 +500,7 @@ type ChargingSchedulePeriod struct {
 	StartPeriod  int     `json:"startPeriod" validate:"gte=0"`
 	Limit        float64 `json:"limit" validate:"gte=0"`
 	NumberPhases *int    `json:"numberPhases,omitempty" validate:"omitempty,gte=0"`
+	PhaseToUse   *int    `json:"phaseToUse,omitempty" validate:"omitempty,gte=1,lte=3"`
 }
 
 func NewChargingSchedulePeriod(startPeriod int, limit float64) ChargingSchedulePeriod {

--- a/ocpp2.0.1_test/common_test.go
+++ b/ocpp2.0.1_test/common_test.go
@@ -89,6 +89,8 @@ func (suite *OcppV2TestSuite) TestChargingSchedulePeriodValidation() {
 		{types.ChargingSchedulePeriod{StartPeriod: 0, Limit: -1.0}, false},
 		{types.ChargingSchedulePeriod{StartPeriod: -1, Limit: 10.0}, false},
 		{types.ChargingSchedulePeriod{StartPeriod: 0, Limit: 10.0, NumberPhases: newInt(-1)}, false},
+		{types.ChargingSchedulePeriod{StartPeriod: 0, Limit: 10.0, NumberPhases: newInt(3), PhaseToUse: newInt(0)}, false},
+		{types.ChargingSchedulePeriod{StartPeriod: 0, Limit: 10.0, NumberPhases: newInt(3), PhaseToUse: newInt(4)}, false},
 	}
 	ExecuteGenericTestTable(t, testTable)
 }


### PR DESCRIPTION
## Proposed changes

* Fix CompositeSchedule type (and associated ChargingSchedulePeriod) to comply with OCPP 2.0.1 schema
* Update the relevant tests

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/xBlaz3kx/ocppManager-go/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

This fix is related to the issue [#385](https://github.com/lorenzodonini/ocpp-go/issues/385).