### PR TITLE
fix: prevent deadlock in server Write and websocket Close/WriteManual

### DIFF
--- a/ws/server.go
+++ b/ws/server.go
@@ -344,8 +344,8 @@ func (s *server) stopConnections() {
 
 func (s *server) Write(webSocketId string, data []byte) error {
 	s.connMutex.RLock()
-	defer s.connMutex.RUnlock()
 	w, ok := s.connections[webSocketId]
+	s.connMutex.RUnlock()
 	if !ok {
 		return fmt.Errorf("couldn't write to websocket. No socket with id %v is open", webSocketId)
 	}

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -286,26 +286,44 @@ func (w *webSocket) Write(data []byte) error {
 	return w.WriteManual(websocket.TextMessage, data)
 }
 
-func (w *webSocket) WriteManual(messageTyp int, data []byte) error {
+func (w *webSocket) WriteManual(messageTyp int, data []byte) (err error) {
 	msg := message{
 		typ:  messageTyp,
 		data: data,
 	}
 	w.mutex.RLock()
-	defer w.mutex.RUnlock()
 	if w.connection == nil {
+		w.mutex.RUnlock()
 		return fmt.Errorf("cannot write to closed connection %s", w.id)
 	}
+	w.mutex.RUnlock()
+	// Recover from a potential panic if outQueue was closed between the nil
+	// check above and the channel send below. This can happen when cleanup()
+	// runs concurrently.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("cannot write to closed connection %s", w.id)
+		}
+	}()
 	w.outQueue <- msg
 	return nil
 }
 
-func (w *webSocket) Close(closeError websocket.CloseError) error {
+func (w *webSocket) Close(closeError websocket.CloseError) (err error) {
 	w.mutex.RLock()
-	defer w.mutex.RUnlock()
 	if w.connection == nil {
+		w.mutex.RUnlock()
 		return fmt.Errorf("cannot close already closed connection %s", w.id)
 	}
+	w.mutex.RUnlock()
+	// Recover from a potential panic if closeC was closed between the nil
+	// check above and the channel send below. This can happen when cleanup()
+	// runs concurrently.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("cannot close already closed connection %s", w.id)
+		}
+	}()
 	w.closeC <- closeError
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes #291

`server.Write` held `connMutex.RLock` while calling `webSocket.WriteManual`, which held `webSocket.mutex.RLock` while sending on `outQueue`. If the channel buffer was full, the goroutine blocked holding both read locks. Concurrently, `cleanup()` needed both write locks — deadlock.

The fix releases each lock immediately after the map lookup / nil check, before any channel send. A deferred `recover` handles the race where `cleanup()` closes the channel between the nil check and the send.

**Changes:**
- `server.Write`: release `connMutex.RLock` right after map lookup
- `webSocket.WriteManual`: release `mutex.RLock` after nil check, add recover
- `webSocket.Close`: same pattern as WriteManual

## Test plan
- [ ] `go test ./ws/... -v -race` passes
- [ ] Verify concurrent writes + forced disconnects no longer freeze the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)