### PR TITLE
fix: guard against nil profile in CALL_RESULT parsing

### DIFF
--- a/ocppj/ocppj.go
+++ b/ocppj/ocppj.go
@@ -461,7 +461,10 @@ func (endpoint *Endpoint) ParseMessage(arr []interface{}, pendingRequestState Cl
 			log.Infof("No previous request %v sent. Discarding response message", uniqueId)
 			return nil, nil
 		}
-		profile, _ := endpoint.GetProfileForFeature(request.GetFeatureName())
+		profile, ok := endpoint.GetProfileForFeature(request.GetFeatureName())
+		if !ok {
+			return nil, ocpp.NewError(InternalError, fmt.Sprintf("no profile found for feature %v", request.GetFeatureName()), uniqueId)
+		}
 		confirmation, err := profile.ParseResponse(request.GetFeatureName(), arr[2], parseRawJsonConfirmation)
 		if err != nil {
 			return nil, ocpp.NewError(FormatErrorType(endpoint), err.Error(), uniqueId)

--- a/ocppj/ocppj_test.go
+++ b/ocppj/ocppj_test.go
@@ -233,6 +233,14 @@ func (m *MockUnsupportedResponse) GetFeatureName() string {
 	return "SomeRandomFeature"
 }
 
+type MockUnsupportedRequest struct {
+	MockValue string `json:"mockValue" validate:"required,max=10"`
+}
+
+func (m *MockUnsupportedRequest) GetFeatureName() string {
+	return "SomeRandomFeature"
+}
+
 // ---------------------- COMMON UTILITY METHODS ----------------------
 
 func NewWebsocketServer(t *testing.T, onMessage func(data []byte) ([]byte, error)) ws.Server {
@@ -681,6 +689,27 @@ func (suite *OcppJTestSuite) TestParseMessageInvalidCallResult() {
 	// Both message and error should be nil
 	require.Nil(t, message)
 	require.NoError(t, err)
+}
+
+func (suite *OcppJTestSuite) TestParseMessageCallResultUnsupportedProfile() {
+	t := suite.T()
+	mockMessage := make([]interface{}, 3)
+	messageId := "12345"
+	mockConfirmation := newMockConfirmation("testValue")
+	// Add a pending request whose feature name has no registered profile
+	unsupportedRequest := &MockUnsupportedRequest{MockValue: "request"}
+	suite.chargePoint.RequestState.AddPendingRequest(messageId, unsupportedRequest)
+	mockMessage[0] = float64(ocppj.CALL_RESULT) // Message Type ID
+	mockMessage[1] = messageId                  // Unique ID
+	mockMessage[2] = mockConfirmation
+	message, err := suite.chargePoint.ParseMessage(mockMessage, suite.chargePoint.RequestState)
+	require.Nil(t, message)
+	require.Error(t, err)
+	protoErr := err.(*ocpp.Error)
+	require.NotNil(t, protoErr)
+	assert.Equal(t, messageId, protoErr.MessageId)
+	assert.Equal(t, ocppj.InternalError, protoErr.Code)
+	assert.Equal(t, fmt.Sprintf("no profile found for feature %v", unsupportedRequest.GetFeatureName()), protoErr.Description)
 }
 
 func (suite *OcppJTestSuite) TestParseMessageInvalidCallError() {


### PR DESCRIPTION
The CALL_RESULT handler in ParseMessage calls GetProfileForFeature on line 464 but discards the ok return value:
goprofile, _ := endpoint.GetProfileForFeature(request.GetFeatureName())
If the profile lookup fails, profile is nil and the immediate profile.ParseResponse(...) call panics with a nil pointer dereference. This can happen when a charge point responds with a CallResult for a feature whose profile isn't registered on the receiving endpoint.
The CALL handler already has the correct guard (line 439-441), so I've added the same check for the CALL_RESULT path. When no profile is found, it now returns an InternalError instead of crashing. Also added a test for this error path.
Fixes #313