### PR TITLE
fix: set dialect on ocpp 2.0.1 server

### DIFF
--- a/ocpp2.0.1/v2.go
+++ b/ocpp2.0.1/v2.go
@@ -440,6 +440,9 @@ func NewCSMS(endpoint *ocppj.Server, server ws.Server) CSMS {
 			transactions.Profile,
 		)
 	}
+
+	endpoint.SetDialect(ocpp.V2)
+
 	cs := newCSMS(endpoint)
 	cs.server.SetRequestHandler(func(client ws.Channel, request ocpp.Request, requestId string, action string) {
 		cs.handleIncomingRequest(client, request, requestId, action)


### PR DESCRIPTION
## Proposed changes

- Instantiating ocpp 2.0.1 server doesnt explicitly set the endpoint dialect to v2. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/xBlaz3kx/ocppManager-go/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
