### PR TITLE
fix: prevent panic on closed channel onPing

### DIFF
--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -357,9 +357,15 @@ func (w *webSocket) initPingPong() {
 func (w *webSocket) onPing(appData string) error {
 	conn := w.connection
 	w.log.Debugf("ping received from %s: %s", w.id, appData)
-	// Schedule pong message via dedicated channel
-	w.pingC <- []byte(appData)
-	w.log.Debugf("pong scheduled for %s", w.id)
+	// Schedule pong message via dedicated channel - check if channel is still open
+	select {
+	case w.pingC <- []byte(appData):
+		w.log.Debugf("pong scheduled for %s", w.id)
+	default:
+		// Channel is closed or blocked, connection is likely being cleaned up
+		w.log.Debugf("failed to schedule pong for %s: channel closed", w.id)
+		return fmt.Errorf("connection is being closed")
+	}
 	// Reset read interval after receiving a ping
 	return conn.SetReadDeadline(w.getReadTimeout())
 }

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -357,6 +357,12 @@ func (w *webSocket) initPingPong() {
 func (w *webSocket) onPing(appData string) error {
 	conn := w.connection
 	w.log.Debugf("ping received from %s: %s", w.id, appData)
+	defer func() {
+		if r := recover(); r != nil {
+			// pingC was closed, websocket is shutting down
+			w.log.Debugf("recovered from panic in ping handler for %s: %v", w.id, r)
+		}
+	}()
 	// Schedule pong message via dedicated channel - check if channel is still open
 	select {
 	case w.pingC <- []byte(appData):


### PR DESCRIPTION
## Proposed changes

I am experiencing a panic in some situations related to the Websocket Ping/Pong.
It seems that in some cases (i assume unstable connections but I have been unable to reproduce this in my tests), the connection is being cleaned up and the OnPing still tries to write to the pingC channel, resulting in "panic: send on closed channel".

This should fix that issue.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/xBlaz3kx/ocppManager-go/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
