### PR TITLE
fix: align CompositeSchedule struct with OCPP 2.0.1 spec

### DIFF
--- a/ocpp2.0.1/smartcharging/get_composite_schedule.go
+++ b/ocpp2.0.1/smartcharging/get_composite_schedule.go
@@ -29,9 +29,24 @@ func isValidGetCompositeScheduleStatus(fl validator.FieldLevel) bool {
 	}
 }
 
+// CompositeScheduleType as defined in the OCPP 2.0.1 specification.
 type CompositeSchedule struct {
-	StartDateTime    *types.DateTime         `json:"startDateTime,omitempty" validate:"omitempty"`
-	ChargingSchedule *types.ChargingSchedule `json:"chargingSchedule,omitempty" validate:"omitempty"`
+	EvseID                 int                          `json:"evseId" validate:"gte=0"`
+	Duration               int                          `json:"duration" validate:"gte=0"`
+	ScheduleStart          *types.DateTime              `json:"scheduleStart" validate:"required"`
+	ChargingRateUnit       types.ChargingRateUnitType   `json:"chargingRateUnit" validate:"required,chargingRateUnit201"`
+	ChargingSchedulePeriod []types.ChargingSchedulePeriod `json:"chargingSchedulePeriod" validate:"required,min=1"`
+}
+
+// Creates a new CompositeSchedule, containing all required fields.
+func NewCompositeSchedule(evseId int, duration int, scheduleStart *types.DateTime, chargingRateUnit types.ChargingRateUnitType, chargingSchedulePeriod ...types.ChargingSchedulePeriod) *CompositeSchedule {
+	return &CompositeSchedule{
+		EvseID:                 evseId,
+		Duration:               duration,
+		ScheduleStart:          scheduleStart,
+		ChargingRateUnit:       chargingRateUnit,
+		ChargingSchedulePeriod: chargingSchedulePeriod,
+	}
 }
 
 // The field definition of the GetCompositeSchedule request payload sent by the CSMS to the Charging System.

