### PR TITLE
fix: prevent deadlock in websocket write during connection cleanup

### DIFF
--- a/ws/server.go
+++ b/ws/server.go
@@ -344,8 +344,8 @@ func (s *server) stopConnections() {
 
 func (s *server) Write(webSocketId string, data []byte) error {
 	s.connMutex.RLock()
-	defer s.connMutex.RUnlock()
 	w, ok := s.connections[webSocketId]
+	s.connMutex.RUnlock()
 	if !ok {
 		return fmt.Errorf("couldn't write to websocket. No socket with id %v is open", webSocketId)
 	}

--- a/ws/websocket.go
+++ b/ws/websocket.go
@@ -232,6 +232,7 @@ type webSocket struct {
 	pingC              chan []byte
 	closeC             chan websocket.CloseError // used to gracefully close a websocket connection.
 	forceCloseC        chan error                // used by the readPump to notify a forcefully closed connection to the writePump.
+	done               chan struct{}             // closed when cleanup begins, unblocking pending writes.
 	tlsConnectionState *tls.ConnectionState
 	cfg                WebSocketConfig
 	log                logging.Logger
@@ -253,6 +254,7 @@ func newWebSocket(id string, conn *websocket.Conn, tlsState *tls.ConnectionState
 		pingC:              make(chan []byte, 1),
 		closeC:             make(chan websocket.CloseError, 1),
 		forceCloseC:        make(chan error, 1),
+		done:               make(chan struct{}),
 		onClosed:           onClosed,
 		onError:            onError,
 		onMessage:          onMessage,
@@ -296,8 +298,12 @@ func (w *webSocket) WriteManual(messageTyp int, data []byte) error {
 	if w.connection == nil {
 		return fmt.Errorf("cannot write to closed connection %s", w.id)
 	}
-	w.outQueue <- msg
-	return nil
+	select {
+	case w.outQueue <- msg:
+		return nil
+	case <-w.done:
+		return fmt.Errorf("cannot write to closing connection %s", w.id)
+	}
 }
 
 func (w *webSocket) Close(closeError websocket.CloseError) error {
@@ -306,8 +312,12 @@ func (w *webSocket) Close(closeError websocket.CloseError) error {
 	if w.connection == nil {
 		return fmt.Errorf("cannot close already closed connection %s", w.id)
 	}
-	w.closeC <- closeError
-	return nil
+	select {
+	case w.closeC <- closeError:
+		return nil
+	case <-w.done:
+		return fmt.Errorf("cannot close already closing connection %s", w.id)
+	}
 }
 
 func (w *webSocket) updateConfig(cfg WebSocketConfig) {
@@ -372,6 +382,10 @@ func (w *webSocket) onPong(appData string) error {
 }
 
 func (w *webSocket) cleanup(err error) {
+	// Signal all pending writes/closes to abort before acquiring the exclusive lock.
+	// This prevents a deadlock where WriteManual holds RLock and blocks on outQueue
+	// while cleanup waits for RLock to be released.
+	close(w.done)
 	w.mutex.Lock()
 	// Properly close the connection
 	if e := w.connection.Close(); e != nil {


### PR DESCRIPTION
## Summary

- Fix a deadlock between `WriteManual`/`Close` and `cleanup` that occurs under high connection concurrency (e.g. 2k+ simultaneous OCPP charge points)
- Add a `done` channel to `webSocket` struct, closed at the start of `cleanup`, which unblocks pending writes/closes via `select`
- Release `s.connMutex.RLock` in `server.Write` before calling `w.Write` to prevent server-wide cleanup starvation

## Problem

**This issue was introduced between v0.17.0 and v0.19.0** by commit 750a822 ("Fix races in websocket and ocppj"), which changed `server.Write` and `server.stopConnections` from using exclusive `Lock` to shared `RLock`. While this improved read concurrency, it introduced a deadlock path that manifests under high connection counts.

**In v0.17.0**, `Write` used exclusive `Lock`, which serialized all writes and made the race window negligibly small — the deadlock was practically impossible.

**In v0.19.0 and later (including current master)**, `Write` uses `RLock`, allowing many concurrent writes. Under high concurrency, the probability of a write blocking on a full `outQueue` while holding `RLock` becomes significant, triggering the deadlock described below.

We confirmed this regression in production: **v0.17.0 handles 5k+ concurrent OCPP charge point connections without issue, while v0.19.0 consistently fails at ~2k connections** with cascading `"already exists"` errors that render the central system unable to write to any WebSocket connection.

### Deadlock mechanism

When many WebSocket connections disconnect simultaneously (e.g. Kubernetes cluster autoscaler pod restart with 5k+ charge points):

1. `writePump` detects a connection error, exits its read loop, and calls `cleanup`
2. A concurrent goroutine calls `WriteManual`, acquires `w.mutex.RLock`, and blocks on `outQueue <- msg` (buffer full, `writePump` no longer reading)
3. `cleanup` waits for `w.mutex.Lock`, which requires all `RLock` holders to release
4. **Deadlock**: `WriteManual` holds `RLock` waiting on channel send, `cleanup` waits for `RLock` release

Additionally, `server.Write` held `s.connMutex.RLock` for the entire duration of `w.Write`. If `w.Write` blocked (deadlock above), it prevented **all** `handleDisconnect` calls (which need `s.connMutex.Lock`) across all connections. Connections could not be removed from the map, so reconnecting charge points received `"already exists"` errors, and eventually no writes could succeed on any connection.

### Production scenario

1. Cluster autoscaler scales down → pod terminates → all charge point WebSocket connections drop
2. 5k+ charge points reconnect simultaneously to the new pod
3. Some old connections haven't been cleaned up yet (deadlocked in cleanup)
4. New connections for the same charge point ID are rejected with `"already exists"`
5. The deadlock cascades — blocked `RLock` holders prevent all connection cleanups
6. Central system becomes completely unable to communicate with any charge point

## Fix

1. **`done` channel**: A new `chan struct{}` field on `webSocket`, created in `newWebSocket` and closed at the start of `cleanup` (before acquiring `w.mutex.Lock`). `WriteManual` and `Close` use `select` to abort immediately when `done` is closed, releasing their `RLock` so `cleanup` can proceed.

2. **`server.Write` lock scope**: Release `s.connMutex.RLock` immediately after looking up the connection, before calling `w.Write`. The `webSocket` pointer remains valid after map deletion, so this is safe. This prevents a single blocked write from starving all `handleDisconnect` calls.

## Test plan

- [x] All existing `ws` package tests pass (TestNetworkErrors failures are pre-existing, caused by missing toxiproxy dependency)
- [x] `go build ./ws/ ./ocppj/ ./ocpp1.6/... ./ocpp2.0.1/...` succeeds
- [ ] Verify with high-concurrency OCPP charge point simulation (2k+ connections with simultaneous reconnection)