--- a/ocpp2.0.1_test/get_composite_schedule_test.go
+++ b/ocpp2.0.1_test/get_composite_schedule_test.go
@@ -29,23 +29,27 @@ func (suite *OcppV2TestSuite) TestGetCompositeScheduleRequestValidation() {
 
 func (suite *OcppV2TestSuite) TestGetCompositeScheduleConfirmationValidation() {
 	t := suite.T()
-	chargingSchedule := types.NewChargingSchedule(1, types.ChargingRateUnitWatts, types.NewChargingSchedulePeriod(0, 10.0))
-	chargingSchedule.Duration = newInt(600)
-	chargingSchedule.MinChargingRate = newFloat(6.0)
-	chargingSchedule.StartSchedule = types.NewDateTime(time.Now())
+	period := types.NewChargingSchedulePeriod(0, 10.0)
 	compositeSchedule := smartcharging.CompositeSchedule{
-		StartDateTime:    types.NewDateTime(time.Now()),
-		ChargingSchedule: chargingSchedule,
+		EvseID:                 1,
+		Duration:               600,
+		ScheduleStart:          types.NewDateTime(time.Now()),
+		ChargingRateUnit:       types.ChargingRateUnitWatts,
+		ChargingSchedulePeriod: []types.ChargingSchedulePeriod{period},
 	}
 	var confirmationTable = []GenericTestEntry{
 		{smartcharging.GetCompositeScheduleResponse{Status: smartcharging.GetCompositeScheduleStatusAccepted, StatusInfo: types.NewStatusInfo("reasoncode", ""), Schedule: &compositeSchedule}, true},
-		{smartcharging.GetCompositeScheduleResponse{Status: smartcharging.GetCompositeScheduleStatusAccepted, StatusInfo: types.NewStatusInfo("reasoncode", ""), Schedule: &smartcharging.CompositeSchedule{}}, true},
 		{smartcharging.GetCompositeScheduleResponse{Status: smartcharging.GetCompositeScheduleStatusAccepted, StatusInfo: types.NewStatusInfo("reasoncode", "")}, true},
 		{smartcharging.GetCompositeScheduleResponse{Status: smartcharging.GetCompositeScheduleStatusAccepted}, true},
 		{smartcharging.GetCompositeScheduleResponse{}, false},
 		{smartcharging.GetCompositeScheduleResponse{Status: "invalidGetCompositeScheduleStatus"}, false},
 		{smartcharging.GetCompositeScheduleResponse{Status: smartcharging.GetCompositeScheduleStatusAccepted, StatusInfo: types.NewStatusInfo("invalidreasoncodeasitslongerthan20", "")}, false},
-		{smartcharging.GetCompositeScheduleResponse{Status: smartcharging.GetCompositeScheduleStatusAccepted, StatusInfo: types.NewStatusInfo("", ""), Schedule: &smartcharging.CompositeSchedule{StartDateTime: types.NewDateTime(time.Now()), ChargingSchedule: types.NewChargingSchedule(1, "invalidChargingRateUnit")}}, false},
+		// Invalid: missing required chargingSchedulePeriod
+		{smartcharging.GetCompositeScheduleResponse{Status: smartcharging.GetCompositeScheduleStatusAccepted, Schedule: &smartcharging.CompositeSchedule{EvseID: 1, Duration: 600, ScheduleStart: types.NewDateTime(time.Now()), ChargingRateUnit: types.ChargingRateUnitWatts}}, false},
+		// Invalid: bad chargingRateUnit
+		{smartcharging.GetCompositeScheduleResponse{Status: smartcharging.GetCompositeScheduleStatusAccepted, Schedule: &smartcharging.CompositeSchedule{EvseID: 1, Duration: 600, ScheduleStart: types.NewDateTime(time.Now()), ChargingRateUnit: "invalidChargingRateUnit", ChargingSchedulePeriod: []types.ChargingSchedulePeriod{period}}}, false},
+		// Invalid: missing scheduleStart
+		{smartcharging.GetCompositeScheduleResponse{Status: smartcharging.GetCompositeScheduleStatusAccepted, Schedule: &smartcharging.CompositeSchedule{EvseID: 1, Duration: 600, ChargingRateUnit: types.ChargingRateUnitWatts, ChargingSchedulePeriod: []types.ChargingSchedulePeriod{period}}}, false},
 	}
 	ExecuteGenericTestTable(t, confirmationTable)
 }
@@ -62,16 +66,18 @@ func (suite *OcppV2TestSuite) TestGetCompositeScheduleE2EMocked() {
 	scheduleStart := types.NewDateTime(time.Now())
 	chargingSchedulePeriod := types.NewChargingSchedulePeriod(0, 10.0)
 	chargingSchedulePeriod.NumberPhases = newInt(3)
-	chargingSchedule := types.NewChargingSchedule(1, chargingRateUnit, chargingSchedulePeriod)
-	chargingSchedule.Duration = newInt(600)
-	chargingSchedule.StartSchedule = types.NewDateTime(time.Now())
-	chargingSchedule.MinChargingRate = newFloat(6.0)
 	statusInfo := types.NewStatusInfo("reasonCode", "")
-	compositeSchedule := smartcharging.CompositeSchedule{StartDateTime: scheduleStart, ChargingSchedule: chargingSchedule}
+	compositeSchedule := smartcharging.CompositeSchedule{
+		EvseID:                 evseID,
+		Duration:               duration,
+		ScheduleStart:          scheduleStart,
+		ChargingRateUnit:       chargingRateUnit,
+		ChargingSchedulePeriod: []types.ChargingSchedulePeriod{chargingSchedulePeriod},
+	}
 	requestJson := fmt.Sprintf(`[2,"%v","%v",{"duration":%v,"chargingRateUnit":"%v","evseId":%v}]`,
 		messageId, smartcharging.GetCompositeScheduleFeatureName, duration, chargingRateUnit, evseID)
-	responseJson := fmt.Sprintf(`[3,"%v",{"status":"%v","statusInfo":{"reasonCode":"%v"},"schedule":{"startDateTime":"%v","chargingSchedule":{"id":%v,"startSchedule":"%v","duration":%v,"chargingRateUnit":"%v","minChargingRate":%v,"chargingSchedulePeriod":[{"startPeriod":%v,"limit":%v,"numberPhases":%v}]}}}]`,
-		messageId, status, statusInfo.ReasonCode, compositeSchedule.StartDateTime.FormatTimestamp(), chargingSchedule.ID, chargingSchedule.StartSchedule.FormatTimestamp(), *chargingSchedule.Duration, chargingSchedule.ChargingRateUnit, *chargingSchedule.MinChargingRate, chargingSchedulePeriod.StartPeriod, chargingSchedulePeriod.Limit, *chargingSchedulePeriod.NumberPhases)
+	responseJson := fmt.Sprintf(`[3,"%v",{"status":"%v","statusInfo":{"reasonCode":"%v"},"schedule":{"evseId":%v,"duration":%v,"scheduleStart":"%v","chargingRateUnit":"%v","chargingSchedulePeriod":[{"startPeriod":%v,"limit":%v,"numberPhases":%v}]}}]`,
+		messageId, status, statusInfo.ReasonCode, evseID, duration, scheduleStart.FormatTimestamp(), chargingRateUnit, chargingSchedulePeriod.StartPeriod, chargingSchedulePeriod.Limit, *chargingSchedulePeriod.NumberPhases)
 	getCompositeScheduleConfirmation := smartcharging.NewGetCompositeScheduleResponse(status)
 	getCompositeScheduleConfirmation.Schedule = &compositeSchedule
 	channel := NewMockWebSocket(wsId)
@@ -98,22 +104,16 @@ func (suite *OcppV2TestSuite) TestGetCompositeScheduleE2EMocked() {
 		assert.Equal(t, status, confirmation.Status)
 		assert.Equal(t, statusInfo.ReasonCode, confirmation.StatusInfo.ReasonCode)
 		require.NotNil(t, confirmation.Schedule)
-		require.NotNil(t, confirmation.Schedule.StartDateTime)
-		assert.Equal(t, compositeSchedule.StartDateTime.FormatTimestamp(), confirmation.Schedule.StartDateTime.FormatTimestamp())
-		require.NotNil(t, confirmation.Schedule.ChargingSchedule)
-		assert.Equal(t, chargingSchedule.ID, confirmation.Schedule.ChargingSchedule.ID)
-		assert.Equal(t, chargingSchedule.ChargingRateUnit, confirmation.Schedule.ChargingSchedule.ChargingRateUnit)
-		require.NotNil(t, confirmation.Schedule.ChargingSchedule.Duration)
-		assert.Equal(t, *chargingSchedule.Duration, *confirmation.Schedule.ChargingSchedule.Duration)
-		require.NotNil(t, confirmation.Schedule.ChargingSchedule.MinChargingRate)
-		assert.Equal(t, *chargingSchedule.MinChargingRate, *confirmation.Schedule.ChargingSchedule.MinChargingRate)
-		require.NotNil(t, confirmation.Schedule.ChargingSchedule.StartSchedule)
-		assert.Equal(t, chargingSchedule.StartSchedule.FormatTimestamp(), confirmation.Schedule.ChargingSchedule.StartSchedule.FormatTimestamp())
-		require.Len(t, confirmation.Schedule.ChargingSchedule.ChargingSchedulePeriod, len(chargingSchedule.ChargingSchedulePeriod))
-		assert.Equal(t, chargingSchedule.ChargingSchedulePeriod[0].Limit, confirmation.Schedule.ChargingSchedule.ChargingSchedulePeriod[0].Limit)
-		assert.Equal(t, chargingSchedule.ChargingSchedulePeriod[0].StartPeriod, confirmation.Schedule.ChargingSchedule.ChargingSchedulePeriod[0].StartPeriod)
-		require.NotNil(t, confirmation.Schedule.ChargingSchedule.ChargingSchedulePeriod[0].NumberPhases)
-		assert.Equal(t, *chargingSchedule.ChargingSchedulePeriod[0].NumberPhases, *confirmation.Schedule.ChargingSchedule.ChargingSchedulePeriod[0].NumberPhases)
+		assert.Equal(t, compositeSchedule.EvseID, confirmation.Schedule.EvseID)
+		assert.Equal(t, compositeSchedule.Duration, confirmation.Schedule.Duration)
+		require.NotNil(t, confirmation.Schedule.ScheduleStart)
+		assert.Equal(t, compositeSchedule.ScheduleStart.FormatTimestamp(), confirmation.Schedule.ScheduleStart.FormatTimestamp())
+		assert.Equal(t, compositeSchedule.ChargingRateUnit, confirmation.Schedule.ChargingRateUnit)
+		require.Len(t, confirmation.Schedule.ChargingSchedulePeriod, len(compositeSchedule.ChargingSchedulePeriod))
+		assert.Equal(t, chargingSchedulePeriod.StartPeriod, confirmation.Schedule.ChargingSchedulePeriod[0].StartPeriod)
+		assert.Equal(t, chargingSchedulePeriod.Limit, confirmation.Schedule.ChargingSchedulePeriod[0].Limit)
+		require.NotNil(t, confirmation.Schedule.ChargingSchedulePeriod[0].NumberPhases)
+		assert.Equal(t, *chargingSchedulePeriod.NumberPhases, *confirmation.Schedule.ChargingSchedulePeriod[0].NumberPhases)
 		resultChannel <- true
 	}, duration, evseID, func(request *smartcharging.GetCompositeScheduleRequest) {
 		request.ChargingRateUnit = chargingRateUnit


### PR DESCRIPTION
The `CompositeSchedule` struct was wrong — it had `StartDateTime` and `ChargingSchedule` fields, but the OCPP 2.0.1 JSON schema for `CompositeScheduleType` actually defines a flat structure with `evseId`, `duration`, `scheduleStart`, `chargingRateUnit`, and `chargingSchedulePeriod` as required fields.

I've fixed the struct to match the spec exactly and added a `NewCompositeSchedule` constructor for convenience. The validation and E2E tests are updated accordingly, with new negative test cases for missing required fields.

Note: this is a breaking change since the struct fields are completely different. Code using `CompositeSchedule{StartDateTime: ..., ChargingSchedule: ...}` will need to switch to the new fields.

Fixes #385

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works